### PR TITLE
feat: complete Milestone 2 — recurrence & project generation

### DIFF
--- a/apps/api_server/package-lock.json
+++ b/apps/api_server/package-lock.json
@@ -11,6 +11,7 @@
         "better-sqlite3": "^12.8.0",
         "cors": "^2.8.5",
         "express": "^4.19.2",
+        "node-cron": "^3.0.3",
         "uuid": "^13.0.0"
       },
       "devDependencies": {
@@ -18,6 +19,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/node": "^20.14.9",
+        "@types/node-cron": "^3.0.11",
         "@types/uuid": "^10.0.0",
         "tsx": "^4.16.0",
         "typescript": "^5.5.2"
@@ -555,6 +557,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.15.0",
@@ -1433,6 +1442,27 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/object-assign": {

--- a/apps/api_server/package.json
+++ b/apps/api_server/package.json
@@ -14,6 +14,7 @@
     "better-sqlite3": "^12.8.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
+    "node-cron": "^3.0.3",
     "uuid": "^13.0.0"
   },
   "devDependencies": {
@@ -21,6 +22,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.9",
+    "@types/node-cron": "^3.0.11",
     "@types/uuid": "^10.0.0",
     "tsx": "^4.16.0",
     "typescript": "^5.5.2"

--- a/apps/api_server/src/app.ts
+++ b/apps/api_server/src/app.ts
@@ -4,7 +4,9 @@ import express from 'express';
 import { errorHandler } from './middleware/error_handler';
 import { authRouter } from './routes/auth_routes';
 import { healthRouter } from './routes/health_routes';
+import { projectInstancesRouter } from './routes/project_instances_routes';
 import { projectTemplatesRouter } from './routes/project_templates_routes';
+import { recurringRulesRouter } from './routes/recurring_rules_routes';
 import { tasksRouter } from './routes/tasks_routes';
 
 export function createApp() {
@@ -17,6 +19,8 @@ export function createApp() {
   app.use('/auth', authRouter);
   app.use('/tasks', tasksRouter);
   app.use('/project-templates', projectTemplatesRouter);
+  app.use('/recurring-rules', recurringRulesRouter);
+  app.use('/project-instances', projectInstancesRouter);
 
   app.use(errorHandler);
 

--- a/apps/api_server/src/controllers/project_generation_controller.ts
+++ b/apps/api_server/src/controllers/project_generation_controller.ts
@@ -1,0 +1,34 @@
+import type { NextFunction, Request, Response } from 'express';
+import { AppError } from '../errors/app_error';
+import { ProjectInstancesRepository } from '../repositories/project_instances_repository';
+import { ProjectGenerationService } from '../services/project_generation_service';
+
+const service = new ProjectGenerationService();
+const instanceRepo = new ProjectInstancesRepository();
+
+export class ProjectGenerationController {
+  generate(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { anchorDate } = req.body as Record<string, unknown>;
+      if (!anchorDate || typeof anchorDate !== 'string') {
+        throw AppError.badRequest('anchorDate (YYYY-MM-DD) is required');
+      }
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(anchorDate)) {
+        throw AppError.badRequest('anchorDate must be in YYYY-MM-DD format');
+      }
+
+      const instance = service.generate(req.params.id, anchorDate);
+      res.status(201).json(instance);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  getAllInstances(_req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(instanceRepo.findAll());
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/apps/api_server/src/controllers/recurring_rules_controller.ts
+++ b/apps/api_server/src/controllers/recurring_rules_controller.ts
@@ -1,0 +1,65 @@
+import type { NextFunction, Request, Response } from 'express';
+import { AppError } from '../errors/app_error';
+import { RecurringTaskRulesRepository } from '../repositories/recurring_task_rules_repository';
+
+const repo = new RecurringTaskRulesRepository();
+
+const VALID_FREQUENCIES = ['weekly', 'monthly', 'annual'] as const;
+
+export class RecurringRulesController {
+  getAll(_req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(repo.findAll());
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  getById(req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(repo.findById(req.params.id));
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  create(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { title, frequency, dayOfWeek, dayOfMonth, month } = req.body as Record<string, unknown>;
+
+      if (!title || typeof title !== 'string') throw AppError.badRequest('title is required');
+      if (!frequency || !VALID_FREQUENCIES.includes(frequency as never)) {
+        throw AppError.badRequest('frequency must be weekly, monthly, or annual');
+      }
+
+      const rule = repo.create({
+        title,
+        frequency: frequency as 'weekly' | 'monthly' | 'annual',
+        dayOfWeek: dayOfWeek as number ?? null,
+        dayOfMonth: dayOfMonth as number ?? null,
+        month: month as number ?? null,
+      });
+      res.status(201).json(rule);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  update(req: Request, res: Response, next: NextFunction) {
+    try {
+      const rule = repo.update(req.params.id, req.body as Record<string, unknown>);
+      res.json(rule);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      repo.delete(req.params.id);
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -48,6 +48,15 @@ export function runMigrations(db: Database.Database): void {
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
+    CREATE TABLE IF NOT EXISTS project_instance_steps (
+      id TEXT PRIMARY KEY,
+      instance_id TEXT NOT NULL REFERENCES project_instances(id) ON DELETE CASCADE,
+      step_id TEXT NOT NULL REFERENCES project_template_steps(id),
+      title TEXT NOT NULL,
+      due_date TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open'
+    );
+
     CREATE TABLE IF NOT EXISTS weekly_plans (
       id TEXT PRIMARY KEY,
       week_label TEXT NOT NULL UNIQUE,

--- a/apps/api_server/src/jobs/recurrence_generation_job.ts
+++ b/apps/api_server/src/jobs/recurrence_generation_job.ts
@@ -1,3 +1,52 @@
-export function recurrenceGenerationJob() {
-  // TODO: Trigger scheduled recurrence generation pipeline.
+import cron from 'node-cron';
+import { RecurrenceService } from '../services/recurrence_service';
+import { RecurringTaskRulesRepository } from '../repositories/recurring_task_rules_repository';
+import { logger } from '../utils/logger';
+
+const DEFAULT_LOOKAHEAD_WEEKS = 8;
+const DEFAULT_CRON_SCHEDULE = '0 0 * * 0'; // Every Sunday at midnight
+
+function getLookaheadWeeks(): number {
+  const val = parseInt(process.env.RECURRENCE_LOOKAHEAD_WEEKS ?? '', 10);
+  return isNaN(val) ? DEFAULT_LOOKAHEAD_WEEKS : val;
+}
+
+function getCronSchedule(): string {
+  return process.env.RECURRENCE_CRON_SCHEDULE ?? DEFAULT_CRON_SCHEDULE;
+}
+
+function runGeneration(): void {
+  try {
+    const rules = new RecurringTaskRulesRepository().findAll();
+    if (rules.length === 0) return;
+
+    const service = new RecurrenceService();
+    const from = new Date();
+    const to = new Date();
+    to.setUTCDate(to.getUTCDate() + getLookaheadWeeks() * 7);
+
+    let total = 0;
+    for (const rule of rules) {
+      const created = service.generateInstances(rule, from, to);
+      total += created.length;
+    }
+
+    logger.info(`RecurrenceGenerationJob: created ${total} task(s) for ${rules.length} rule(s)`);
+  } catch (err) {
+    logger.error(`RecurrenceGenerationJob error: ${String(err)}`);
+  }
+}
+
+export function startRecurrenceGenerationJob(): void {
+  // Run immediately on startup
+  runGeneration();
+
+  // Schedule recurring runs
+  const schedule = getCronSchedule();
+  cron.schedule(schedule, () => {
+    logger.info('RecurrenceGenerationJob: running scheduled generation');
+    runGeneration();
+  });
+
+  logger.info(`RecurrenceGenerationJob: scheduled with cron "${schedule}", lookahead ${getLookaheadWeeks()} weeks`);
 }

--- a/apps/api_server/src/models/project_instance.ts
+++ b/apps/api_server/src/models/project_instance.ts
@@ -1,0 +1,17 @@
+export interface ProjectInstanceStep {
+  id: string;
+  instanceId: string;
+  stepId: string;
+  title: string;
+  dueDate: string;
+  status: 'open' | 'done';
+}
+
+export interface ProjectInstance {
+  id: string;
+  templateId: string;
+  anchorDate: string;
+  status: string;
+  createdAt: string;
+  steps: ProjectInstanceStep[];
+}

--- a/apps/api_server/src/models/recurring_task_rule.ts
+++ b/apps/api_server/src/models/recurring_task_rule.ts
@@ -1,0 +1,25 @@
+export interface RecurringTaskRule {
+  id: string;
+  title: string;
+  frequency: 'weekly' | 'monthly' | 'annual';
+  dayOfWeek: number | null;
+  dayOfMonth: number | null;
+  month: number | null;
+  createdAt: string;
+}
+
+export interface CreateRecurringTaskRuleDto {
+  title: string;
+  frequency: 'weekly' | 'monthly' | 'annual';
+  dayOfWeek?: number | null;
+  dayOfMonth?: number | null;
+  month?: number | null;
+}
+
+export interface UpdateRecurringTaskRuleDto {
+  title?: string;
+  frequency?: 'weekly' | 'monthly' | 'annual';
+  dayOfWeek?: number | null;
+  dayOfMonth?: number | null;
+  month?: number | null;
+}

--- a/apps/api_server/src/models/task.ts
+++ b/apps/api_server/src/models/task.ts
@@ -13,6 +13,8 @@ export interface CreateTaskDto {
   title: string;
   dueDate?: string | null;
   status?: 'open' | 'done';
+  sourceType?: string | null;
+  sourceId?: string | null;
 }
 
 export interface UpdateTaskDto {

--- a/apps/api_server/src/repositories/project_instances_repository.ts
+++ b/apps/api_server/src/repositories/project_instances_repository.ts
@@ -1,0 +1,101 @@
+import { v4 as uuidv4 } from 'uuid';
+import { getDb } from '../database/db';
+import { AppError } from '../errors/app_error';
+import type { ProjectInstance, ProjectInstanceStep } from '../models/project_instance';
+
+interface InstanceRow {
+  id: string;
+  template_id: string;
+  anchor_date: string;
+  status: string;
+  created_at: string;
+}
+
+interface InstanceStepRow {
+  id: string;
+  instance_id: string;
+  step_id: string;
+  title: string;
+  due_date: string;
+  status: string;
+}
+
+function rowToStep(row: InstanceStepRow): ProjectInstanceStep {
+  return {
+    id: row.id,
+    instanceId: row.instance_id,
+    stepId: row.step_id,
+    title: row.title,
+    dueDate: row.due_date,
+    status: row.status as ProjectInstanceStep['status'],
+  };
+}
+
+function rowToInstance(row: InstanceRow, steps: ProjectInstanceStep[]): ProjectInstance {
+  return {
+    id: row.id,
+    templateId: row.template_id,
+    anchorDate: row.anchor_date,
+    status: row.status,
+    createdAt: row.created_at,
+    steps,
+  };
+}
+
+export class ProjectInstancesRepository {
+  private getSteps(instanceId: string): ProjectInstanceStep[] {
+    const rows = getDb()
+      .prepare('SELECT * FROM project_instance_steps WHERE instance_id = ? ORDER BY due_date ASC')
+      .all(instanceId) as InstanceStepRow[];
+    return rows.map(rowToStep);
+  }
+
+  findAll(): ProjectInstance[] {
+    const rows = getDb()
+      .prepare('SELECT * FROM project_instances ORDER BY created_at DESC')
+      .all() as InstanceRow[];
+    return rows.map((row) => rowToInstance(row, this.getSteps(row.id)));
+  }
+
+  findById(id: string): ProjectInstance {
+    const row = getDb()
+      .prepare('SELECT * FROM project_instances WHERE id = ?')
+      .get(id) as InstanceRow | undefined;
+    if (!row) throw AppError.notFound('ProjectInstance');
+    return rowToInstance(row, this.getSteps(id));
+  }
+
+  findByTemplateAndAnchor(templateId: string, anchorDate: string): ProjectInstance | null {
+    const row = getDb()
+      .prepare('SELECT * FROM project_instances WHERE template_id = ? AND anchor_date = ?')
+      .get(templateId, anchorDate) as InstanceRow | undefined;
+    if (!row) return null;
+    return rowToInstance(row, this.getSteps(row.id));
+  }
+
+  createWithSteps(
+    templateId: string,
+    anchorDate: string,
+    steps: Array<{ stepId: string; title: string; dueDate: string }>,
+  ): ProjectInstance {
+    const instanceId = uuidv4();
+    const now = new Date().toISOString();
+
+    const db = getDb();
+    const insertInstance = db.prepare(
+      `INSERT INTO project_instances (id, template_id, anchor_date, status, created_at) VALUES (?, ?, ?, ?, ?)`,
+    );
+    const insertStep = db.prepare(
+      `INSERT INTO project_instance_steps (id, instance_id, step_id, title, due_date, status) VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+
+    db.transaction(() => {
+      insertInstance.run(instanceId, templateId, anchorDate, 'active', now);
+      for (const step of steps) {
+        insertStep.run(uuidv4(), instanceId, step.stepId, step.title, step.dueDate, 'open');
+      }
+    })();
+
+    return this.findById(instanceId);
+  }
+}

--- a/apps/api_server/src/repositories/recurring_task_rules_repository.ts
+++ b/apps/api_server/src/repositories/recurring_task_rules_repository.ts
@@ -1,0 +1,91 @@
+import { v4 as uuidv4 } from 'uuid';
+import { getDb } from '../database/db';
+import { AppError } from '../errors/app_error';
+import type {
+  CreateRecurringTaskRuleDto,
+  RecurringTaskRule,
+  UpdateRecurringTaskRuleDto,
+} from '../models/recurring_task_rule';
+
+interface RuleRow {
+  id: string;
+  title: string;
+  frequency: string;
+  day_of_week: number | null;
+  day_of_month: number | null;
+  month: number | null;
+  created_at: string;
+}
+
+function rowToRule(row: RuleRow): RecurringTaskRule {
+  return {
+    id: row.id,
+    title: row.title,
+    frequency: row.frequency as RecurringTaskRule['frequency'],
+    dayOfWeek: row.day_of_week,
+    dayOfMonth: row.day_of_month,
+    month: row.month,
+    createdAt: row.created_at,
+  };
+}
+
+export class RecurringTaskRulesRepository {
+  findAll(): RecurringTaskRule[] {
+    const rows = getDb()
+      .prepare('SELECT * FROM recurring_task_rules ORDER BY created_at ASC')
+      .all() as RuleRow[];
+    return rows.map(rowToRule);
+  }
+
+  findById(id: string): RecurringTaskRule {
+    const row = getDb()
+      .prepare('SELECT * FROM recurring_task_rules WHERE id = ?')
+      .get(id) as RuleRow | undefined;
+    if (!row) throw AppError.notFound('RecurringTaskRule');
+    return rowToRule(row);
+  }
+
+  create(data: CreateRecurringTaskRuleDto): RecurringTaskRule {
+    const id = uuidv4();
+    const now = new Date().toISOString();
+    getDb()
+      .prepare(
+        `INSERT INTO recurring_task_rules (id, title, frequency, day_of_week, day_of_month, month, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        data.title,
+        data.frequency,
+        data.dayOfWeek ?? null,
+        data.dayOfMonth ?? null,
+        data.month ?? null,
+        now,
+      );
+    return this.findById(id);
+  }
+
+  update(id: string, data: UpdateRecurringTaskRuleDto): RecurringTaskRule {
+    const existing = this.findById(id);
+    getDb()
+      .prepare(
+        `UPDATE recurring_task_rules
+         SET title = ?, frequency = ?, day_of_week = ?, day_of_month = ?, month = ?
+         WHERE id = ?`,
+      )
+      .run(
+        data.title ?? existing.title,
+        data.frequency ?? existing.frequency,
+        data.dayOfWeek !== undefined ? data.dayOfWeek : existing.dayOfWeek,
+        data.dayOfMonth !== undefined ? data.dayOfMonth : existing.dayOfMonth,
+        data.month !== undefined ? data.month : existing.month,
+        id,
+      );
+    return this.findById(id);
+  }
+
+  delete(id: string): void {
+    const result = getDb().prepare('DELETE FROM recurring_task_rules WHERE id = ?').run(id);
+    if (result.changes === 0) throw AppError.notFound('RecurringTaskRule');
+  }
+}

--- a/apps/api_server/src/repositories/tasks_repository.ts
+++ b/apps/api_server/src/repositories/tasks_repository.ts
@@ -44,10 +44,10 @@ export class TasksRepository {
     const now = new Date().toISOString();
     getDb()
       .prepare(
-        `INSERT INTO tasks (id, title, due_date, status, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO tasks (id, title, due_date, status, source_type, source_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(id, data.title, data.dueDate ?? null, data.status ?? 'open', now, now);
+      .run(id, data.title, data.dueDate ?? null, data.status ?? 'open', data.sourceType ?? null, data.sourceId ?? null, now, now);
     return this.findById(id);
   }
 

--- a/apps/api_server/src/routes/project_instances_routes.ts
+++ b/apps/api_server/src/routes/project_instances_routes.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import { ProjectGenerationController } from '../controllers/project_generation_controller';
+
+const controller = new ProjectGenerationController();
+export const projectInstancesRouter = Router();
+
+projectInstancesRouter.get('/', controller.getAllInstances.bind(controller));

--- a/apps/api_server/src/routes/project_templates_routes.ts
+++ b/apps/api_server/src/routes/project_templates_routes.ts
@@ -1,7 +1,9 @@
 import { Router } from 'express';
+import { ProjectGenerationController } from '../controllers/project_generation_controller';
 import { ProjectTemplatesController } from '../controllers/project_templates_controller';
 
 const controller = new ProjectTemplatesController();
+const genController = new ProjectGenerationController();
 export const projectTemplatesRouter = Router();
 
 projectTemplatesRouter.get('/', controller.getAll.bind(controller));
@@ -10,3 +12,4 @@ projectTemplatesRouter.post('/', controller.create.bind(controller));
 projectTemplatesRouter.patch('/:id', controller.update.bind(controller));
 projectTemplatesRouter.delete('/:id', controller.remove.bind(controller));
 projectTemplatesRouter.post('/:id/steps', controller.addStep.bind(controller));
+projectTemplatesRouter.post('/:id/generate', genController.generate.bind(genController));

--- a/apps/api_server/src/routes/recurring_rules_routes.ts
+++ b/apps/api_server/src/routes/recurring_rules_routes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { RecurringRulesController } from '../controllers/recurring_rules_controller';
+
+const controller = new RecurringRulesController();
+export const recurringRulesRouter = Router();
+
+recurringRulesRouter.get('/', controller.getAll.bind(controller));
+recurringRulesRouter.get('/:id', controller.getById.bind(controller));
+recurringRulesRouter.post('/', controller.create.bind(controller));
+recurringRulesRouter.patch('/:id', controller.update.bind(controller));
+recurringRulesRouter.delete('/:id', controller.remove.bind(controller));

--- a/apps/api_server/src/server.ts
+++ b/apps/api_server/src/server.ts
@@ -1,11 +1,14 @@
 import { createApp } from './app';
 import { initDb } from './database/db';
+import { startRecurrenceGenerationJob } from './jobs/recurrence_generation_job';
 import { logger } from './utils/logger';
 
 const port = Number(process.env.PORT ?? 4000);
 
 initDb();
 logger.info('Database initialized');
+
+startRecurrenceGenerationJob();
 
 const app = createApp();
 

--- a/apps/api_server/src/services/project_generation_service.ts
+++ b/apps/api_server/src/services/project_generation_service.ts
@@ -1,0 +1,33 @@
+import type { ProjectInstance } from '../models/project_instance';
+import { ProjectInstancesRepository } from '../repositories/project_instances_repository';
+import { ProjectTemplatesRepository } from '../repositories/project_templates_repository';
+
+export class ProjectGenerationService {
+  private readonly templateRepo = new ProjectTemplatesRepository();
+  private readonly instanceRepo = new ProjectInstancesRepository();
+
+  /**
+   * Generate a ProjectInstance from a template and an anchor date.
+   * Each step's due date = anchorDate + offsetDays.
+   * Idempotent: returns the existing instance if one already exists for this template + anchorDate.
+   */
+  generate(templateId: string, anchorDate: string): ProjectInstance {
+    const existing = this.instanceRepo.findByTemplateAndAnchor(templateId, anchorDate);
+    if (existing) return existing;
+
+    const template = this.templateRepo.findById(templateId);
+    const anchor = new Date(anchorDate + 'T00:00:00Z');
+
+    const steps = template.steps.map((step) => {
+      const dueDate = new Date(anchor);
+      dueDate.setUTCDate(dueDate.getUTCDate() + step.offsetDays);
+      return {
+        stepId: step.id,
+        title: step.title,
+        dueDate: dueDate.toISOString().split('T')[0],
+      };
+    });
+
+    return this.instanceRepo.createWithSteps(templateId, anchorDate, steps);
+  }
+}

--- a/apps/api_server/src/services/recurrence_service.ts
+++ b/apps/api_server/src/services/recurrence_service.ts
@@ -1,3 +1,110 @@
+import { getDb } from '../database/db';
+import type { RecurringTaskRule } from '../models/recurring_task_rule';
+import type { Task } from '../models/task';
+import { TasksRepository } from '../repositories/tasks_repository';
+
 export class RecurrenceService {
-  // TODO: Generate concrete recurring task/project instances.
+  private readonly tasksRepo = new TasksRepository();
+
+  /**
+   * Generate concrete task instances for a recurring rule within [from, to].
+   * Idempotent: skips dates where a task with matching source_type/source_id/due_date already exists.
+   */
+  generateInstances(rule: RecurringTaskRule, from: Date, to: Date): Task[] {
+    const dates = this.computeDates(rule, from, to);
+    const created: Task[] = [];
+
+    for (const date of dates) {
+      const dateStr = toDateStr(date);
+      const existing = getDb()
+        .prepare('SELECT id FROM tasks WHERE source_type = ? AND source_id = ? AND due_date = ?')
+        .get('recurring_rule', rule.id, dateStr);
+
+      if (!existing) {
+        const task = this.tasksRepo.create({
+          title: rule.title,
+          dueDate: dateStr,
+          status: 'open',
+          sourceType: 'recurring_rule',
+          sourceId: rule.id,
+        });
+        created.push(task);
+      }
+    }
+
+    return created;
+  }
+
+  private computeDates(rule: RecurringTaskRule, from: Date, to: Date): Date[] {
+    switch (rule.frequency) {
+      case 'weekly':
+        return this.weeklyDates(rule, from, to);
+      case 'monthly':
+        return this.monthlyDates(rule, from, to);
+      case 'annual':
+        return this.annualDates(rule, from, to);
+    }
+  }
+
+  private weeklyDates(rule: RecurringTaskRule, from: Date, to: Date): Date[] {
+    const targetDow = rule.dayOfWeek ?? 1; // default Monday
+    const results: Date[] = [];
+    const cur = utcMidnight(from);
+
+    // Advance to the first matching day of week
+    const diff = (targetDow - cur.getUTCDay() + 7) % 7;
+    cur.setUTCDate(cur.getUTCDate() + diff);
+
+    while (cur <= to) {
+      results.push(new Date(cur));
+      cur.setUTCDate(cur.getUTCDate() + 7);
+    }
+    return results;
+  }
+
+  private monthlyDates(rule: RecurringTaskRule, from: Date, to: Date): Date[] {
+    const dayOfMonth = rule.dayOfMonth ?? 1;
+    const results: Date[] = [];
+
+    let year = from.getUTCFullYear();
+    let month = from.getUTCMonth();
+
+    while (true) {
+      const date = resolveMonthDay(year, month, dayOfMonth);
+      if (date > to) break;
+      if (date >= utcMidnight(from)) results.push(date);
+      month++;
+      if (month > 11) {
+        month = 0;
+        year++;
+      }
+    }
+    return results;
+  }
+
+  private annualDates(rule: RecurringTaskRule, from: Date, to: Date): Date[] {
+    const month = (rule.month ?? 1) - 1; // 1-indexed → 0-indexed
+    const dayOfMonth = rule.dayOfMonth ?? 1;
+    const results: Date[] = [];
+
+    for (let year = from.getUTCFullYear(); year <= to.getUTCFullYear(); year++) {
+      const date = resolveMonthDay(year, month, dayOfMonth);
+      if (date >= utcMidnight(from) && date <= to) results.push(date);
+    }
+    return results;
+  }
+}
+
+function utcMidnight(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+function resolveMonthDay(year: number, month: number, day: number): Date {
+  // Last day of the given month (handles month-end overflow and leap years)
+  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  return new Date(Date.UTC(year, month, Math.min(day, lastDay)));
+}
+
+function toDateStr(d: Date): string {
+  return d.toISOString().split('T')[0];
 }

--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+import '../../../features/integrations/views/integrations_view.dart';
 import '../../../features/projects/views/projects_view.dart';
+import '../../../features/rhythms/views/rhythms_view.dart';
 import '../../../features/tasks/views/tasks_view.dart';
 import '../../../features/weekly_planner/views/weekly_planner_view.dart';
-import '../../../features/integrations/views/integrations_view.dart';
 import 'navigation_sidebar.dart';
 
 class AppShell extends StatefulWidget {
@@ -18,6 +19,7 @@ class _AppShellState extends State<AppShell> {
   static const _views = [
     WeeklyPlannerView(),
     TasksView(),
+    RhythmsView(),
     ProjectsView(),
     IntegrationsView(),
   ];

--- a/apps/desktop_flutter/lib/app/core/layout/navigation_sidebar.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/navigation_sidebar.dart
@@ -13,6 +13,7 @@ class NavigationSidebar extends StatelessWidget {
   static const _items = [
     _NavItem(icon: Icons.calendar_view_week, label: 'Weekly Planner'),
     _NavItem(icon: Icons.check_circle_outline, label: 'Tasks'),
+    _NavItem(icon: Icons.repeat, label: 'Rhythms'),
     _NavItem(icon: Icons.folder_open, label: 'Projects'),
     _NavItem(icon: Icons.link, label: 'Integrations'),
   ];

--- a/apps/desktop_flutter/lib/features/projects/controllers/project_template_controller.dart
+++ b/apps/desktop_flutter/lib/features/projects/controllers/project_template_controller.dart
@@ -55,4 +55,28 @@ class ProjectTemplateController extends ChangeNotifier {
       notifyListeners();
     }
   }
+
+  Future<void> addStep(
+    String templateId, {
+    required String title,
+    required int offsetDays,
+    String? offsetDescription,
+    int? sortOrder,
+  }) async {
+    try {
+      await _repository.addStep(
+        templateId,
+        title: title,
+        offsetDays: offsetDays,
+        offsetDescription: offsetDescription,
+        sortOrder: sortOrder,
+      );
+      // Reload to get updated template with new step
+      await load();
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = ProjectsStatus.error;
+      notifyListeners();
+    }
+  }
 }

--- a/apps/desktop_flutter/lib/features/projects/models/project_instance.dart
+++ b/apps/desktop_flutter/lib/features/projects/models/project_instance.dart
@@ -1,6 +1,60 @@
+class ProjectInstanceStep {
+  ProjectInstanceStep({
+    required this.id,
+    required this.instanceId,
+    required this.stepId,
+    required this.title,
+    required this.dueDate,
+    required this.status,
+  });
+
+  factory ProjectInstanceStep.fromJson(Map<String, dynamic> json) {
+    return ProjectInstanceStep(
+      id: json['id'] as String,
+      instanceId: json['instanceId'] as String,
+      stepId: json['stepId'] as String,
+      title: json['title'] as String,
+      dueDate: json['dueDate'] as String,
+      status: json['status'] as String? ?? 'open',
+    );
+  }
+
+  final String id;
+  final String instanceId;
+  final String stepId;
+  final String title;
+  final String dueDate;
+  final String status;
+}
+
 class ProjectInstance {
-  ProjectInstance({required this.id, required this.templateId});
+  ProjectInstance({
+    required this.id,
+    required this.templateId,
+    required this.anchorDate,
+    required this.status,
+    required this.createdAt,
+    required this.steps,
+  });
+
+  factory ProjectInstance.fromJson(Map<String, dynamic> json) {
+    final stepList = (json['steps'] as List<dynamic>? ?? [])
+        .map((s) => ProjectInstanceStep.fromJson(s as Map<String, dynamic>))
+        .toList();
+    return ProjectInstance(
+      id: json['id'] as String,
+      templateId: json['templateId'] as String,
+      anchorDate: json['anchorDate'] as String,
+      status: json['status'] as String? ?? 'active',
+      createdAt: json['createdAt'] as String,
+      steps: stepList,
+    );
+  }
 
   final String id;
   final String templateId;
+  final String anchorDate;
+  final String status;
+  final String createdAt;
+  final List<ProjectInstanceStep> steps;
 }

--- a/apps/desktop_flutter/lib/features/projects/services/project_generation_service.dart
+++ b/apps/desktop_flutter/lib/features/projects/services/project_generation_service.dart
@@ -1,3 +1,24 @@
+import '../models/project_template.dart';
+import '../models/project_template_step.dart';
+
+class ResolvedStep {
+  ResolvedStep({required this.step, required this.dueDate});
+  final ProjectTemplateStep step;
+  final DateTime dueDate;
+}
+
+/// Client-side preview service for project generation.
+/// Pure function — no side effects, used exclusively for UI previews.
 class ProjectGenerationService {
-  // TODO: Generate recurring project instances and steps.
+  /// Returns each step of [template] with its resolved due date based on [anchorDate].
+  List<ResolvedStep> previewSteps(ProjectTemplate template, DateTime anchorDate) {
+    final anchor = DateTime.utc(anchorDate.year, anchorDate.month, anchorDate.day);
+    return template.steps
+        .map((step) => ResolvedStep(
+              step: step,
+              dueDate: anchor.add(Duration(days: step.offsetDays)),
+            ))
+        .toList()
+      ..sort((a, b) => a.dueDate.compareTo(b.dueDate));
+  }
 }

--- a/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
+++ b/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
@@ -1,12 +1,606 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
+import 'package:provider/provider.dart';
+import '../controllers/project_template_controller.dart';
+import '../models/project_instance.dart';
+import '../models/project_template.dart';
+import '../models/project_template_step.dart';
+import '../services/project_generation_service.dart';
+import '../../../app/core/constants/app_constants.dart';
 
-class ProjectsView extends StatelessWidget {
+class ProjectsView extends StatefulWidget {
   const ProjectsView({super.key});
 
   @override
+  State<ProjectsView> createState() => _ProjectsViewState();
+}
+
+class _ProjectsViewState extends State<ProjectsView> {
+  ProjectTemplate? _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<ProjectTemplateController>().load();
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Project Templates — coming in Phase 2'),
+    return Consumer<ProjectTemplateController>(
+      builder: (context, controller, _) {
+        // If the selected template was deleted, deselect it.
+        if (_selected != null && !controller.templates.any((t) => t.id == _selected!.id)) {
+          _selected = null;
+        }
+        // Refresh selected template reference to reflect updates
+        if (_selected != null) {
+          _selected = controller.templates.firstWhere((t) => t.id == _selected!.id, orElse: () => _selected!);
+        }
+
+        return Row(
+          children: [
+            // Left panel: template list
+            SizedBox(
+              width: 280,
+              child: _TemplateList(
+                controller: controller,
+                selected: _selected,
+                onSelect: (t) => setState(() => _selected = t),
+              ),
+            ),
+            const VerticalDivider(width: 1),
+            // Right panel: detail
+            Expanded(
+              child: _selected == null
+                  ? const Center(child: Text('Select a template to view details'))
+                  : _TemplateDetail(
+                      template: _selected!,
+                      controller: controller,
+                    ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Template List (left panel)
+// ---------------------------------------------------------------------------
+
+class _TemplateList extends StatelessWidget {
+  const _TemplateList({required this.controller, required this.selected, required this.onSelect});
+  final ProjectTemplateController controller;
+  final ProjectTemplate? selected;
+  final ValueChanged<ProjectTemplate> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 24, 16, 0),
+          child: Row(
+            children: [
+              Text('Templates', style: Theme.of(context).textTheme.titleMedium),
+              const Spacer(),
+              IconButton(
+                icon: const Icon(Icons.add),
+                tooltip: 'New template',
+                onPressed: () => _showCreateDialog(context, controller),
+              ),
+            ],
+          ),
+        ),
+        if (controller.status == ProjectsStatus.error && controller.errorMessage != null)
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Text(controller.errorMessage!, style: const TextStyle(color: Colors.red, fontSize: 12)),
+          ),
+        if (controller.status == ProjectsStatus.loading && controller.templates.isEmpty)
+          const Padding(padding: EdgeInsets.all(16), child: LinearProgressIndicator()),
+        Expanded(
+          child: controller.templates.isEmpty
+              ? const Center(child: Text('No templates yet', style: TextStyle(color: Colors.grey)))
+              : ListView.builder(
+                  itemCount: controller.templates.length,
+                  itemBuilder: (ctx, i) {
+                    final t = controller.templates[i];
+                    final isSelected = selected?.id == t.id;
+                    return ListTile(
+                      selected: isSelected,
+                      title: Text(t.name),
+                      subtitle: Text('${t.steps.length} step${t.steps.length == 1 ? '' : 's'}'),
+                      onTap: () => onSelect(t),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.delete_outline, size: 18),
+                        tooltip: 'Delete',
+                        onPressed: () => _confirmDelete(ctx, controller, t),
+                      ),
+                    );
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _showCreateDialog(BuildContext context, ProjectTemplateController controller) async {
+    await showDialog<void>(
+      context: context,
+      builder: (_) => _CreateTemplateDialog(controller: controller),
+    );
+  }
+
+  Future<void> _confirmDelete(BuildContext context, ProjectTemplateController controller, ProjectTemplate t) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Template'),
+        content: Text('Delete "${t.name}"?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.error),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) await controller.deleteTemplate(t.id);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Template Detail (right panel)
+// ---------------------------------------------------------------------------
+
+class _TemplateDetail extends StatelessWidget {
+  const _TemplateDetail({required this.template, required this.controller});
+  final ProjectTemplate template;
+  final ProjectTemplateController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final sortedSteps = [...template.steps]..sort((a, b) => a.offsetDays.compareTo(b.offsetDays));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(template.name, style: Theme.of(context).textTheme.headlineSmall),
+                    if (template.description != null && template.description!.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(template.description!, style: const TextStyle(color: Colors.grey)),
+                      ),
+                    const SizedBox(height: 4),
+                    Text('Anchor type: ${template.anchorType}',
+                        style: Theme.of(context).textTheme.bodySmall),
+                  ],
+                ),
+              ),
+              FilledButton.icon(
+                onPressed: () => _showGenerateDialog(context),
+                icon: const Icon(Icons.play_arrow, size: 18),
+                label: const Text('Generate Instance'),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Row(
+            children: [
+              Text('Steps', style: Theme.of(context).textTheme.titleMedium),
+              const Spacer(),
+              TextButton.icon(
+                onPressed: () => _showAddStepDialog(context),
+                icon: const Icon(Icons.add, size: 16),
+                label: const Text('Add Step'),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: sortedSteps.isEmpty
+              ? const Center(child: Text('No steps yet. Add a step to get started.'))
+              : ListView.separated(
+                  padding: const EdgeInsets.all(24),
+                  itemCount: sortedSteps.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 8),
+                  itemBuilder: (ctx, i) => _StepTile(step: sortedSteps[i]),
+                ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _showAddStepDialog(BuildContext context) async {
+    await showDialog<void>(
+      context: context,
+      builder: (_) => _AddStepDialog(template: template, controller: controller),
+    );
+  }
+
+  Future<void> _showGenerateDialog(BuildContext context) async {
+    await showDialog<void>(
+      context: context,
+      builder: (_) => _GenerateInstanceDialog(template: template),
+    );
+  }
+}
+
+class _StepTile extends StatelessWidget {
+  const _StepTile({required this.step});
+  final ProjectTemplateStep step;
+
+  @override
+  Widget build(BuildContext context) {
+    final offsetLabel = step.offsetDescription ??
+        (step.offsetDays == 0
+            ? 'On anchor date'
+            : step.offsetDays > 0
+                ? '+${step.offsetDays} days'
+                : '${step.offsetDays} days');
+
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      child: ListTile(
+        leading: CircleAvatar(
+          radius: 14,
+          backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+          child: Text(
+            step.sortOrder.toString(),
+            style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onPrimaryContainer),
+          ),
+        ),
+        title: Text(step.title),
+        subtitle: Text(offsetLabel),
+        trailing: Text(
+          'Offset: ${step.offsetDays}d',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dialogs
+// ---------------------------------------------------------------------------
+
+class _CreateTemplateDialog extends StatefulWidget {
+  const _CreateTemplateDialog({required this.controller});
+  final ProjectTemplateController controller;
+
+  @override
+  State<_CreateTemplateDialog> createState() => _CreateTemplateDialogState();
+}
+
+class _CreateTemplateDialogState extends State<_CreateTemplateDialog> {
+  final _nameController = TextEditingController();
+  final _descController = TextEditingController();
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('New Template'),
+      content: SizedBox(
+        width: 360,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name', border: OutlineInputBorder()),
+              autofocus: true,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _descController,
+              decoration: const InputDecoration(labelText: 'Description (optional)', border: OutlineInputBorder()),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(onPressed: _saving ? null : () => Navigator.pop(context), child: const Text('Cancel')),
+        FilledButton(
+          onPressed: _saving ? null : _save,
+          child: _saving ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)) : const Text('Create'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _save() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+    setState(() => _saving = true);
+    await widget.controller.createTemplate(name, description: _descController.text.trim().isEmpty ? null : _descController.text.trim());
+    if (mounted) Navigator.pop(context);
+  }
+}
+
+class _AddStepDialog extends StatefulWidget {
+  const _AddStepDialog({required this.template, required this.controller});
+  final ProjectTemplate template;
+  final ProjectTemplateController controller;
+
+  @override
+  State<_AddStepDialog> createState() => _AddStepDialogState();
+}
+
+class _AddStepDialogState extends State<_AddStepDialog> {
+  final _titleController = TextEditingController();
+  final _descController = TextEditingController();
+  final _offsetController = TextEditingController(text: '0');
+  bool _saving = false;
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _descController.dispose();
+    _offsetController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Add Step'),
+      content: SizedBox(
+        width: 360,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(labelText: 'Step title', border: OutlineInputBorder()),
+              autofocus: true,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _offsetController,
+              decoration: const InputDecoration(
+                labelText: 'Offset days (negative = before anchor)',
+                border: OutlineInputBorder(),
+              ),
+              keyboardType: const TextInputType.numberWithOptions(signed: true),
+              inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'^-?\d*'))],
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _descController,
+              decoration: const InputDecoration(
+                labelText: 'Description (e.g. "8 weeks before")',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(onPressed: _saving ? null : () => Navigator.pop(context), child: const Text('Cancel')),
+        FilledButton(
+          onPressed: _saving ? null : _save,
+          child: _saving ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)) : const Text('Add'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _save() async {
+    final title = _titleController.text.trim();
+    if (title.isEmpty) return;
+    final offsetDays = int.tryParse(_offsetController.text) ?? 0;
+    setState(() => _saving = true);
+    await widget.controller.addStep(
+      widget.template.id,
+      title: title,
+      offsetDays: offsetDays,
+      offsetDescription: _descController.text.trim().isEmpty ? null : _descController.text.trim(),
+      sortOrder: widget.template.steps.length,
+    );
+    if (mounted) Navigator.pop(context);
+  }
+}
+
+class _GenerateInstanceDialog extends StatefulWidget {
+  const _GenerateInstanceDialog({required this.template});
+  final ProjectTemplate template;
+
+  @override
+  State<_GenerateInstanceDialog> createState() => _GenerateInstanceDialogState();
+}
+
+class _GenerateInstanceDialogState extends State<_GenerateInstanceDialog> {
+  DateTime? _anchorDate;
+  bool _generating = false;
+  ProjectInstance? _result;
+  String? _error;
+
+  List<ResolvedStep> get _preview {
+    if (_anchorDate == null) return [];
+    return ProjectGenerationService().previewSteps(widget.template, _anchorDate!);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text('Generate: ${widget.template.name}'),
+      content: SizedBox(
+        width: 480,
+        child: _result != null ? _SuccessView(instance: _result!) : _FormView(
+          anchorDate: _anchorDate,
+          preview: _preview,
+          error: _error,
+          onPickDate: _pickDate,
+        ),
+      ),
+      actions: _result != null
+          ? [FilledButton(onPressed: () => Navigator.pop(context), child: const Text('Close'))]
+          : [
+              TextButton(onPressed: _generating ? null : () => Navigator.pop(context), child: const Text('Cancel')),
+              FilledButton(
+                onPressed: _anchorDate == null || _generating ? null : _generate,
+                child: _generating
+                    ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2))
+                    : const Text('Generate'),
+              ),
+            ],
+    );
+  }
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: DateTime.now(),
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+    if (picked != null) setState(() => _anchorDate = picked);
+  }
+
+  Future<void> _generate() async {
+    if (_anchorDate == null) return;
+    setState(() { _generating = true; _error = null; });
+
+    final dateStr =
+        '${_anchorDate!.year}-${_anchorDate!.month.toString().padLeft(2, '0')}-${_anchorDate!.day.toString().padLeft(2, '0')}';
+
+    try {
+      final response = await http.post(
+        Uri.parse('${AppConstants.apiBaseUrl}/project-templates/${widget.template.id}/generate'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'anchorDate': dateStr}),
+      );
+      if (response.statusCode >= 400) {
+        final body = jsonDecode(response.body) as Map<String, dynamic>?;
+        final msg = (body?['error'] as Map<String, dynamic>?)?['message'] as String? ?? 'Generation failed';
+        setState(() { _error = msg; _generating = false; });
+      } else {
+        final instance = ProjectInstance.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+        setState(() { _result = instance; _generating = false; });
+      }
+    } catch (e) {
+      setState(() { _error = e.toString(); _generating = false; });
+    }
+  }
+}
+
+class _FormView extends StatelessWidget {
+  const _FormView({required this.anchorDate, required this.preview, required this.error, required this.onPickDate});
+  final DateTime? anchorDate;
+  final List<ResolvedStep> preview;
+  final String? error;
+  final VoidCallback onPickDate;
+
+  @override
+  Widget build(BuildContext context) {
+    final dateLabel = anchorDate == null
+        ? 'Pick anchor date'
+        : '${anchorDate!.year}-${anchorDate!.month.toString().padLeft(2, '0')}-${anchorDate!.day.toString().padLeft(2, '0')}';
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        OutlinedButton.icon(
+          onPressed: onPickDate,
+          icon: const Icon(Icons.calendar_today, size: 16),
+          label: Text(dateLabel),
+        ),
+        if (error != null) ...[
+          const SizedBox(height: 8),
+          Text(error!, style: const TextStyle(color: Colors.red, fontSize: 12)),
+        ],
+        if (preview.isNotEmpty) ...[
+          const SizedBox(height: 16),
+          Text('Preview of resolved dates:', style: Theme.of(context).textTheme.labelLarge),
+          const SizedBox(height: 8),
+          ...preview.map((rs) {
+            final d = rs.dueDate;
+            final ds = '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Row(
+                children: [
+                  const Icon(Icons.arrow_right, size: 16, color: Colors.grey),
+                  const SizedBox(width: 4),
+                  Expanded(child: Text(rs.step.title)),
+                  Text(ds, style: const TextStyle(color: Colors.grey, fontSize: 12)),
+                ],
+              ),
+            );
+          }),
+        ],
+      ],
+    );
+  }
+}
+
+class _SuccessView extends StatelessWidget {
+  const _SuccessView({required this.instance});
+  final ProjectInstance instance;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.check_circle, color: Theme.of(context).colorScheme.primary),
+            const SizedBox(width: 8),
+            const Text('Instance generated successfully!'),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Text('Anchor: ${instance.anchorDate}', style: Theme.of(context).textTheme.bodySmall),
+        const SizedBox(height: 8),
+        ...instance.steps.map((s) => Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Row(
+                children: [
+                  const Icon(Icons.task_alt, size: 14, color: Colors.grey),
+                  const SizedBox(width: 6),
+                  Expanded(child: Text(s.title, style: Theme.of(context).textTheme.bodySmall)),
+                  Text(s.dueDate, style: const TextStyle(color: Colors.grey, fontSize: 11)),
+                ],
+              ),
+            )),
+      ],
     );
   }
 }

--- a/apps/desktop_flutter/lib/features/rhythms/controllers/rhythms_controller.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/controllers/rhythms_controller.dart
@@ -1,3 +1,70 @@
-class RhythmsController {
-  // TODO: Coordinate rhythm-related UI events.
+import 'package:flutter/foundation.dart';
+import '../../../features/tasks/models/recurring_task_rule.dart';
+import '../repositories/rhythms_repository.dart';
+
+enum RhythmsStatus { idle, loading, error }
+
+class RhythmsController extends ChangeNotifier {
+  RhythmsController(this._repository);
+
+  final RhythmsRepository _repository;
+
+  List<RecurringTaskRule> _rules = [];
+  RhythmsStatus _status = RhythmsStatus.idle;
+  String? _errorMessage;
+
+  List<RecurringTaskRule> get rules => _rules;
+  RhythmsStatus get status => _status;
+  String? get errorMessage => _errorMessage;
+
+  Future<void> load() async {
+    _status = RhythmsStatus.loading;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      _rules = await _repository.getAll();
+      _status = RhythmsStatus.idle;
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = RhythmsStatus.error;
+    }
+    notifyListeners();
+  }
+
+  Future<void> createRule({
+    required String title,
+    required String frequency,
+    int? dayOfWeek,
+    int? dayOfMonth,
+    int? month,
+  }) async {
+    try {
+      final rule = await _repository.create(
+        title: title,
+        frequency: frequency,
+        dayOfWeek: dayOfWeek,
+        dayOfMonth: dayOfMonth,
+        month: month,
+      );
+      _rules = [..._rules, rule];
+      notifyListeners();
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = RhythmsStatus.error;
+      notifyListeners();
+    }
+  }
+
+  Future<void> deleteRule(String id) async {
+    try {
+      await _repository.delete(id);
+      _rules = _rules.where((r) => r.id != id).toList();
+      notifyListeners();
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = RhythmsStatus.error;
+      notifyListeners();
+    }
+  }
 }

--- a/apps/desktop_flutter/lib/features/rhythms/data/rhythms_data_source.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/data/rhythms_data_source.dart
@@ -1,3 +1,51 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../../../app/core/constants/app_constants.dart';
+import '../../../app/core/errors/app_error.dart';
+import '../../../features/tasks/models/recurring_task_rule.dart';
+
 class RhythmsDataSource {
-  // TODO: Data source implementation.
+  final _base = Uri.parse('${AppConstants.apiBaseUrl}/recurring-rules');
+
+  Future<List<RecurringTaskRule>> fetchAll() async {
+    final response = await http.get(_base);
+    _assertOk(response);
+    final list = jsonDecode(response.body) as List<dynamic>;
+    return list.map((j) => RecurringTaskRule.fromJson(j as Map<String, dynamic>)).toList();
+  }
+
+  Future<RecurringTaskRule> create({
+    required String title,
+    required String frequency,
+    int? dayOfWeek,
+    int? dayOfMonth,
+    int? month,
+  }) async {
+    final response = await http.post(
+      _base,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'title': title,
+        'frequency': frequency,
+        if (dayOfWeek != null) 'dayOfWeek': dayOfWeek,
+        if (dayOfMonth != null) 'dayOfMonth': dayOfMonth,
+        if (month != null) 'month': month,
+      }),
+    );
+    _assertOk(response);
+    return RecurringTaskRule.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  Future<void> delete(String id) async {
+    final response = await http.delete(Uri.parse('${AppConstants.apiBaseUrl}/recurring-rules/$id'));
+    _assertOk(response);
+  }
+
+  void _assertOk(http.Response response) {
+    if (response.statusCode >= 400) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>?;
+      final message = (body?['error'] as Map<String, dynamic>?)?['message'] as String? ?? 'Request failed';
+      throw AppError(message);
+    }
+  }
 }

--- a/apps/desktop_flutter/lib/features/rhythms/repositories/rhythms_repository.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/repositories/rhythms_repository.dart
@@ -1,3 +1,27 @@
+import '../../../features/tasks/models/recurring_task_rule.dart';
+import '../data/rhythms_data_source.dart';
+
 class RhythmsRepository {
-  // TODO: Persistence for rhythm entities.
+  RhythmsRepository(this._dataSource);
+
+  final RhythmsDataSource _dataSource;
+
+  Future<List<RecurringTaskRule>> getAll() => _dataSource.fetchAll();
+
+  Future<RecurringTaskRule> create({
+    required String title,
+    required String frequency,
+    int? dayOfWeek,
+    int? dayOfMonth,
+    int? month,
+  }) =>
+      _dataSource.create(
+        title: title,
+        frequency: frequency,
+        dayOfWeek: dayOfWeek,
+        dayOfMonth: dayOfMonth,
+        month: month,
+      );
+
+  Future<void> delete(String id) => _dataSource.delete(id);
 }

--- a/apps/desktop_flutter/lib/features/rhythms/views/rhythms_view.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/views/rhythms_view.dart
@@ -1,1 +1,347 @@
-class RhythmsView {}
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+import '../controllers/rhythms_controller.dart';
+import '../../../features/tasks/models/recurring_task_rule.dart';
+import '../../../features/tasks/services/recurrence_service.dart';
+
+class RhythmsView extends StatefulWidget {
+  const RhythmsView({super.key});
+
+  @override
+  State<RhythmsView> createState() => _RhythmsViewState();
+}
+
+class _RhythmsViewState extends State<RhythmsView> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<RhythmsController>().load();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<RhythmsController>(
+      builder: (context, controller, _) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _Header(onAdd: () => _showCreateDialog(context, controller)),
+            if (controller.status == RhythmsStatus.error && controller.errorMessage != null)
+              _ErrorBanner(
+                message: controller.errorMessage!,
+                onRetry: controller.load,
+              ),
+            Expanded(child: _RulesList(controller: controller)),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _showCreateDialog(BuildContext context, RhythmsController controller) async {
+    await showDialog<void>(
+      context: context,
+      builder: (_) => _CreateRuleDialog(controller: controller),
+    );
+  }
+}
+
+class _Header extends StatelessWidget {
+  const _Header({required this.onAdd});
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+      child: Row(
+        children: [
+          Text('Rhythms', style: Theme.of(context).textTheme.headlineSmall),
+          const Spacer(),
+          FilledButton.icon(
+            onPressed: onAdd,
+            icon: const Icon(Icons.add, size: 18),
+            label: const Text('New Rule'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorBanner extends StatelessWidget {
+  const _ErrorBanner({required this.message, required this.onRetry});
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(24, 12, 24, 0),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.error_outline, color: Theme.of(context).colorScheme.onErrorContainer),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(message, style: TextStyle(color: Theme.of(context).colorScheme.onErrorContainer)),
+          ),
+          TextButton(onPressed: onRetry, child: const Text('Retry')),
+        ],
+      ),
+    );
+  }
+}
+
+class _RulesList extends StatelessWidget {
+  const _RulesList({required this.controller});
+  final RhythmsController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    if (controller.status == RhythmsStatus.loading && controller.rules.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (controller.rules.isEmpty) {
+      return const Center(
+        child: Text('No recurring rules yet. Create one to get started.'),
+      );
+    }
+
+    return ListView.separated(
+      padding: const EdgeInsets.all(24),
+      itemCount: controller.rules.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 8),
+      itemBuilder: (context, i) => _RuleTile(
+        rule: controller.rules[i],
+        onDelete: () => controller.deleteRule(controller.rules[i].id),
+      ),
+    );
+  }
+}
+
+class _RuleTile extends StatefulWidget {
+  const _RuleTile({required this.rule, required this.onDelete});
+  final RecurringTaskRule rule;
+  final VoidCallback onDelete;
+
+  @override
+  State<_RuleTile> createState() => _RuleTileState();
+}
+
+class _RuleTileState extends State<_RuleTile> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final preview = RecurrenceService()
+        .previewNextDates(widget.rule, DateTime.now(), count: 3)
+        .map((d) => '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}')
+        .join('  ·  ');
+
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      child: Column(
+        children: [
+          ListTile(
+            leading: const Icon(Icons.repeat),
+            title: Text(widget.rule.title),
+            subtitle: Text(widget.rule.patternDescription),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  icon: Icon(_expanded ? Icons.expand_less : Icons.expand_more),
+                  onPressed: () => setState(() => _expanded = !_expanded),
+                  tooltip: 'Preview dates',
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  onPressed: () => _confirmDelete(context),
+                  tooltip: 'Delete rule',
+                ),
+              ],
+            ),
+          ),
+          if (_expanded)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+              child: Row(
+                children: [
+                  const Icon(Icons.calendar_today, size: 14, color: Colors.grey),
+                  const SizedBox(width: 6),
+                  Text('Next: $preview', style: Theme.of(context).textTheme.bodySmall),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Rule'),
+        content: Text('Delete "${widget.rule.title}"? This will not remove already-generated tasks.'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.error),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) widget.onDelete();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Create Rule Dialog
+// ---------------------------------------------------------------------------
+
+class _CreateRuleDialog extends StatefulWidget {
+  const _CreateRuleDialog({required this.controller});
+  final RhythmsController controller;
+
+  @override
+  State<_CreateRuleDialog> createState() => _CreateRuleDialogState();
+}
+
+class _CreateRuleDialogState extends State<_CreateRuleDialog> {
+  final _titleController = TextEditingController();
+  String _frequency = 'weekly';
+  int _dayOfWeek = 1; // Monday
+  int _dayOfMonth = 1;
+  int _month = 1;
+  bool _saving = false;
+
+  static const _weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  static const _months = ['January', 'February', 'March', 'April', 'May', 'June',
+      'July', 'August', 'September', 'October', 'November', 'December'];
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('New Recurring Rule'),
+      content: SizedBox(
+        width: 400,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(labelText: 'Title', border: OutlineInputBorder()),
+              autofocus: true,
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              value: _frequency,
+              decoration: const InputDecoration(labelText: 'Frequency', border: OutlineInputBorder()),
+              items: const [
+                DropdownMenuItem(value: 'weekly', child: Text('Weekly')),
+                DropdownMenuItem(value: 'monthly', child: Text('Monthly')),
+                DropdownMenuItem(value: 'annual', child: Text('Annual')),
+              ],
+              onChanged: (v) => setState(() => _frequency = v!),
+            ),
+            const SizedBox(height: 16),
+            if (_frequency == 'weekly') ...[
+              DropdownButtonFormField<int>(
+                value: _dayOfWeek,
+                decoration: const InputDecoration(labelText: 'Day of Week', border: OutlineInputBorder()),
+                items: List.generate(7, (i) => DropdownMenuItem(value: i, child: Text(_weekdays[i]))),
+                onChanged: (v) => setState(() => _dayOfWeek = v!),
+              ),
+            ],
+            if (_frequency == 'monthly') ...[
+              _DayOfMonthField(
+                value: _dayOfMonth,
+                onChanged: (v) => setState(() => _dayOfMonth = v),
+              ),
+            ],
+            if (_frequency == 'annual') ...[
+              DropdownButtonFormField<int>(
+                value: _month,
+                decoration: const InputDecoration(labelText: 'Month', border: OutlineInputBorder()),
+                items: List.generate(12, (i) => DropdownMenuItem(value: i + 1, child: Text(_months[i]))),
+                onChanged: (v) => setState(() => _month = v!),
+              ),
+              const SizedBox(height: 12),
+              _DayOfMonthField(
+                value: _dayOfMonth,
+                onChanged: (v) => setState(() => _dayOfMonth = v),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _saving ? null : () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _saving ? null : _save,
+          child: _saving ? const SizedBox(width: 16, height: 16, child: CircularProgressIndicator(strokeWidth: 2)) : const Text('Create'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _save() async {
+    final title = _titleController.text.trim();
+    if (title.isEmpty) return;
+
+    setState(() => _saving = true);
+    await widget.controller.createRule(
+      title: title,
+      frequency: _frequency,
+      dayOfWeek: _frequency == 'weekly' ? _dayOfWeek : null,
+      dayOfMonth: (_frequency == 'monthly' || _frequency == 'annual') ? _dayOfMonth : null,
+      month: _frequency == 'annual' ? _month : null,
+    );
+    if (mounted) Navigator.pop(context);
+  }
+}
+
+class _DayOfMonthField extends StatelessWidget {
+  const _DayOfMonthField({required this.value, required this.onChanged});
+  final int value;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      initialValue: value.toString(),
+      decoration: const InputDecoration(labelText: 'Day of Month (1–31)', border: OutlineInputBorder()),
+      keyboardType: TextInputType.number,
+      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+      onChanged: (v) {
+        final n = int.tryParse(v);
+        if (n != null && n >= 1 && n <= 31) onChanged(n);
+      },
+    );
+  }
+}

--- a/apps/desktop_flutter/lib/features/tasks/models/recurring_task_rule.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/recurring_task_rule.dart
@@ -1,6 +1,61 @@
 class RecurringTaskRule {
-  RecurringTaskRule({required this.id, required this.pattern});
+  RecurringTaskRule({
+    required this.id,
+    required this.title,
+    required this.frequency,
+    required this.createdAt,
+    this.dayOfWeek,
+    this.dayOfMonth,
+    this.month,
+  });
+
+  factory RecurringTaskRule.fromJson(Map<String, dynamic> json) {
+    return RecurringTaskRule(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      frequency: json['frequency'] as String,
+      dayOfWeek: json['dayOfWeek'] as int?,
+      dayOfMonth: json['dayOfMonth'] as int?,
+      month: json['month'] as int?,
+      createdAt: json['createdAt'] as String,
+    );
+  }
 
   final String id;
-  final String pattern;
+  final String title;
+  final String frequency; // 'weekly' | 'monthly' | 'annual'
+  final int? dayOfWeek;   // 0=Sun..6=Sat (weekly)
+  final int? dayOfMonth;  // 1-31 (monthly / annual)
+  final int? month;       // 1-12 (annual)
+  final String createdAt;
+
+  String get patternDescription {
+    switch (frequency) {
+      case 'weekly':
+        final days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+        final dow = dayOfWeek ?? 1;
+        return 'Every ${days[dow.clamp(0, 6)]}';
+      case 'monthly':
+        final d = dayOfMonth ?? 1;
+        return 'Monthly on the ${_ordinal(d)}';
+      case 'annual':
+        final months = ['', 'January', 'February', 'March', 'April', 'May', 'June',
+            'July', 'August', 'September', 'October', 'November', 'December'];
+        final m = month ?? 1;
+        final d = dayOfMonth ?? 1;
+        return 'Every ${months[m.clamp(1, 12)]} ${_ordinal(d)}';
+      default:
+        return frequency;
+    }
+  }
+
+  static String _ordinal(int n) {
+    if (n >= 11 && n <= 13) return '${n}th';
+    switch (n % 10) {
+      case 1: return '${n}st';
+      case 2: return '${n}nd';
+      case 3: return '${n}rd';
+      default: return '${n}th';
+    }
+  }
 }

--- a/apps/desktop_flutter/lib/features/tasks/services/recurrence_service.dart
+++ b/apps/desktop_flutter/lib/features/tasks/services/recurrence_service.dart
@@ -1,3 +1,78 @@
+import '../models/recurring_task_rule.dart';
+
+/// Client-side preview service that mirrors the backend recurrence logic.
+/// Used exclusively for UI previews — no persistence side effects.
 class RecurrenceService {
-  // TODO: Generate concrete task instances from recurrence rules.
+  /// Returns the next [count] occurrence dates for [rule] starting from [from].
+  List<DateTime> previewNextDates(RecurringTaskRule rule, DateTime from, {int count = 5}) {
+    final results = <DateTime>[];
+    DateTime cursor = DateTime.utc(from.year, from.month, from.day);
+
+    while (results.length < count) {
+      final candidates = _computeYear(rule, cursor.year);
+      for (final date in candidates) {
+        if (!date.isBefore(cursor) && results.length < count) {
+          results.add(date);
+        }
+      }
+      cursor = DateTime.utc(cursor.year + 1, 1, 1);
+      if (cursor.year > from.year + 10) break; // safety ceiling
+    }
+    return results;
+  }
+
+  /// Returns all dates for [rule] within [from]..[to] (inclusive).
+  List<DateTime> generateDates(RecurringTaskRule rule, DateTime from, DateTime to) {
+    final results = <DateTime>[];
+    for (int year = from.year; year <= to.year; year++) {
+      for (final date in _computeYear(rule, year)) {
+        if (!date.isBefore(from) && !date.isAfter(to)) {
+          results.add(date);
+        }
+      }
+    }
+    return results;
+  }
+
+  List<DateTime> _computeYear(RecurringTaskRule rule, int year) {
+    switch (rule.frequency) {
+      case 'weekly':
+        return _weeklyDatesForYear(rule, year);
+      case 'monthly':
+        return _monthlyDatesForYear(rule, year);
+      case 'annual':
+        return _annualDatesForYear(rule, year);
+      default:
+        return [];
+    }
+  }
+
+  List<DateTime> _weeklyDatesForYear(RecurringTaskRule rule, int year) {
+    final targetDow = rule.dayOfWeek ?? 1; // Monday
+    final results = <DateTime>[];
+    var cur = DateTime.utc(year, 1, 1);
+    final daysUntilTarget = (targetDow - cur.weekday % 7 + 7) % 7;
+    cur = cur.add(Duration(days: daysUntilTarget));
+    while (cur.year == year) {
+      results.add(cur);
+      cur = cur.add(const Duration(days: 7));
+    }
+    return results;
+  }
+
+  List<DateTime> _monthlyDatesForYear(RecurringTaskRule rule, int year) {
+    final dom = rule.dayOfMonth ?? 1;
+    return List.generate(12, (i) => _resolveMonthDay(year, i + 1, dom));
+  }
+
+  List<DateTime> _annualDatesForYear(RecurringTaskRule rule, int year) {
+    final m = rule.month ?? 1;
+    final d = rule.dayOfMonth ?? 1;
+    return [_resolveMonthDay(year, m, d)];
+  }
+
+  DateTime _resolveMonthDay(int year, int month, int day) {
+    final lastDay = DateTime.utc(year, month + 1, 0).day;
+    return DateTime.utc(year, month, day.clamp(1, lastDay));
+  }
 }

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -8,6 +8,9 @@ import 'app/theme/app_theme.dart';
 import 'features/projects/controllers/project_template_controller.dart';
 import 'features/projects/data/projects_local_data_source.dart';
 import 'features/projects/repositories/projects_repository.dart';
+import 'features/rhythms/controllers/rhythms_controller.dart';
+import 'features/rhythms/data/rhythms_data_source.dart';
+import 'features/rhythms/repositories/rhythms_repository.dart';
 import 'features/tasks/controllers/tasks_controller.dart';
 import 'features/tasks/data/tasks_local_data_source.dart';
 import 'features/tasks/repositories/tasks_repository.dart';
@@ -45,6 +48,11 @@ class RhythmApp extends StatelessWidget {
         ChangeNotifierProvider(
           create: (_) => ProjectTemplateController(
             ProjectsRepository(ProjectsLocalDataSource()),
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => RhythmsController(
+            RhythmsRepository(RhythmsDataSource()),
           ),
         ),
       ],


### PR DESCRIPTION
## Summary
Implements all 8 Phase 2 issues (#14–#21):

**Backend**
- `RecurrenceService` — generates idempotent task instances for weekly/monthly/annual rules; handles leap-year Feb 29 and month-end overflow
- `ProjectGenerationService` — converts a `ProjectTemplate` + anchor date into a `ProjectInstance` with computed step due dates (`anchorDate + offsetDays`); idempotent by template + anchorDate
- `RecurrenceGenerationJob` — `node-cron` scheduled job: runs on startup + every Sunday midnight; 8-week rolling lookahead; configurable via `RECURRENCE_LOOKAHEAD_WEEKS` and `RECURRENCE_CRON_SCHEDULE` env vars
- REST API: `GET/POST/PATCH/DELETE /recurring-rules`, `POST /project-templates/:id/generate`, `GET /project-instances`
- New models: `RecurringTaskRule`, `ProjectInstance` / `ProjectInstanceStep`
- Migration: adds `project_instance_steps` table

**Flutter**
- `RecurrenceService` (Dart) — client-side preview of next occurrence dates (mirrors backend logic, no side effects)
- `ProjectGenerationService` (Dart) — pure preview of resolved step dates before committing to the server
- `RecurringTaskRule` model — full `fromJson` + `patternDescription` helper ("Every Monday", "Monthly on the 1st", etc.)
- `RhythmsController` + data layer — `ChangeNotifier` backed by `/recurring-rules` API
- `RhythmsView` — full CRUD UI: rule list with live next-3-dates preview, creation dialog with dynamic fields per frequency, delete with confirmation
- `ProjectsView` — two-panel layout: template list + detail with ordered steps, add-step form, generate-instance dialog with date preview confirmation before submission
- `ProjectTemplateController` — added `addStep` action
- Navigation sidebar — added **Rhythms** item (index 2)

## Test plan
- [ ] Create a weekly rule → verify task instances appear in Tasks view after server restart
- [ ] Create a monthly rule with day 31 → verify February resolves to Feb 28/29
- [ ] Create a project template with steps at -7, 0, +14 offset days → generate instance → verify resolved dates
- [ ] Re-generate same template + anchor date → verify no duplicates (idempotency)
- [ ] Recurring rules CRUD via Rhythms view matches `/recurring-rules` API responses

Closes #14, #15, #16, #17, #18, #19, #20, #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)