### PR TITLE
chore: add .gitignore for api_server (exclude DB and dist files)

### DIFF
--- a/apps/api_server/.gitignore
+++ b/apps/api_server/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.db
+*.db-shm
+*.db-wal


### PR DESCRIPTION
## Summary
- Adds `.gitignore` for the `api_server` package
- Excludes the SQLite database file and compiled `dist/` output from version control

## Test plan
- [ ] Verify `apps/api_server/rhythm.db` and `apps/api_server/dist/` are not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)