### PR TITLE
feat: Phase 3 - Weekly Planner

### DIFF
--- a/apps/api_server/src/app.ts
+++ b/apps/api_server/src/app.ts
@@ -8,6 +8,7 @@ import { projectInstancesRouter } from './routes/project_instances_routes';
 import { projectTemplatesRouter } from './routes/project_templates_routes';
 import { recurringRulesRouter } from './routes/recurring_rules_routes';
 import { tasksRouter } from './routes/tasks_routes';
+import { weeklyPlanRouter } from './routes/weekly_plan_routes';
 
 export function createApp() {
   const app = express();
@@ -21,6 +22,7 @@ export function createApp() {
   app.use('/project-templates', projectTemplatesRouter);
   app.use('/recurring-rules', recurringRulesRouter);
   app.use('/project-instances', projectInstancesRouter);
+  app.use('/weekly-plan', weeklyPlanRouter);
 
   app.use(errorHandler);
 

--- a/apps/api_server/src/controllers/recurring_rules_controller.ts
+++ b/apps/api_server/src/controllers/recurring_rules_controller.ts
@@ -1,8 +1,12 @@
 import type { NextFunction, Request, Response } from 'express';
 import { AppError } from '../errors/app_error';
 import { RecurringTaskRulesRepository } from '../repositories/recurring_task_rules_repository';
+import { RecurrenceService } from '../services/recurrence_service';
 
 const repo = new RecurringTaskRulesRepository();
+const recurrenceService = new RecurrenceService();
+
+const DEFAULT_LOOKAHEAD_WEEKS = 8;
 
 const VALID_FREQUENCIES = ['weekly', 'monthly', 'annual'] as const;
 
@@ -39,6 +43,15 @@ export class RecurringRulesController {
         dayOfMonth: dayOfMonth as number ?? null,
         month: month as number ?? null,
       });
+
+      // Immediately generate task instances so they appear in the weekly planner
+      const lookaheadWeeks = parseInt(process.env.RECURRENCE_LOOKAHEAD_WEEKS ?? '', 10);
+      const weeks = isNaN(lookaheadWeeks) ? DEFAULT_LOOKAHEAD_WEEKS : lookaheadWeeks;
+      const from = new Date();
+      const to = new Date();
+      to.setUTCDate(to.getUTCDate() + weeks * 7);
+      recurrenceService.generateInstances(rule, from, to);
+
       res.status(201).json(rule);
     } catch (err) {
       next(err);

--- a/apps/api_server/src/controllers/tasks_controller.ts
+++ b/apps/api_server/src/controllers/tasks_controller.ts
@@ -23,11 +23,11 @@ export class TasksController {
 
   create(req: Request, res: Response, next: NextFunction) {
     try {
-      const { title, dueDate, status } = req.body as Record<string, unknown>;
+      const { title, notes, dueDate, status } = req.body as Record<string, unknown>;
       if (!title || typeof title !== 'string') {
         throw AppError.badRequest('title is required');
       }
-      const task = repo.create({ title, dueDate: dueDate as string ?? null, status: status as 'open' | 'done' });
+      const task = repo.create({ title, notes: notes as string ?? null, dueDate: dueDate as string ?? null, status: status as 'open' | 'done' });
       res.status(201).json(task);
     } catch (err) {
       next(err);

--- a/apps/api_server/src/controllers/weekly_plan_controller.ts
+++ b/apps/api_server/src/controllers/weekly_plan_controller.ts
@@ -1,0 +1,31 @@
+import type { Request, Response, NextFunction } from 'express';
+import { AppError } from '../errors/app_error';
+import { TasksRepository } from '../repositories/tasks_repository';
+import { WeeklyPlanningService, currentWeekLabel } from '../services/weekly_planning_service';
+
+const service = new WeeklyPlanningService();
+const tasksRepo = new TasksRepository();
+
+export function getPlan(req: Request, res: Response, next: NextFunction): void {
+  try {
+    const weekLabel = (req.query.week as string | undefined) ?? currentWeekLabel();
+    if (!/^\d{4}-W\d{1,2}$/.test(weekLabel)) {
+      throw AppError.badRequest('Invalid week format. Use YYYY-WNN (e.g. 2026-W13).');
+    }
+    const plan = service.assemblePlan(weekLabel);
+    res.json(plan);
+  } catch (err) {
+    next(err);
+  }
+}
+
+export function scheduleTask(req: Request, res: Response, next: NextFunction): void {
+  try {
+    const { id } = req.params;
+    const { scheduledDate, locked } = req.body as { scheduledDate?: string; locked?: boolean };
+    const updated = tasksRepo.update(id, { scheduledDate, locked });
+    res.json(updated);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -65,4 +65,13 @@ export function runMigrations(db: Database.Database): void {
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
   `);
+
+  // Additive column migrations — safe to run on existing DBs
+  const taskCols = (db.pragma('table_info(tasks)') as { name: string }[]).map((c) => c.name);
+  if (!taskCols.includes('scheduled_date')) {
+    db.exec(`ALTER TABLE tasks ADD COLUMN scheduled_date TEXT`);
+  }
+  if (!taskCols.includes('locked')) {
+    db.exec(`ALTER TABLE tasks ADD COLUMN locked INTEGER NOT NULL DEFAULT 0`);
+  }
 }

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -74,4 +74,7 @@ export function runMigrations(db: Database.Database): void {
   if (!taskCols.includes('locked')) {
     db.exec(`ALTER TABLE tasks ADD COLUMN locked INTEGER NOT NULL DEFAULT 0`);
   }
+  if (!taskCols.includes('notes')) {
+    db.exec(`ALTER TABLE tasks ADD COLUMN notes TEXT`);
+  }
 }

--- a/apps/api_server/src/models/task.ts
+++ b/apps/api_server/src/models/task.ts
@@ -1,6 +1,7 @@
 export interface Task {
   id: string;
   title: string;
+  notes: string | null;
   dueDate: string | null;
   scheduledDate: string | null;
   locked: boolean;
@@ -13,6 +14,7 @@ export interface Task {
 
 export interface CreateTaskDto {
   title: string;
+  notes?: string | null;
   dueDate?: string | null;
   status?: 'open' | 'done';
   sourceType?: string | null;
@@ -21,6 +23,7 @@ export interface CreateTaskDto {
 
 export interface UpdateTaskDto {
   title?: string;
+  notes?: string | null;
   dueDate?: string | null;
   status?: 'open' | 'done';
   scheduledDate?: string | null;

--- a/apps/api_server/src/models/task.ts
+++ b/apps/api_server/src/models/task.ts
@@ -2,6 +2,8 @@ export interface Task {
   id: string;
   title: string;
   dueDate: string | null;
+  scheduledDate: string | null;
+  locked: boolean;
   status: 'open' | 'done';
   sourceType: string | null;
   sourceId: string | null;
@@ -21,4 +23,6 @@ export interface UpdateTaskDto {
   title?: string;
   dueDate?: string | null;
   status?: 'open' | 'done';
+  scheduledDate?: string | null;
+  locked?: boolean;
 }

--- a/apps/api_server/src/repositories/tasks_repository.ts
+++ b/apps/api_server/src/repositories/tasks_repository.ts
@@ -6,6 +6,7 @@ import type { CreateTaskDto, Task, UpdateTaskDto } from '../models/task';
 interface TaskRow {
   id: string;
   title: string;
+  notes: string | null;
   due_date: string | null;
   scheduled_date: string | null;
   locked: number;
@@ -20,6 +21,7 @@ function rowToTask(row: TaskRow): Task {
   return {
     id: row.id,
     title: row.title,
+    notes: row.notes ?? null,
     dueDate: row.due_date,
     scheduledDate: row.scheduled_date ?? null,
     locked: row.locked === 1,
@@ -33,12 +35,16 @@ function rowToTask(row: TaskRow): Task {
 
 export class TasksRepository {
   findAll(): Task[] {
-    const rows = getDb().prepare('SELECT * FROM tasks ORDER BY due_date ASC, created_at ASC').all() as TaskRow[];
+    const rows = getDb()
+      .prepare('SELECT * FROM tasks ORDER BY due_date ASC, created_at ASC')
+      .all() as TaskRow[];
     return rows.map(rowToTask);
   }
 
   findById(id: string): Task {
-    const row = getDb().prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow | undefined;
+    const row = getDb()
+      .prepare('SELECT * FROM tasks WHERE id = ?')
+      .get(id) as TaskRow | undefined;
     if (!row) throw AppError.notFound('Task');
     return rowToTask(row);
   }
@@ -59,10 +65,20 @@ export class TasksRepository {
     const now = new Date().toISOString();
     getDb()
       .prepare(
-        `INSERT INTO tasks (id, title, due_date, status, source_type, source_id, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO tasks (id, title, notes, due_date, status, source_type, source_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(id, data.title, data.dueDate ?? null, data.status ?? 'open', data.sourceType ?? null, data.sourceId ?? null, now, now);
+      .run(
+        id,
+        data.title,
+        data.notes ?? null,
+        data.dueDate ?? null,
+        data.status ?? 'open',
+        data.sourceType ?? null,
+        data.sourceId ?? null,
+        now,
+        now,
+      );
     return this.findById(id);
   }
 
@@ -71,10 +87,14 @@ export class TasksRepository {
     const now = new Date().toISOString();
     getDb()
       .prepare(
-        `UPDATE tasks SET title = ?, due_date = ?, status = ?, scheduled_date = ?, locked = ?, updated_at = ? WHERE id = ?`,
+        `UPDATE tasks
+         SET title = ?, notes = ?, due_date = ?, status = ?,
+             scheduled_date = ?, locked = ?, updated_at = ?
+         WHERE id = ?`,
       )
       .run(
         data.title ?? existing.title,
+        data.notes !== undefined ? data.notes : existing.notes,
         data.dueDate !== undefined ? data.dueDate : existing.dueDate,
         data.status ?? existing.status,
         data.scheduledDate !== undefined ? data.scheduledDate : existing.scheduledDate,

--- a/apps/api_server/src/repositories/tasks_repository.ts
+++ b/apps/api_server/src/repositories/tasks_repository.ts
@@ -7,6 +7,8 @@ interface TaskRow {
   id: string;
   title: string;
   due_date: string | null;
+  scheduled_date: string | null;
+  locked: number;
   status: string;
   source_type: string | null;
   source_id: string | null;
@@ -19,6 +21,8 @@ function rowToTask(row: TaskRow): Task {
     id: row.id,
     title: row.title,
     dueDate: row.due_date,
+    scheduledDate: row.scheduled_date ?? null,
+    locked: row.locked === 1,
     status: row.status as Task['status'],
     sourceType: row.source_type,
     sourceId: row.source_id,
@@ -39,6 +43,17 @@ export class TasksRepository {
     return rowToTask(row);
   }
 
+  findByWeek(weekStart: string, weekEnd: string): Task[] {
+    const rows = getDb()
+      .prepare(
+        `SELECT * FROM tasks
+         WHERE (due_date BETWEEN ? AND ? OR scheduled_date BETWEEN ? AND ?)
+         ORDER BY due_date ASC, created_at ASC`,
+      )
+      .all(weekStart, weekEnd, weekStart, weekEnd) as TaskRow[];
+    return rows.map(rowToTask);
+  }
+
   create(data: CreateTaskDto): Task {
     const id = uuidv4();
     const now = new Date().toISOString();
@@ -56,12 +71,14 @@ export class TasksRepository {
     const now = new Date().toISOString();
     getDb()
       .prepare(
-        `UPDATE tasks SET title = ?, due_date = ?, status = ?, updated_at = ? WHERE id = ?`,
+        `UPDATE tasks SET title = ?, due_date = ?, status = ?, scheduled_date = ?, locked = ?, updated_at = ? WHERE id = ?`,
       )
       .run(
         data.title ?? existing.title,
         data.dueDate !== undefined ? data.dueDate : existing.dueDate,
         data.status ?? existing.status,
+        data.scheduledDate !== undefined ? data.scheduledDate : existing.scheduledDate,
+        data.locked !== undefined ? (data.locked ? 1 : 0) : (existing.locked ? 1 : 0),
         now,
         id,
       );

--- a/apps/api_server/src/routes/weekly_plan_routes.ts
+++ b/apps/api_server/src/routes/weekly_plan_routes.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express';
+import { getPlan, scheduleTask } from '../controllers/weekly_plan_controller';
+
+export const weeklyPlanRouter = Router();
+
+weeklyPlanRouter.get('/', getPlan);
+weeklyPlanRouter.patch('/tasks/:id', scheduleTask);

--- a/apps/api_server/src/services/weekly_planning_service.ts
+++ b/apps/api_server/src/services/weekly_planning_service.ts
@@ -1,0 +1,148 @@
+import { getDb } from '../database/db';
+import type { Task } from '../models/task';
+
+export interface WeeklyPlanDay {
+  date: string;
+  tasks: Task[];
+}
+
+export interface WeeklyPlan {
+  weekLabel: string;
+  weekStart: string;
+  days: WeeklyPlanDay[];
+}
+
+interface ProjectStepRow {
+  id: string;
+  title: string;
+  due_date: string;
+  status: string;
+  instance_id: string;
+  template_id: string;
+}
+
+/** Parse a YYYY-WNN label into the Monday UTC date for that ISO week. */
+export function parseWeekLabel(weekLabel: string): Date {
+  const m = weekLabel.match(/^(\d{4})-W(\d{1,2})$/);
+  if (!m) throw new Error(`Invalid week label: ${weekLabel}`);
+  const year = parseInt(m[1], 10);
+  const week = parseInt(m[2], 10);
+  // Jan 4 is always in ISO week 1
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const mondayWeek1 = new Date(jan4);
+  mondayWeek1.setUTCDate(jan4.getUTCDate() - ((jan4.getUTCDay() + 6) % 7));
+  const result = new Date(mondayWeek1);
+  result.setUTCDate(mondayWeek1.getUTCDate() + (week - 1) * 7);
+  return result;
+}
+
+/** Return the ISO week label (YYYY-WNN) for today. */
+export function currentWeekLabel(): string {
+  const now = new Date();
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  d.setUTCDate(d.getUTCDate() + 3 - ((d.getUTCDay() + 6) % 7));
+  const jan4 = new Date(Date.UTC(d.getUTCFullYear(), 0, 4));
+  const weekNum =
+    1 +
+    Math.round(
+      ((d.getTime() - jan4.getTime()) / 86400000 - 3 + ((jan4.getUTCDay() + 6) % 7)) / 7,
+    );
+  return `${d.getUTCFullYear()}-W${weekNum.toString().padStart(2, '0')}`;
+}
+
+function isoDate(date: Date): string {
+  return date.toISOString().substring(0, 10);
+}
+
+export class WeeklyPlanningService {
+  assemblePlan(weekLabel: string): WeeklyPlan {
+    const weekStart = parseWeekLabel(weekLabel);
+    const weekEnd = new Date(weekStart);
+    weekEnd.setUTCDate(weekStart.getUTCDate() + 6);
+
+    const startStr = isoDate(weekStart);
+    const endStr = isoDate(weekEnd);
+    const db = getDb();
+
+    // Build day buckets Mon–Sun
+    const days: WeeklyPlanDay[] = Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(weekStart);
+      d.setUTCDate(weekStart.getUTCDate() + i);
+      return { date: isoDate(d), tasks: [] };
+    });
+    const dayMap = new Map(days.map((d) => [d.date, d]));
+
+    // 1+2: tasks (one-off and recurring instances) with due_date or scheduled_date in week
+    type TaskRow = {
+      id: string;
+      title: string;
+      due_date: string | null;
+      scheduled_date: string | null;
+      locked: number;
+      status: string;
+      source_type: string | null;
+      source_id: string | null;
+      created_at: string;
+      updated_at: string;
+    };
+    const taskRows = db
+      .prepare(
+        `SELECT * FROM tasks
+         WHERE (due_date BETWEEN ? AND ? OR scheduled_date BETWEEN ? AND ?)
+         ORDER BY due_date ASC, created_at ASC`,
+      )
+      .all(startStr, endStr, startStr, endStr) as TaskRow[];
+
+    for (const row of taskRows) {
+      const dateKey = row.scheduled_date ?? row.due_date;
+      if (!dateKey) continue;
+      const day = dayMap.get(dateKey);
+      if (!day) continue;
+      day.tasks.push({
+        id: row.id,
+        title: row.title,
+        dueDate: row.due_date,
+        scheduledDate: row.scheduled_date ?? null,
+        locked: row.locked === 1,
+        status: row.status as Task['status'],
+        sourceType: row.source_type,
+        sourceId: row.source_id,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+      });
+    }
+
+    // 3: project instance steps due in the week
+    const stepRows = db
+      .prepare(
+        `SELECT pis.id, pis.title, pis.due_date, pis.status, pis.instance_id,
+                pi.template_id
+         FROM project_instance_steps pis
+         JOIN project_instances pi ON pi.id = pis.instance_id
+         WHERE pis.due_date BETWEEN ? AND ?
+         ORDER BY pis.due_date ASC`,
+      )
+      .all(startStr, endStr) as ProjectStepRow[];
+
+    for (const row of stepRows) {
+      const day = dayMap.get(row.due_date);
+      if (!day) continue;
+      day.tasks.push({
+        id: row.id,
+        title: row.title,
+        dueDate: row.due_date,
+        scheduledDate: null,
+        locked: false,
+        status: row.status as Task['status'],
+        sourceType: 'project_step',
+        sourceId: row.template_id,
+        createdAt: '',
+        updatedAt: '',
+      });
+    }
+
+    // 4: calendar shadow events — stubbed empty for Phase 4
+
+    return { weekLabel, weekStart: startStr, days };
+  }
+}

--- a/apps/api_server/src/services/weekly_planning_service.ts
+++ b/apps/api_server/src/services/weekly_planning_service.ts
@@ -10,6 +10,7 @@ export interface WeeklyPlan {
   weekLabel: string;
   weekStart: string;
   days: WeeklyPlanDay[];
+  backlog: Task[];
 }
 
 interface ProjectStepRow {
@@ -146,6 +147,29 @@ export class WeeklyPlanningService {
 
     // 4: calendar shadow events — stubbed empty for Phase 4
 
-    return { weekLabel, weekStart: startStr, days };
+    // 5: backlog — open tasks with no due_date and no scheduled_date
+    type BacklogRow = TaskRow;
+    const backlogRows = db
+      .prepare(
+        `SELECT * FROM tasks
+         WHERE status = 'open' AND due_date IS NULL AND scheduled_date IS NULL
+         ORDER BY created_at ASC`,
+      )
+      .all() as BacklogRow[];
+    const backlog: Task[] = backlogRows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      notes: row.notes ?? null,
+      dueDate: null,
+      scheduledDate: null,
+      locked: false,
+      status: 'open' as Task['status'],
+      sourceType: row.source_type,
+      sourceId: row.source_id,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+
+    return { weekLabel, weekStart: startStr, days, backlog };
   }
 }

--- a/apps/api_server/src/services/weekly_planning_service.ts
+++ b/apps/api_server/src/services/weekly_planning_service.ts
@@ -76,6 +76,7 @@ export class WeeklyPlanningService {
     type TaskRow = {
       id: string;
       title: string;
+      notes: string | null;
       due_date: string | null;
       scheduled_date: string | null;
       locked: number;
@@ -103,6 +104,7 @@ export class WeeklyPlanningService {
         title: row.title,
         dueDate: row.due_date,
         scheduledDate: row.scheduled_date ?? null,
+        notes: row.notes ?? null,
         locked: row.locked === 1,
         status: row.status as Task['status'],
         sourceType: row.source_type,
@@ -130,6 +132,7 @@ export class WeeklyPlanningService {
       day.tasks.push({
         id: row.id,
         title: row.title,
+        notes: null,
         dueDate: row.due_date,
         scheduledDate: null,
         locked: false,

--- a/apps/desktop_flutter/lib/features/tasks/controllers/tasks_controller.dart
+++ b/apps/desktop_flutter/lib/features/tasks/controllers/tasks_controller.dart
@@ -21,7 +21,6 @@ class TasksController extends ChangeNotifier {
     _status = TasksStatus.loading;
     _errorMessage = null;
     notifyListeners();
-
     try {
       _tasks = await _repository.getAll();
       _status = TasksStatus.idle;
@@ -32,9 +31,11 @@ class TasksController extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> createTask(String title, {String? dueDate}) async {
+  Future<void> createTask(String title,
+      {String? notes, String? dueDate}) async {
     try {
-      final task = await _repository.create(title, dueDate: dueDate);
+      final task =
+          await _repository.create(title, notes: notes, dueDate: dueDate);
       _tasks = [..._tasks, task];
       notifyListeners();
     } catch (e) {
@@ -44,10 +45,11 @@ class TasksController extends ChangeNotifier {
     }
   }
 
-  Future<void> updateTask(String id, {String? title, String? dueDate}) async {
+  Future<void> updateTask(String id,
+      {String? title, String? notes, String? dueDate}) async {
     try {
-      final updated =
-          await _repository.update(id, title: title, dueDate: dueDate);
+      final updated = await _repository.update(id,
+          title: title, notes: notes, dueDate: dueDate);
       _tasks = _tasks.map((t) => t.id == id ? updated : t).toList();
       notifyListeners();
     } catch (e) {

--- a/apps/desktop_flutter/lib/features/tasks/data/tasks_local_data_source.dart
+++ b/apps/desktop_flutter/lib/features/tasks/data/tasks_local_data_source.dart
@@ -14,24 +14,28 @@ class TasksLocalDataSource {
     return list.map((j) => Task.fromJson(j as Map<String, dynamic>)).toList();
   }
 
-  Future<Task> create(String title, {String? dueDate}) async {
+  Future<Task> create(String title, {String? notes, String? dueDate}) async {
     final response = await http.post(
       _base,
       headers: {'Content-Type': 'application/json'},
-      body:
-          jsonEncode({'title': title, if (dueDate != null) 'dueDate': dueDate}),
+      body: jsonEncode({
+        'title': title,
+        if (notes != null && notes.isNotEmpty) 'notes': notes,
+        if (dueDate != null) 'dueDate': dueDate,
+      }),
     );
     _assertOk(response);
     return Task.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
   }
 
   Future<Task> update(String id,
-      {String? title, String? dueDate, String? status}) async {
+      {String? title, String? notes, String? dueDate, String? status}) async {
     final response = await http.patch(
       Uri.parse('${AppConstants.apiBaseUrl}/tasks/$id'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         if (title != null) 'title': title,
+        if (notes != null) 'notes': notes,
         if (dueDate != null) 'dueDate': dueDate,
         if (status != null) 'status': status,
       }),

--- a/apps/desktop_flutter/lib/features/tasks/models/task.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/task.dart
@@ -5,6 +5,7 @@ class Task {
     required this.status,
     required this.createdAt,
     required this.updatedAt,
+    this.notes,
     this.dueDate,
     this.scheduledDate,
     this.locked = false,
@@ -16,6 +17,7 @@ class Task {
     return Task(
       id: json['id'] as String,
       title: json['title'] as String,
+      notes: json['notes'] as String?,
       dueDate: json['dueDate'] as String?,
       scheduledDate: json['scheduledDate'] as String?,
       locked: (json['locked'] as bool?) ?? false,
@@ -29,6 +31,7 @@ class Task {
 
   final String id;
   final String title;
+  final String? notes;
   final String? dueDate;
   final String? scheduledDate;
   final bool locked;
@@ -41,6 +44,7 @@ class Task {
   Map<String, dynamic> toJson() => {
         'id': id,
         'title': title,
+        'notes': notes,
         'dueDate': dueDate,
         'scheduledDate': scheduledDate,
         'locked': locked,
@@ -53,6 +57,7 @@ class Task {
 
   Task copyWith({
     String? title,
+    String? notes,
     String? dueDate,
     String? scheduledDate,
     bool? locked,
@@ -61,6 +66,7 @@ class Task {
     return Task(
       id: id,
       title: title ?? this.title,
+      notes: notes ?? this.notes,
       dueDate: dueDate ?? this.dueDate,
       scheduledDate: scheduledDate ?? this.scheduledDate,
       locked: locked ?? this.locked,

--- a/apps/desktop_flutter/lib/features/tasks/models/task.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/task.dart
@@ -6,6 +6,8 @@ class Task {
     required this.createdAt,
     required this.updatedAt,
     this.dueDate,
+    this.scheduledDate,
+    this.locked = false,
     this.sourceType,
     this.sourceId,
   });
@@ -15,17 +17,21 @@ class Task {
       id: json['id'] as String,
       title: json['title'] as String,
       dueDate: json['dueDate'] as String?,
+      scheduledDate: json['scheduledDate'] as String?,
+      locked: (json['locked'] as bool?) ?? false,
       status: json['status'] as String? ?? 'open',
       sourceType: json['sourceType'] as String?,
       sourceId: json['sourceId'] as String?,
-      createdAt: json['createdAt'] as String,
-      updatedAt: json['updatedAt'] as String,
+      createdAt: json['createdAt'] as String? ?? '',
+      updatedAt: json['updatedAt'] as String? ?? '',
     );
   }
 
   final String id;
   final String title;
   final String? dueDate;
+  final String? scheduledDate;
+  final bool locked;
   final String status;
   final String? sourceType;
   final String? sourceId;
@@ -36,6 +42,8 @@ class Task {
         'id': id,
         'title': title,
         'dueDate': dueDate,
+        'scheduledDate': scheduledDate,
+        'locked': locked,
         'status': status,
         'sourceType': sourceType,
         'sourceId': sourceId,
@@ -43,11 +51,19 @@ class Task {
         'updatedAt': updatedAt,
       };
 
-  Task copyWith({String? title, String? dueDate, String? status}) {
+  Task copyWith({
+    String? title,
+    String? dueDate,
+    String? scheduledDate,
+    bool? locked,
+    String? status,
+  }) {
     return Task(
       id: id,
       title: title ?? this.title,
       dueDate: dueDate ?? this.dueDate,
+      scheduledDate: scheduledDate ?? this.scheduledDate,
+      locked: locked ?? this.locked,
       status: status ?? this.status,
       sourceType: sourceType,
       sourceId: sourceId,

--- a/apps/desktop_flutter/lib/features/tasks/repositories/tasks_repository.dart
+++ b/apps/desktop_flutter/lib/features/tasks/repositories/tasks_repository.dart
@@ -8,12 +8,13 @@ class TasksRepository {
 
   Future<List<Task>> getAll() => _dataSource.fetchAll();
 
-  Future<Task> create(String title, {String? dueDate}) =>
-      _dataSource.create(title, dueDate: dueDate);
+  Future<Task> create(String title, {String? notes, String? dueDate}) =>
+      _dataSource.create(title, notes: notes, dueDate: dueDate);
 
   Future<Task> update(String id,
-          {String? title, String? dueDate, String? status}) =>
-      _dataSource.update(id, title: title, dueDate: dueDate, status: status);
+          {String? title, String? notes, String? dueDate, String? status}) =>
+      _dataSource.update(id,
+          title: title, notes: notes, dueDate: dueDate, status: status);
 
   Future<void> delete(String id) => _dataSource.delete(id);
 }

--- a/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
@@ -13,6 +13,7 @@ class TasksView extends StatefulWidget {
 
 class _TasksViewState extends State<TasksView> {
   final _titleController = TextEditingController();
+  final _notesController = TextEditingController();
   String? _selectedDueDate;
 
   @override
@@ -26,6 +27,7 @@ class _TasksViewState extends State<TasksView> {
   @override
   void dispose() {
     _titleController.dispose();
+    _notesController.dispose();
     super.dispose();
   }
 
@@ -45,10 +47,14 @@ class _TasksViewState extends State<TasksView> {
   Future<void> _submitCreate() async {
     final title = _titleController.text.trim();
     if (title.isEmpty) return;
-    await context
-        .read<TasksController>()
-        .createTask(title, dueDate: _selectedDueDate);
+    final notes = _notesController.text.trim();
+    await context.read<TasksController>().createTask(
+          title,
+          notes: notes.isEmpty ? null : notes,
+          dueDate: _selectedDueDate,
+        );
     _titleController.clear();
+    _notesController.clear();
     setState(() => _selectedDueDate = null);
   }
 
@@ -118,7 +124,19 @@ class _TasksViewState extends State<TasksView> {
           color: isDone ? Colors.grey : null,
         ),
       ),
-      subtitle: task.dueDate != null ? Text('Due: ${task.dueDate}') : null,
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (task.dueDate != null) Text('Due: ${task.dueDate}'),
+          if (task.notes != null && task.notes!.isNotEmpty)
+            Text(
+              task.notes!,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: Colors.grey, fontSize: 12),
+            ),
+        ],
+      ),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -151,27 +169,43 @@ class _TasksViewState extends State<TasksView> {
         color: Theme.of(context).colorScheme.surfaceContainerLow,
         border: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
       ),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Expanded(
-            child: TextField(
-              controller: _titleController,
-              decoration: const InputDecoration(
-                hintText: 'New task title...',
-                isDense: true,
-                border: OutlineInputBorder(),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _titleController,
+                  decoration: const InputDecoration(
+                    hintText: 'New task title...',
+                    isDense: true,
+                    border: OutlineInputBorder(),
+                  ),
+                  onSubmitted: (_) => _submitCreate(),
+                ),
               ),
-              onSubmitted: (_) => _submitCreate(),
+              const SizedBox(width: 8),
+              OutlinedButton.icon(
+                onPressed: _pickDate,
+                icon: const Icon(Icons.calendar_today, size: 16),
+                label: Text(_selectedDueDate ?? 'Due date'),
+              ),
+              const SizedBox(width: 8),
+              FilledButton(onPressed: _submitCreate, child: const Text('Add')),
+            ],
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _notesController,
+            decoration: const InputDecoration(
+              hintText: 'Add a note... (optional)',
+              isDense: true,
+              border: OutlineInputBorder(),
             ),
+            minLines: 1,
+            maxLines: 3,
           ),
-          const SizedBox(width: 8),
-          OutlinedButton.icon(
-            onPressed: _pickDate,
-            icon: const Icon(Icons.calendar_today, size: 16),
-            label: Text(_selectedDueDate ?? 'Due date'),
-          ),
-          const SizedBox(width: 8),
-          FilledButton(onPressed: _submitCreate, child: const Text('Add')),
         ],
       ),
     );
@@ -189,6 +223,7 @@ class _EditTaskDialog extends StatefulWidget {
 
 class _EditTaskDialogState extends State<_EditTaskDialog> {
   late final TextEditingController _titleController;
+  late final TextEditingController _notesController;
   String? _dueDate;
   bool _saving = false;
 
@@ -196,12 +231,14 @@ class _EditTaskDialogState extends State<_EditTaskDialog> {
   void initState() {
     super.initState();
     _titleController = TextEditingController(text: widget.task.title);
+    _notesController = TextEditingController(text: widget.task.notes ?? '');
     _dueDate = widget.task.dueDate;
   }
 
   @override
   void dispose() {
     _titleController.dispose();
+    _notesController.dispose();
     super.dispose();
   }
 
@@ -225,7 +262,7 @@ class _EditTaskDialogState extends State<_EditTaskDialog> {
     return AlertDialog(
       title: const Text('Edit Task'),
       content: SizedBox(
-        width: 360,
+        width: 400,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -234,6 +271,14 @@ class _EditTaskDialogState extends State<_EditTaskDialog> {
               decoration: const InputDecoration(
                   labelText: 'Title', border: OutlineInputBorder()),
               autofocus: true,
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _notesController,
+              decoration: const InputDecoration(
+                  labelText: 'Notes (optional)', border: OutlineInputBorder()),
+              minLines: 2,
+              maxLines: 5,
             ),
             const SizedBox(height: 12),
             Row(
@@ -276,8 +321,13 @@ class _EditTaskDialogState extends State<_EditTaskDialog> {
     final title = _titleController.text.trim();
     if (title.isEmpty) return;
     setState(() => _saving = true);
-    await widget.controller
-        .updateTask(widget.task.id, title: title, dueDate: _dueDate);
+    final notes = _notesController.text.trim();
+    await widget.controller.updateTask(
+      widget.task.id,
+      title: title,
+      notes: notes.isEmpty ? null : notes,
+      dueDate: _dueDate,
+    );
     if (mounted) Navigator.pop(context);
   }
 }

--- a/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
@@ -1,3 +1,136 @@
-class WeeklyPlannerController {
-  // TODO: Thin controller for weekly planner orchestration.
+import 'package:flutter/foundation.dart';
+import '../models/weekly_plan.dart';
+import '../repositories/weekly_plan_repository.dart';
+
+enum WeeklyPlannerStatus { idle, loading, error }
+
+class WeeklyPlannerController extends ChangeNotifier {
+  WeeklyPlannerController(this._repository);
+
+  final WeeklyPlanRepository _repository;
+
+  WeeklyPlan? _plan;
+  WeeklyPlannerStatus _status = WeeklyPlannerStatus.idle;
+  String? _errorMessage;
+  late String _currentWeekLabel;
+  String? _selectedTaskId;
+
+  WeeklyPlan? get plan => _plan;
+  WeeklyPlannerStatus get status => _status;
+  String? get errorMessage => _errorMessage;
+  String get currentWeekLabel => _currentWeekLabel;
+  String? get selectedTaskId => _selectedTaskId;
+
+  @override
+  void addListener(VoidCallback listener) {
+    _currentWeekLabel = _todayWeekLabel();
+    super.addListener(listener);
+  }
+
+  void _init() {
+    _currentWeekLabel = _todayWeekLabel();
+  }
+
+  WeeklyPlannerController._internal(this._repository) {
+    _currentWeekLabel = _todayWeekLabel();
+  }
+
+  factory WeeklyPlannerController.create(WeeklyPlanRepository repository) {
+    return WeeklyPlannerController._internal(repository);
+  }
+
+  static String _todayWeekLabel() {
+    final now = DateTime.now().toUtc();
+    final d = DateTime.utc(now.year, now.month, now.day);
+    // Find Thursday of the same ISO week (weekday 4 = Thursday)
+    final thursday = d.subtract(Duration(days: (d.weekday - 4 + 7) % 7));
+    final jan4 = DateTime.utc(thursday.year, 1, 4);
+    final mondayJan4 =
+        jan4.subtract(Duration(days: (jan4.weekday - 1 + 7) % 7));
+    final weekNum = ((thursday.difference(mondayJan4).inDays) ~/ 7) + 1;
+    return '${thursday.year}-W${weekNum.toString().padLeft(2, '0')}';
+  }
+
+  bool get isCurrentWeek => _currentWeekLabel == _todayWeekLabel();
+
+  Future<void> load() async {
+    if (_status == WeeklyPlannerStatus.idle || _currentWeekLabel.isNotEmpty) {
+      _init();
+    }
+    _status = WeeklyPlannerStatus.loading;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      _plan = await _repository.fetchPlan(_currentWeekLabel);
+      _status = WeeklyPlannerStatus.idle;
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = WeeklyPlannerStatus.error;
+    }
+    notifyListeners();
+  }
+
+  void goToPrevWeek() {
+    _currentWeekLabel = _offsetWeek(_currentWeekLabel, -1);
+    load();
+  }
+
+  void goToNextWeek() {
+    _currentWeekLabel = _offsetWeek(_currentWeekLabel, 1);
+    load();
+  }
+
+  void goToToday() {
+    _currentWeekLabel = _todayWeekLabel();
+    load();
+  }
+
+  void selectTask(String? id) {
+    _selectedTaskId = id;
+    notifyListeners();
+  }
+
+  Future<void> scheduleTask(String taskId, String date) async {
+    try {
+      await _repository.scheduleTask(taskId, date);
+      await load();
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = WeeklyPlannerStatus.error;
+      notifyListeners();
+    }
+  }
+
+  Future<void> unscheduleTask(String taskId) async {
+    // scheduleTask with empty date effectively removes scheduling — we use
+    // a dedicated unschedule by patching scheduledDate to null via the API.
+    // For now re-fetch to sync state.
+    try {
+      await _repository.scheduleTask(taskId, '');
+    } catch (_) {}
+    await load();
+  }
+
+  static String _offsetWeek(String label, int delta) {
+    final m = RegExp(r'^(\d{4})-W(\d{1,2})$').firstMatch(label);
+    if (m == null) return label;
+    final year = int.parse(m.group(1)!);
+    final week = int.parse(m.group(2)!);
+    // Convert to absolute week number, add delta, convert back
+    final jan4 = DateTime.utc(year, 1, 4);
+    final mondayWeek1 =
+        jan4.subtract(Duration(days: (jan4.weekday - 1 + 7) % 7));
+    final current = mondayWeek1.add(Duration(days: (week - 1) * 7));
+    final next = current.add(Duration(days: delta * 7));
+    return _dateToWeekLabel(next);
+  }
+
+  static String _dateToWeekLabel(DateTime date) {
+    final thursday = date.subtract(Duration(days: (date.weekday - 4 + 7) % 7));
+    final jan4 = DateTime.utc(thursday.year, 1, 4);
+    final mondayJan4 =
+        jan4.subtract(Duration(days: (jan4.weekday - 1 + 7) % 7));
+    final weekNum = ((thursday.difference(mondayJan4).inDays) ~/ 7) + 1;
+    return '${thursday.year}-W${weekNum.toString().padLeft(2, '0')}';
+  }
 }

--- a/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
@@ -5,14 +5,15 @@ import '../repositories/weekly_plan_repository.dart';
 enum WeeklyPlannerStatus { idle, loading, error }
 
 class WeeklyPlannerController extends ChangeNotifier {
-  WeeklyPlannerController(this._repository);
+  WeeklyPlannerController(this._repository)
+      : _currentWeekLabel = _todayWeekLabel();
 
   final WeeklyPlanRepository _repository;
 
   WeeklyPlan? _plan;
   WeeklyPlannerStatus _status = WeeklyPlannerStatus.idle;
   String? _errorMessage;
-  late String _currentWeekLabel;
+  String _currentWeekLabel;
   String? _selectedTaskId;
 
   WeeklyPlan? get plan => _plan;
@@ -21,42 +22,9 @@ class WeeklyPlannerController extends ChangeNotifier {
   String get currentWeekLabel => _currentWeekLabel;
   String? get selectedTaskId => _selectedTaskId;
 
-  @override
-  void addListener(VoidCallback listener) {
-    _currentWeekLabel = _todayWeekLabel();
-    super.addListener(listener);
-  }
-
-  void _init() {
-    _currentWeekLabel = _todayWeekLabel();
-  }
-
-  WeeklyPlannerController._internal(this._repository) {
-    _currentWeekLabel = _todayWeekLabel();
-  }
-
-  factory WeeklyPlannerController.create(WeeklyPlanRepository repository) {
-    return WeeklyPlannerController._internal(repository);
-  }
-
-  static String _todayWeekLabel() {
-    final now = DateTime.now().toUtc();
-    final d = DateTime.utc(now.year, now.month, now.day);
-    // Find Thursday of the same ISO week (weekday 4 = Thursday)
-    final thursday = d.subtract(Duration(days: (d.weekday - 4 + 7) % 7));
-    final jan4 = DateTime.utc(thursday.year, 1, 4);
-    final mondayJan4 =
-        jan4.subtract(Duration(days: (jan4.weekday - 1 + 7) % 7));
-    final weekNum = ((thursday.difference(mondayJan4).inDays) ~/ 7) + 1;
-    return '${thursday.year}-W${weekNum.toString().padLeft(2, '0')}';
-  }
-
   bool get isCurrentWeek => _currentWeekLabel == _todayWeekLabel();
 
   Future<void> load() async {
-    if (_status == WeeklyPlannerStatus.idle || _currentWeekLabel.isNotEmpty) {
-      _init();
-    }
     _status = WeeklyPlannerStatus.loading;
     _errorMessage = null;
     notifyListeners();
@@ -101,14 +69,16 @@ class WeeklyPlannerController extends ChangeNotifier {
     }
   }
 
-  Future<void> unscheduleTask(String taskId) async {
-    // scheduleTask with empty date effectively removes scheduling — we use
-    // a dedicated unschedule by patching scheduledDate to null via the API.
-    // For now re-fetch to sync state.
-    try {
-      await _repository.scheduleTask(taskId, '');
-    } catch (_) {}
-    await load();
+  static String _todayWeekLabel() {
+    final now = DateTime.now().toUtc();
+    final d = DateTime.utc(now.year, now.month, now.day);
+    // Find Thursday of the same ISO week to determine year + week number
+    final thursday = d.subtract(Duration(days: (d.weekday - 4 + 7) % 7));
+    final jan4 = DateTime.utc(thursday.year, 1, 4);
+    final mondayJan4 =
+        jan4.subtract(Duration(days: (jan4.weekday - 1 + 7) % 7));
+    final weekNum = ((thursday.difference(mondayJan4).inDays) ~/ 7) + 1;
+    return '${thursday.year}-W${weekNum.toString().padLeft(2, '0')}';
   }
 
   static String _offsetWeek(String label, int delta) {
@@ -116,7 +86,6 @@ class WeeklyPlannerController extends ChangeNotifier {
     if (m == null) return label;
     final year = int.parse(m.group(1)!);
     final week = int.parse(m.group(2)!);
-    // Convert to absolute week number, add delta, convert back
     final jan4 = DateTime.utc(year, 1, 4);
     final mondayWeek1 =
         jan4.subtract(Duration(days: (jan4.weekday - 1 + 7) % 7));

--- a/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
@@ -69,16 +69,50 @@ class WeeklyPlannerController extends ChangeNotifier {
     }
   }
 
+  Future<void> toggleTaskDone(String taskId, bool currentlyDone) async {
+    try {
+      await _repository.updateTask(taskId,
+          status: currentlyDone ? 'open' : 'done');
+      await load();
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = WeeklyPlannerStatus.error;
+      notifyListeners();
+    }
+  }
+
+  Future<void> updateTaskNotes(String taskId, String notes) async {
+    try {
+      await _repository.updateTask(taskId, notes: notes.isEmpty ? null : notes);
+      await load();
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = WeeklyPlannerStatus.error;
+      notifyListeners();
+    }
+  }
+
+  // ── ISO week helpers ──────────────────────────────────────────────────────
+
+  /// Find Thursday of the ISO week containing [date].
+  /// In Dart weekday: 1=Mon … 7=Sun. ISO Thursday = weekday 4.
+  /// Go to Monday of the week (subtract weekday-1 days), then add 3.
+  static DateTime _isoThursday(DateTime date) {
+    final monday = date.subtract(Duration(days: date.weekday - 1));
+    return monday.add(const Duration(days: 3));
+  }
+
+  static String _isoWeekLabelFromThursday(DateTime thursday) {
+    final jan4 = DateTime.utc(thursday.year, 1, 4);
+    final mondayJan4 = jan4.subtract(Duration(days: jan4.weekday - 1));
+    final weekNum = ((thursday.difference(mondayJan4).inDays) ~/ 7) + 1;
+    return '${thursday.year}-W${weekNum.toString().padLeft(2, '0')}';
+  }
+
   static String _todayWeekLabel() {
     final now = DateTime.now().toUtc();
     final d = DateTime.utc(now.year, now.month, now.day);
-    // Find Thursday of the same ISO week to determine year + week number
-    final thursday = d.subtract(Duration(days: (d.weekday - 4 + 7) % 7));
-    final jan4 = DateTime.utc(thursday.year, 1, 4);
-    final mondayJan4 =
-        jan4.subtract(Duration(days: (jan4.weekday - 1 + 7) % 7));
-    final weekNum = ((thursday.difference(mondayJan4).inDays) ~/ 7) + 1;
-    return '${thursday.year}-W${weekNum.toString().padLeft(2, '0')}';
+    return _isoWeekLabelFromThursday(_isoThursday(d));
   }
 
   static String _offsetWeek(String label, int delta) {
@@ -86,20 +120,11 @@ class WeeklyPlannerController extends ChangeNotifier {
     if (m == null) return label;
     final year = int.parse(m.group(1)!);
     final week = int.parse(m.group(2)!);
+    // Reconstruct Monday of the parsed week, shift by delta weeks
     final jan4 = DateTime.utc(year, 1, 4);
-    final mondayWeek1 =
-        jan4.subtract(Duration(days: (jan4.weekday - 1 + 7) % 7));
-    final current = mondayWeek1.add(Duration(days: (week - 1) * 7));
-    final next = current.add(Duration(days: delta * 7));
-    return _dateToWeekLabel(next);
-  }
-
-  static String _dateToWeekLabel(DateTime date) {
-    final thursday = date.subtract(Duration(days: (date.weekday - 4 + 7) % 7));
-    final jan4 = DateTime.utc(thursday.year, 1, 4);
-    final mondayJan4 =
-        jan4.subtract(Duration(days: (jan4.weekday - 1 + 7) % 7));
-    final weekNum = ((thursday.difference(mondayJan4).inDays) ~/ 7) + 1;
-    return '${thursday.year}-W${weekNum.toString().padLeft(2, '0')}';
+    final mondayWeek1 = jan4.subtract(Duration(days: jan4.weekday - 1));
+    final monday = mondayWeek1.add(Duration(days: (week - 1) * 7));
+    final shifted = monday.add(Duration(days: delta * 7));
+    return _isoWeekLabelFromThursday(_isoThursday(shifted));
   }
 }

--- a/apps/desktop_flutter/lib/features/weekly_planner/data/weekly_plan_data_source.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/data/weekly_plan_data_source.dart
@@ -1,3 +1,39 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../../../app/core/constants/app_constants.dart';
+import '../../../app/core/errors/app_error.dart';
+import '../../tasks/models/task.dart';
+import '../models/weekly_plan.dart';
+
 class WeeklyPlanDataSource {
-  // TODO: Data-source boundary for weekly planning.
+  final _base = Uri.parse('${AppConstants.apiBaseUrl}/weekly-plan');
+
+  Future<WeeklyPlan> fetchPlan(String weekLabel) async {
+    final uri = _base.replace(queryParameters: {'week': weekLabel});
+    final response = await http.get(uri);
+    _assertOk(response);
+    return WeeklyPlan.fromJson(
+        jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  Future<Task> scheduleTask(String taskId, String date,
+      {bool locked = false}) async {
+    final response = await http.patch(
+      Uri.parse('${AppConstants.apiBaseUrl}/weekly-plan/tasks/$taskId'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'scheduledDate': date, 'locked': locked}),
+    );
+    _assertOk(response);
+    return Task.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  void _assertOk(http.Response response) {
+    if (response.statusCode >= 400) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>?;
+      final message =
+          (body?['error'] as Map<String, dynamic>?)?['message'] as String? ??
+              'Request failed';
+      throw AppError(message);
+    }
+  }
 }

--- a/apps/desktop_flutter/lib/features/weekly_planner/data/weekly_plan_data_source.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/data/weekly_plan_data_source.dart
@@ -27,6 +27,20 @@ class WeeklyPlanDataSource {
     return Task.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
   }
 
+  Future<Task> updateTask(String taskId,
+      {String? notes, String? status}) async {
+    final response = await http.patch(
+      Uri.parse('${AppConstants.apiBaseUrl}/tasks/$taskId'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        if (notes != null) 'notes': notes,
+        if (status != null) 'status': status,
+      }),
+    );
+    _assertOk(response);
+    return Task.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
   void _assertOk(http.Response response) {
     if (response.statusCode >= 400) {
       final body = jsonDecode(response.body) as Map<String, dynamic>?;

--- a/apps/desktop_flutter/lib/features/weekly_planner/models/weekly_plan.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/models/weekly_plan.dart
@@ -37,15 +37,17 @@ class WeeklyPlan {
   final String weekStart;
   final List<WeeklyPlanDay> days;
 
-  /// Tasks that have not yet been scheduled to a specific day.
+  /// Tasks with no date at all — truly unscheduled (no due date, no scheduled date).
   List<Task> get backlog => days
       .expand((d) => d.tasks)
-      .where((t) => t.scheduledDate == null)
+      .where((t) => t.scheduledDate == null && t.dueDate == null)
       .toList();
 
-  /// Tasks scheduled for a given date.
+  /// Tasks to display in a day column.
+  /// scheduledDate takes priority; falls back to dueDate so tasks auto-populate
+  /// into their due date column before the user explicitly schedules them.
   List<Task> tasksForDate(String date) => days
       .expand((d) => d.tasks)
-      .where((t) => t.scheduledDate == date)
+      .where((t) => (t.scheduledDate ?? t.dueDate) == date)
       .toList();
 }

--- a/apps/desktop_flutter/lib/features/weekly_planner/models/weekly_plan.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/models/weekly_plan.dart
@@ -21,6 +21,7 @@ class WeeklyPlan {
     required this.weekLabel,
     required this.weekStart,
     required this.days,
+    required this.backlog,
   });
 
   factory WeeklyPlan.fromJson(Map<String, dynamic> json) {
@@ -30,6 +31,9 @@ class WeeklyPlan {
       days: (json['days'] as List<dynamic>)
           .map((d) => WeeklyPlanDay.fromJson(d as Map<String, dynamic>))
           .toList(),
+      backlog: ((json['backlog'] as List<dynamic>?) ?? [])
+          .map((t) => Task.fromJson(t as Map<String, dynamic>))
+          .toList(),
     );
   }
 
@@ -37,15 +41,11 @@ class WeeklyPlan {
   final String weekStart;
   final List<WeeklyPlanDay> days;
 
-  /// Tasks with no date at all — truly unscheduled (no due date, no scheduled date).
-  List<Task> get backlog => days
-      .expand((d) => d.tasks)
-      .where((t) => t.scheduledDate == null && t.dueDate == null)
-      .toList();
+  /// Tasks with no due date and no scheduled date — from API backlog field.
+  final List<Task> backlog;
 
   /// Tasks to display in a day column.
-  /// scheduledDate takes priority; falls back to dueDate so tasks auto-populate
-  /// into their due date column before the user explicitly schedules them.
+  /// scheduledDate takes priority; falls back to dueDate.
   List<Task> tasksForDate(String date) => days
       .expand((d) => d.tasks)
       .where((t) => (t.scheduledDate ?? t.dueDate) == date)

--- a/apps/desktop_flutter/lib/features/weekly_planner/models/weekly_plan.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/models/weekly_plan.dart
@@ -1,6 +1,51 @@
-class WeeklyPlan {
-  WeeklyPlan({required this.id, required this.weekLabel});
+import '../../tasks/models/task.dart';
 
-  final String id;
+class WeeklyPlanDay {
+  WeeklyPlanDay({required this.date, required this.tasks});
+
+  factory WeeklyPlanDay.fromJson(Map<String, dynamic> json) {
+    return WeeklyPlanDay(
+      date: json['date'] as String,
+      tasks: (json['tasks'] as List<dynamic>)
+          .map((t) => Task.fromJson(t as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  final String date;
+  final List<Task> tasks;
+}
+
+class WeeklyPlan {
+  WeeklyPlan({
+    required this.weekLabel,
+    required this.weekStart,
+    required this.days,
+  });
+
+  factory WeeklyPlan.fromJson(Map<String, dynamic> json) {
+    return WeeklyPlan(
+      weekLabel: json['weekLabel'] as String,
+      weekStart: json['weekStart'] as String,
+      days: (json['days'] as List<dynamic>)
+          .map((d) => WeeklyPlanDay.fromJson(d as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
   final String weekLabel;
+  final String weekStart;
+  final List<WeeklyPlanDay> days;
+
+  /// Tasks that have not yet been scheduled to a specific day.
+  List<Task> get backlog => days
+      .expand((d) => d.tasks)
+      .where((t) => t.scheduledDate == null)
+      .toList();
+
+  /// Tasks scheduled for a given date.
+  List<Task> tasksForDate(String date) => days
+      .expand((d) => d.tasks)
+      .where((t) => t.scheduledDate == date)
+      .toList();
 }

--- a/apps/desktop_flutter/lib/features/weekly_planner/repositories/weekly_plan_repository.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/repositories/weekly_plan_repository.dart
@@ -1,3 +1,16 @@
+import '../../tasks/models/task.dart';
+import '../data/weekly_plan_data_source.dart';
+import '../models/weekly_plan.dart';
+
 class WeeklyPlanRepository {
-  // TODO: Handle weekly plan persistence.
+  WeeklyPlanRepository(this._dataSource);
+
+  final WeeklyPlanDataSource _dataSource;
+
+  Future<WeeklyPlan> fetchPlan(String weekLabel) =>
+      _dataSource.fetchPlan(weekLabel);
+
+  Future<Task> scheduleTask(String taskId, String date,
+          {bool locked = false}) =>
+      _dataSource.scheduleTask(taskId, date, locked: locked);
 }

--- a/apps/desktop_flutter/lib/features/weekly_planner/repositories/weekly_plan_repository.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/repositories/weekly_plan_repository.dart
@@ -13,4 +13,7 @@ class WeeklyPlanRepository {
   Future<Task> scheduleTask(String taskId, String date,
           {bool locked = false}) =>
       _dataSource.scheduleTask(taskId, date, locked: locked);
+
+  Future<Task> updateTask(String taskId, {String? notes, String? status}) =>
+      _dataSource.updateTask(taskId, notes: notes, status: status);
 }

--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -93,8 +93,7 @@ class _WeekHeader extends StatelessWidget {
     final year = int.parse(m.group(1)!);
     final week = int.parse(m.group(2)!);
     final jan4 = DateTime.utc(year, 1, 4);
-    final mondayWeek1 =
-        jan4.subtract(Duration(days: (jan4.weekday - 1 + 7) % 7));
+    final mondayWeek1 = jan4.subtract(Duration(days: jan4.weekday - 1));
     final monday = mondayWeek1.add(Duration(days: (week - 1) * 7));
     const months = [
       'Jan',
@@ -115,7 +114,7 @@ class _WeekHeader extends StatelessWidget {
 }
 
 // ---------------------------------------------------------------------------
-// Error banner (inline, no MaterialBanner quirks)
+// Error banner
 // ---------------------------------------------------------------------------
 
 class _ErrorBanner extends StatelessWidget {
@@ -144,10 +143,7 @@ class _ErrorBanner extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
             ),
           ),
-          TextButton(
-            onPressed: onRetry,
-            child: const Text('Retry'),
-          ),
+          TextButton(onPressed: onRetry, child: const Text('Retry')),
         ],
       ),
     );
@@ -173,7 +169,10 @@ class _PlannerBody extends StatelessWidget {
       return const Center(child: Text('No plan loaded.'));
     }
 
-    final allTasks = plan.days.expand((d) => d.tasks);
+    final allTasks = [
+      ...plan.days.expand((d) => d.tasks),
+      ...plan.backlog,
+    ];
     final selectedTask = controller.selectedTaskId != null
         ? allTasks.cast<Task?>().firstWhere(
             (t) => t?.id == controller.selectedTaskId,
@@ -183,22 +182,22 @@ class _PlannerBody extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Left: Backlog (only shows if truly unscheduled tasks exist)
         SizedBox(
           width: 220,
           child: _BacklogPane(plan: plan, controller: controller),
         ),
         VerticalDivider(width: 1, color: Theme.of(context).dividerColor),
-        // Center: Day columns
         Expanded(
           child: _DayColumnsPane(plan: plan, controller: controller),
         ),
-        // Right: Detail panel
         if (selectedTask != null) ...[
           VerticalDivider(width: 1, color: Theme.of(context).dividerColor),
           SizedBox(
             width: 280,
-            child: _DetailPane(task: selectedTask, controller: controller),
+            child: _DetailPane(
+                key: ValueKey(selectedTask.id),
+                task: selectedTask,
+                controller: controller),
           ),
         ],
       ],
@@ -225,13 +224,11 @@ class _BacklogPane extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
           child: Row(
             children: [
-              Text(
-                'Unscheduled',
-                style: Theme.of(context)
-                    .textTheme
-                    .titleSmall
-                    ?.copyWith(fontWeight: FontWeight.bold),
-              ),
+              Text('Unscheduled',
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleSmall
+                      ?.copyWith(fontWeight: FontWeight.bold)),
               const SizedBox(width: 6),
               if (backlog.isNotEmpty)
                 Container(
@@ -253,86 +250,21 @@ class _BacklogPane extends StatelessWidget {
               ? const Center(
                   child: Padding(
                   padding: EdgeInsets.all(16),
-                  child: Text(
-                    'All tasks have a due date',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(color: Colors.grey, fontSize: 12),
-                  ),
+                  child: Text('No undated tasks',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(color: Colors.grey, fontSize: 12)),
                 ))
               : ListView.builder(
                   padding: const EdgeInsets.symmetric(vertical: 8),
                   itemCount: backlog.length,
-                  itemBuilder: (context, i) => _BacklogTaskTile(
-                      task: backlog[i], controller: controller),
+                  itemBuilder: (context, i) => _TaskTile(
+                    task: backlog[i],
+                    controller: controller,
+                    draggable: true,
+                  ),
                 ),
         ),
       ],
-    );
-  }
-}
-
-class _BacklogTaskTile extends StatelessWidget {
-  const _BacklogTaskTile({required this.task, required this.controller});
-  final Task task;
-  final WeeklyPlannerController controller;
-
-  @override
-  Widget build(BuildContext context) {
-    return Draggable<Task>(
-      data: task,
-      feedback: Material(
-        elevation: 4,
-        borderRadius: BorderRadius.circular(6),
-        child: Container(
-          width: 180,
-          padding: const EdgeInsets.all(10),
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.primaryContainer,
-            borderRadius: BorderRadius.circular(6),
-          ),
-          child: Text(task.title,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: Theme.of(context).textTheme.bodySmall),
-        ),
-      ),
-      childWhenDragging: Opacity(opacity: 0.4, child: _taskCard(context)),
-      child: GestureDetector(
-        onTap: () => controller.selectTask(task.id),
-        child: _taskCard(context),
-      ),
-    );
-  }
-
-  Widget _taskCard(BuildContext context) {
-    final isSelected = controller.selectedTaskId == task.id;
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-      padding: const EdgeInsets.all(10),
-      decoration: BoxDecoration(
-        color: isSelected
-            ? Theme.of(context).colorScheme.primaryContainer
-            : Theme.of(context).colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(6),
-        border: Border.all(
-          color: isSelected
-              ? Theme.of(context).colorScheme.primary
-              : Colors.transparent,
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(task.title,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: Theme.of(context).textTheme.bodySmall),
-          if (task.sourceType != null) ...[
-            const SizedBox(height: 3),
-            _SourceChip(sourceType: task.sourceType!),
-          ],
-        ],
-      ),
     );
   }
 }
@@ -414,16 +346,15 @@ class _DayColumnState extends State<_DayColumn> {
         setState(() => _hovering = false);
         widget.controller.scheduleTask(details.data.id, widget.date);
       },
-      builder: (context, candidateData, _) {
-        return Container(
+      builder: (context, _, __) {
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 120),
           decoration: BoxDecoration(
-            // Drag-hover: subtle teal tint on the column body only
             color: _hovering
                 ? Theme.of(context).colorScheme.tertiary.withValues(alpha: 0.08)
                 : null,
             border: Border(
               right: BorderSide(color: Theme.of(context).dividerColor),
-              // Today: a 2px primary-coloured top border on the whole column
               top: today
                   ? BorderSide(color: primaryColor, width: 2)
                   : BorderSide.none,
@@ -438,19 +369,15 @@ class _DayColumnState extends State<_DayColumn> {
                 color: Theme.of(context).colorScheme.surfaceContainerLow,
                 child: Column(
                   children: [
-                    Text(
-                      widget.dayName,
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                            fontWeight: FontWeight.bold,
-                            color: today ? primaryColor : null,
-                          ),
-                    ),
-                    Text(
-                      _shortDate(),
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                            color: today ? primaryColor : Colors.grey,
-                          ),
-                    ),
+                    Text(widget.dayName,
+                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: today ? primaryColor : null,
+                            )),
+                    Text(_shortDate(),
+                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                              color: today ? primaryColor : Colors.grey,
+                            )),
                   ],
                 ),
               ),
@@ -459,7 +386,7 @@ class _DayColumnState extends State<_DayColumn> {
                   color: today
                       ? primaryColor.withValues(alpha: 0.4)
                       : Theme.of(context).dividerColor),
-              // Task list
+              // Tasks
               Expanded(
                 child: widget.tasks.isEmpty
                     ? Center(
@@ -468,9 +395,11 @@ class _DayColumnState extends State<_DayColumn> {
                     : ListView.builder(
                         padding: const EdgeInsets.all(6),
                         itemCount: widget.tasks.length,
-                        itemBuilder: (context, i) => _ScheduledTaskTile(
+                        itemBuilder: (context, i) => _TaskTile(
                           task: widget.tasks[i],
                           controller: widget.controller,
+                          draggable: true,
+                          compact: true,
                         ),
                       ),
               ),
@@ -482,24 +411,64 @@ class _DayColumnState extends State<_DayColumn> {
   }
 }
 
-class _ScheduledTaskTile extends StatelessWidget {
-  const _ScheduledTaskTile({required this.task, required this.controller});
+// ---------------------------------------------------------------------------
+// Unified task tile — used in both backlog and day columns
+// ---------------------------------------------------------------------------
+
+class _TaskTile extends StatelessWidget {
+  const _TaskTile({
+    required this.task,
+    required this.controller,
+    this.draggable = false,
+    this.compact = false,
+  });
   final Task task;
   final WeeklyPlannerController controller;
+  final bool draggable;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
+    final card = _card(context);
+    if (!draggable) return card;
+    return Draggable<Task>(
+      data: task,
+      feedback: Material(
+        elevation: 4,
+        borderRadius: BorderRadius.circular(6),
+        child: Container(
+          width: 160,
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.primaryContainer,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(task.title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall),
+        ),
+      ),
+      childWhenDragging: Opacity(opacity: 0.35, child: card),
+      child: card,
+    );
+  }
+
+  Widget _card(BuildContext context) {
     final isSelected = controller.selectedTaskId == task.id;
+    final isDone = task.status == 'done';
     return GestureDetector(
       onTap: () => controller.selectTask(task.id),
       child: Container(
-        margin: const EdgeInsets.only(bottom: 4),
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        margin: compact
+            ? const EdgeInsets.only(bottom: 4)
+            : const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        padding: EdgeInsets.symmetric(horizontal: 8, vertical: compact ? 4 : 8),
         decoration: BoxDecoration(
           color: isSelected
               ? Theme.of(context).colorScheme.primaryContainer
               : Theme.of(context).colorScheme.surfaceContainerHighest,
-          borderRadius: BorderRadius.circular(4),
+          borderRadius: BorderRadius.circular(6),
           border: Border.all(
             color: isSelected
                 ? Theme.of(context).colorScheme.primary
@@ -508,20 +477,34 @@ class _ScheduledTaskTile extends StatelessWidget {
         ),
         child: Row(
           children: [
-            if (task.locked)
-              Padding(
-                padding: const EdgeInsets.only(right: 4),
-                child: Icon(Icons.lock,
-                    size: 11, color: Theme.of(context).colorScheme.primary),
+            // Completion checkbox
+            SizedBox(
+              width: 20,
+              height: 20,
+              child: Checkbox(
+                value: isDone,
+                onChanged: (_) => controller.toggleTaskDone(task.id, isDone),
+                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                visualDensity: VisualDensity.compact,
               ),
+            ),
+            const SizedBox(width: 6),
             Expanded(
               child: Text(
                 task.title,
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.bodySmall,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      decoration: isDone ? TextDecoration.lineThrough : null,
+                      color: isDone ? Colors.grey : null,
+                    ),
               ),
             ),
+            if (task.locked) ...[
+              const SizedBox(width: 4),
+              Icon(Icons.lock,
+                  size: 11, color: Theme.of(context).colorScheme.primary),
+            ],
             if (task.sourceType != null) ...[
               const SizedBox(width: 4),
               _SourceChip(sourceType: task.sourceType!),
@@ -534,19 +517,54 @@ class _ScheduledTaskTile extends StatelessWidget {
 }
 
 // ---------------------------------------------------------------------------
-// Detail pane
+// Detail pane — editable notes
 // ---------------------------------------------------------------------------
 
-class _DetailPane extends StatelessWidget {
-  const _DetailPane({required this.task, required this.controller});
+class _DetailPane extends StatefulWidget {
+  const _DetailPane({super.key, required this.task, required this.controller});
   final Task task;
   final WeeklyPlannerController controller;
 
   @override
+  State<_DetailPane> createState() => _DetailPaneState();
+}
+
+class _DetailPaneState extends State<_DetailPane> {
+  late TextEditingController _notesCtrl;
+  bool _notesDirty = false;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _notesCtrl = TextEditingController(text: widget.task.notes ?? '');
+    _notesCtrl.addListener(() => setState(
+        () => _notesDirty = _notesCtrl.text != (widget.task.notes ?? '')));
+  }
+
+  @override
+  void dispose() {
+    _notesCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _saveNotes() async {
+    setState(() => _saving = true);
+    await widget.controller.updateTaskNotes(widget.task.id, _notesCtrl.text);
+    setState(() {
+      _saving = false;
+      _notesDirty = false;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final task = widget.task;
+    final isDone = task.status == 'done';
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // Header
         Container(
           padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
           decoration: BoxDecoration(
@@ -565,7 +583,7 @@ class _DetailPane extends StatelessWidget {
               ),
               IconButton(
                 icon: const Icon(Icons.close, size: 18),
-                onPressed: () => controller.selectTask(null),
+                onPressed: () => widget.controller.selectTask(null),
                 padding: EdgeInsets.zero,
                 constraints: const BoxConstraints(),
               ),
@@ -579,27 +597,77 @@ class _DetailPane extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(task.title,
-                    style: Theme.of(context).textTheme.titleMedium),
-                const SizedBox(height: 16),
-                _detailRow(context, 'Status', task.status.toUpperCase()),
-                if (task.dueDate != null)
-                  _detailRow(context, 'Due', task.dueDate!),
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          decoration:
+                              isDone ? TextDecoration.lineThrough : null,
+                          color: isDone ? Colors.grey : null,
+                        )),
+                const SizedBox(height: 4),
+                // Quick complete toggle
+                TextButton.icon(
+                  icon: Icon(
+                      isDone
+                          ? Icons.check_circle
+                          : Icons.radio_button_unchecked,
+                      size: 16),
+                  label: Text(isDone ? 'Mark open' : 'Mark done'),
+                  style: TextButton.styleFrom(
+                    padding: EdgeInsets.zero,
+                    minimumSize: Size.zero,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  onPressed: () =>
+                      widget.controller.toggleTaskDone(task.id, isDone),
+                ),
+                const SizedBox(height: 12),
+                if (task.dueDate != null) _row(context, 'Due', task.dueDate!),
                 if (task.scheduledDate != null)
-                  _detailRow(context, 'Scheduled', task.scheduledDate!),
-                _detailRow(context, 'Locked', task.locked ? 'Yes' : 'No'),
+                  _row(context, 'Scheduled', task.scheduledDate!),
                 if (task.sourceType != null)
-                  _detailRow(context, 'Source', _sourceLabel(task.sourceType!)),
-                if (task.notes != null && task.notes!.isNotEmpty) ...[
-                  const SizedBox(height: 12),
-                  Text('Notes',
-                      style: Theme.of(context)
-                          .textTheme
-                          .labelSmall
-                          ?.copyWith(color: Colors.grey)),
-                  const SizedBox(height: 4),
-                  Text(task.notes!,
-                      style: Theme.of(context).textTheme.bodySmall),
-                ],
+                  _row(context, 'Source', _sourceLabel(task.sourceType!)),
+                const SizedBox(height: 16),
+                Text('Notes',
+                    style: Theme.of(context)
+                        .textTheme
+                        .labelSmall
+                        ?.copyWith(fontWeight: FontWeight.bold)),
+                const SizedBox(height: 6),
+                TextField(
+                  controller: _notesCtrl,
+                  decoration: const InputDecoration(
+                    hintText: 'Add a note...',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                  minLines: 3,
+                  maxLines: 8,
+                ),
+                const SizedBox(height: 8),
+                if (_notesDirty)
+                  Row(
+                    children: [
+                      FilledButton.tonal(
+                        onPressed: _saving ? null : _saveNotes,
+                        child: _saving
+                            ? const SizedBox(
+                                width: 14,
+                                height: 14,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2))
+                            : const Text('Save'),
+                      ),
+                      const SizedBox(width: 8),
+                      TextButton(
+                        onPressed: _saving
+                            ? null
+                            : () => setState(() {
+                                  _notesCtrl.text = widget.task.notes ?? '';
+                                  _notesDirty = false;
+                                }),
+                        child: const Text('Discard'),
+                      ),
+                    ],
+                  ),
               ],
             ),
           ),
@@ -608,11 +676,10 @@ class _DetailPane extends StatelessWidget {
     );
   }
 
-  Widget _detailRow(BuildContext context, String label, String value) {
+  Widget _row(BuildContext context, String label, String value) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.only(bottom: 6),
       child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SizedBox(
             width: 76,
@@ -623,22 +690,21 @@ class _DetailPane extends StatelessWidget {
                     ?.copyWith(color: Colors.grey)),
           ),
           Expanded(
-            child: Text(value, style: Theme.of(context).textTheme.bodySmall),
-          ),
+              child: Text(value, style: Theme.of(context).textTheme.bodySmall)),
         ],
       ),
     );
   }
 
-  String _sourceLabel(String sourceType) => switch (sourceType) {
+  String _sourceLabel(String t) => switch (t) {
         'recurring_rule' => 'Rhythm',
         'project_step' => 'Project',
-        _ => sourceType,
+        _ => t,
       };
 }
 
 // ---------------------------------------------------------------------------
-// Shared widgets
+// Shared
 // ---------------------------------------------------------------------------
 
 class _SourceChip extends StatelessWidget {

--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -41,7 +41,7 @@ class _WeeklyPlannerViewState extends State<WeeklyPlannerView> {
 }
 
 // ---------------------------------------------------------------------------
-// Header with week navigation
+// Header
 // ---------------------------------------------------------------------------
 
 class _WeekHeader extends StatelessWidget {
@@ -88,7 +88,6 @@ class _WeekHeader extends StatelessWidget {
   }
 
   String _formatWeekLabel(String label) {
-    // Parse YYYY-WNN → "Week of Mon DD, YYYY"
     final m = RegExp(r'^(\d{4})-W(\d{1,2})$').firstMatch(label);
     if (m == null) return label;
     final year = int.parse(m.group(1)!);
@@ -109,14 +108,14 @@ class _WeekHeader extends StatelessWidget {
       'Sep',
       'Oct',
       'Nov',
-      'Dec'
+      'Dec',
     ];
     return 'Week of ${months[monday.month - 1]} ${monday.day}, ${monday.year}';
   }
 }
 
 // ---------------------------------------------------------------------------
-// Error banner
+// Error banner (inline, no MaterialBanner quirks)
 // ---------------------------------------------------------------------------
 
 class _ErrorBanner extends StatelessWidget {
@@ -126,11 +125,31 @@ class _ErrorBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialBanner(
-      content: Text(message),
-      actions: [
-        TextButton(onPressed: onRetry, child: const Text('Retry')),
-      ],
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 10),
+      color: Theme.of(context).colorScheme.errorContainer,
+      child: Row(
+        children: [
+          Icon(Icons.error_outline,
+              color: Theme.of(context).colorScheme.onErrorContainer, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(
+                  color: Theme.of(context).colorScheme.onErrorContainer,
+                  fontSize: 13),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          TextButton(
+            onPressed: onRetry,
+            child: const Text('Retry'),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -154,8 +173,9 @@ class _PlannerBody extends StatelessWidget {
       return const Center(child: Text('No plan loaded.'));
     }
 
+    final allTasks = plan.days.expand((d) => d.tasks);
     final selectedTask = controller.selectedTaskId != null
-        ? plan.days.expand((d) => d.tasks).cast<Task?>().firstWhere(
+        ? allTasks.cast<Task?>().firstWhere(
             (t) => t?.id == controller.selectedTaskId,
             orElse: () => null)
         : null;
@@ -163,9 +183,9 @@ class _PlannerBody extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Left: Backlog
+        // Left: Backlog (only shows if truly unscheduled tasks exist)
         SizedBox(
-          width: 240,
+          width: 220,
           child: _BacklogPane(plan: plan, controller: controller),
         ),
         VerticalDivider(width: 1, color: Theme.of(context).dividerColor),
@@ -173,7 +193,7 @@ class _PlannerBody extends StatelessWidget {
         Expanded(
           child: _DayColumnsPane(plan: plan, controller: controller),
         ),
-        // Right: Detail panel (only when a task is selected)
+        // Right: Detail panel
         if (selectedTask != null) ...[
           VerticalDivider(width: 1, color: Theme.of(context).dividerColor),
           SizedBox(
@@ -205,11 +225,13 @@ class _BacklogPane extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
           child: Row(
             children: [
-              Text('Backlog',
-                  style: Theme.of(context)
-                      .textTheme
-                      .titleSmall
-                      ?.copyWith(fontWeight: FontWeight.bold)),
+              Text(
+                'Unscheduled',
+                style: Theme.of(context)
+                    .textTheme
+                    .titleSmall
+                    ?.copyWith(fontWeight: FontWeight.bold),
+              ),
               const SizedBox(width: 6),
               if (backlog.isNotEmpty)
                 Container(
@@ -231,9 +253,11 @@ class _BacklogPane extends StatelessWidget {
               ? const Center(
                   child: Padding(
                   padding: EdgeInsets.all(16),
-                  child: Text('All tasks scheduled',
-                      textAlign: TextAlign.center,
-                      style: TextStyle(color: Colors.grey)),
+                  child: Text(
+                    'All tasks have a due date',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(color: Colors.grey, fontSize: 12),
+                  ),
                 ))
               : ListView.builder(
                   padding: const EdgeInsets.symmetric(vertical: 8),
@@ -260,7 +284,7 @@ class _BacklogTaskTile extends StatelessWidget {
         elevation: 4,
         borderRadius: BorderRadius.circular(6),
         child: Container(
-          width: 200,
+          width: 180,
           padding: const EdgeInsets.all(10),
           decoration: BoxDecoration(
             color: Theme.of(context).colorScheme.primaryContainer,
@@ -272,10 +296,7 @@ class _BacklogTaskTile extends StatelessWidget {
               style: Theme.of(context).textTheme.bodySmall),
         ),
       ),
-      childWhenDragging: Opacity(
-        opacity: 0.4,
-        child: _taskCard(context),
-      ),
+      childWhenDragging: Opacity(opacity: 0.4, child: _taskCard(context)),
       child: GestureDetector(
         onTap: () => controller.selectTask(task.id),
         child: _taskCard(context),
@@ -306,16 +327,8 @@ class _BacklogTaskTile extends StatelessWidget {
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
               style: Theme.of(context).textTheme.bodySmall),
-          if (task.dueDate != null) ...[
-            const SizedBox(height: 4),
-            Text('Due ${task.dueDate}',
-                style: Theme.of(context)
-                    .textTheme
-                    .labelSmall
-                    ?.copyWith(color: Colors.grey)),
-          ],
           if (task.sourceType != null) ...[
-            const SizedBox(height: 2),
+            const SizedBox(height: 3),
             _SourceChip(sourceType: task.sourceType!),
           ],
         ],
@@ -341,12 +354,11 @@ class _DayColumnsPane extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: List.generate(plan.days.length, (i) {
         final day = plan.days[i];
-        final scheduled = plan.tasksForDate(day.date);
         return Expanded(
           child: _DayColumn(
             dayName: _dayNames[i],
             date: day.date,
-            tasks: scheduled,
+            tasks: plan.tasksForDate(day.date),
             controller: controller,
           ),
         );
@@ -374,9 +386,24 @@ class _DayColumn extends StatefulWidget {
 class _DayColumnState extends State<_DayColumn> {
   bool _hovering = false;
 
+  bool _isToday() {
+    final now = DateTime.now();
+    final today =
+        '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+    return widget.date == today;
+  }
+
+  String _shortDate() {
+    final parts = widget.date.split('-');
+    if (parts.length != 3) return widget.date;
+    return '${int.parse(parts[1])}/${int.parse(parts[2])}';
+  }
+
   @override
   Widget build(BuildContext context) {
-    final today = _isToday(widget.date);
+    final today = _isToday();
+    final primaryColor = Theme.of(context).colorScheme.primary;
+
     return DragTarget<Task>(
       onWillAcceptWithDetails: (_) {
         setState(() => _hovering = true);
@@ -388,45 +415,51 @@ class _DayColumnState extends State<_DayColumn> {
         widget.controller.scheduleTask(details.data.id, widget.date);
       },
       builder: (context, candidateData, _) {
-        return AnimatedContainer(
-          duration: const Duration(milliseconds: 150),
+        return Container(
           decoration: BoxDecoration(
+            // Drag-hover: subtle teal tint on the column body only
             color: _hovering
-                ? Theme.of(context)
-                    .colorScheme
-                    .primaryContainer
-                    .withValues(alpha: 0.3)
+                ? Theme.of(context).colorScheme.tertiary.withValues(alpha: 0.08)
                 : null,
             border: Border(
               right: BorderSide(color: Theme.of(context).dividerColor),
+              // Today: a 2px primary-coloured top border on the whole column
+              top: today
+                  ? BorderSide(color: primaryColor, width: 2)
+                  : BorderSide.none,
             ),
           ),
           child: Column(
             children: [
               // Day header
               Container(
-                padding: const EdgeInsets.symmetric(vertical: 10),
-                decoration: BoxDecoration(
-                  color: today
-                      ? Theme.of(context).colorScheme.primaryContainer
-                      : Theme.of(context).colorScheme.surfaceContainerLow,
-                  border: Border(
-                      bottom:
-                          BorderSide(color: Theme.of(context).dividerColor)),
-                ),
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                color: Theme.of(context).colorScheme.surfaceContainerLow,
                 child: Column(
                   children: [
-                    Text(widget.dayName,
-                        style: Theme.of(context)
-                            .textTheme
-                            .labelSmall
-                            ?.copyWith(fontWeight: FontWeight.bold)),
-                    Text(_shortDate(widget.date),
-                        style: Theme.of(context).textTheme.labelSmall),
+                    Text(
+                      widget.dayName,
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: today ? primaryColor : null,
+                          ),
+                    ),
+                    Text(
+                      _shortDate(),
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color: today ? primaryColor : Colors.grey,
+                          ),
+                    ),
                   ],
                 ),
               ),
-              // Tasks
+              Divider(
+                  height: 1,
+                  color: today
+                      ? primaryColor.withValues(alpha: 0.4)
+                      : Theme.of(context).dividerColor),
+              // Task list
               Expanded(
                 child: widget.tasks.isEmpty
                     ? Center(
@@ -446,20 +479,6 @@ class _DayColumnState extends State<_DayColumn> {
         );
       },
     );
-  }
-
-  bool _isToday(String date) {
-    final now = DateTime.now();
-    final today =
-        '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
-    return date == today;
-  }
-
-  String _shortDate(String date) {
-    // YYYY-MM-DD → M/D
-    final parts = date.split('-');
-    if (parts.length != 3) return date;
-    return '${int.parse(parts[1])}/${int.parse(parts[2])}';
   }
 }
 
@@ -493,7 +512,7 @@ class _ScheduledTaskTile extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(right: 4),
                 child: Icon(Icons.lock,
-                    size: 12, color: Theme.of(context).colorScheme.primary),
+                    size: 11, color: Theme.of(context).colorScheme.primary),
               ),
             Expanded(
               child: Text(
@@ -503,8 +522,10 @@ class _ScheduledTaskTile extends StatelessWidget {
                 style: Theme.of(context).textTheme.bodySmall,
               ),
             ),
-            if (task.sourceType != null)
+            if (task.sourceType != null) ...[
+              const SizedBox(width: 4),
               _SourceChip(sourceType: task.sourceType!),
+            ],
           ],
         ),
       ),
@@ -526,8 +547,13 @@ class _DetailPane extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
+        Container(
+          padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainerLow,
+            border: Border(
+                bottom: BorderSide(color: Theme.of(context).dividerColor)),
+          ),
           child: Row(
             children: [
               Expanded(
@@ -540,11 +566,12 @@ class _DetailPane extends StatelessWidget {
               IconButton(
                 icon: const Icon(Icons.close, size: 18),
                 onPressed: () => controller.selectTask(null),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
               ),
             ],
           ),
         ),
-        const Divider(height: 1),
         Expanded(
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(16),
@@ -553,7 +580,7 @@ class _DetailPane extends StatelessWidget {
               children: [
                 Text(task.title,
                     style: Theme.of(context).textTheme.titleMedium),
-                const SizedBox(height: 12),
+                const SizedBox(height: 16),
                 _detailRow(context, 'Status', task.status.toUpperCase()),
                 if (task.dueDate != null)
                   _detailRow(context, 'Due', task.dueDate!),
@@ -561,7 +588,18 @@ class _DetailPane extends StatelessWidget {
                   _detailRow(context, 'Scheduled', task.scheduledDate!),
                 _detailRow(context, 'Locked', task.locked ? 'Yes' : 'No'),
                 if (task.sourceType != null)
-                  _detailRow(context, 'Source', task.sourceType!),
+                  _detailRow(context, 'Source', _sourceLabel(task.sourceType!)),
+                if (task.notes != null && task.notes!.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  Text('Notes',
+                      style: Theme.of(context)
+                          .textTheme
+                          .labelSmall
+                          ?.copyWith(color: Colors.grey)),
+                  const SizedBox(height: 4),
+                  Text(task.notes!,
+                      style: Theme.of(context).textTheme.bodySmall),
+                ],
               ],
             ),
           ),
@@ -577,7 +615,7 @@ class _DetailPane extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SizedBox(
-            width: 80,
+            width: 76,
             child: Text(label,
                 style: Theme.of(context)
                     .textTheme
@@ -591,6 +629,12 @@ class _DetailPane extends StatelessWidget {
       ),
     );
   }
+
+  String _sourceLabel(String sourceType) => switch (sourceType) {
+        'recurring_rule' => 'Rhythm',
+        'project_step' => 'Project',
+        _ => sourceType,
+      };
 }
 
 // ---------------------------------------------------------------------------
@@ -609,7 +653,7 @@ class _SourceChip extends StatelessWidget {
       _ => ('T', Colors.grey),
     };
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
       decoration: BoxDecoration(
         color: color.withValues(alpha: 0.15),
         borderRadius: BorderRadius.circular(3),

--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -1,12 +1,622 @@
+// ignore_for_file: use_build_context_synchronously
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../tasks/models/task.dart';
+import '../controllers/weekly_planner_controller.dart';
+import '../models/weekly_plan.dart';
 
-class WeeklyPlannerView extends StatelessWidget {
+class WeeklyPlannerView extends StatefulWidget {
   const WeeklyPlannerView({super.key});
 
   @override
+  State<WeeklyPlannerView> createState() => _WeeklyPlannerViewState();
+}
+
+class _WeeklyPlannerViewState extends State<WeeklyPlannerView> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<WeeklyPlannerController>().load();
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Weekly Planner — coming in Phase 3'),
+    return Consumer<WeeklyPlannerController>(
+      builder: (context, controller, _) {
+        return Column(
+          children: [
+            _WeekHeader(controller: controller),
+            if (controller.status == WeeklyPlannerStatus.error &&
+                controller.errorMessage != null)
+              _ErrorBanner(
+                  message: controller.errorMessage!, onRetry: controller.load),
+            Expanded(child: _PlannerBody(controller: controller)),
+          ],
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Header with week navigation
+// ---------------------------------------------------------------------------
+
+class _WeekHeader extends StatelessWidget {
+  const _WeekHeader({required this.controller});
+  final WeeklyPlannerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = _formatWeekLabel(controller.currentWeekLabel);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        border:
+            Border(bottom: BorderSide(color: Theme.of(context).dividerColor)),
+      ),
+      child: Row(
+        children: [
+          Text('Weekly Planner',
+              style: Theme.of(context).textTheme.headlineSmall),
+          const Spacer(),
+          IconButton(
+            icon: const Icon(Icons.chevron_left),
+            tooltip: 'Previous week',
+            onPressed: controller.goToPrevWeek,
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Text(label, style: Theme.of(context).textTheme.titleMedium),
+          ),
+          IconButton(
+            icon: const Icon(Icons.chevron_right),
+            tooltip: 'Next week',
+            onPressed: controller.goToNextWeek,
+          ),
+          const SizedBox(width: 8),
+          OutlinedButton(
+            onPressed: controller.isCurrentWeek ? null : controller.goToToday,
+            child: const Text('Today'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatWeekLabel(String label) {
+    // Parse YYYY-WNN → "Week of Mon DD, YYYY"
+    final m = RegExp(r'^(\d{4})-W(\d{1,2})$').firstMatch(label);
+    if (m == null) return label;
+    final year = int.parse(m.group(1)!);
+    final week = int.parse(m.group(2)!);
+    final jan4 = DateTime.utc(year, 1, 4);
+    final mondayWeek1 =
+        jan4.subtract(Duration(days: (jan4.weekday - 1 + 7) % 7));
+    final monday = mondayWeek1.add(Duration(days: (week - 1) * 7));
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec'
+    ];
+    return 'Week of ${months[monday.month - 1]} ${monday.day}, ${monday.year}';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error banner
+// ---------------------------------------------------------------------------
+
+class _ErrorBanner extends StatelessWidget {
+  const _ErrorBanner({required this.message, required this.onRetry});
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialBanner(
+      content: Text(message),
+      actions: [
+        TextButton(onPressed: onRetry, child: const Text('Retry')),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Three-pane body
+// ---------------------------------------------------------------------------
+
+class _PlannerBody extends StatelessWidget {
+  const _PlannerBody({required this.controller});
+  final WeeklyPlannerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    if (controller.status == WeeklyPlannerStatus.loading &&
+        controller.plan == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final plan = controller.plan;
+    if (plan == null) {
+      return const Center(child: Text('No plan loaded.'));
+    }
+
+    final selectedTask = controller.selectedTaskId != null
+        ? plan.days.expand((d) => d.tasks).cast<Task?>().firstWhere(
+            (t) => t?.id == controller.selectedTaskId,
+            orElse: () => null)
+        : null;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Left: Backlog
+        SizedBox(
+          width: 240,
+          child: _BacklogPane(plan: plan, controller: controller),
+        ),
+        VerticalDivider(width: 1, color: Theme.of(context).dividerColor),
+        // Center: Day columns
+        Expanded(
+          child: _DayColumnsPane(plan: plan, controller: controller),
+        ),
+        // Right: Detail panel (only when a task is selected)
+        if (selectedTask != null) ...[
+          VerticalDivider(width: 1, color: Theme.of(context).dividerColor),
+          SizedBox(
+            width: 280,
+            child: _DetailPane(task: selectedTask, controller: controller),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Backlog pane
+// ---------------------------------------------------------------------------
+
+class _BacklogPane extends StatelessWidget {
+  const _BacklogPane({required this.plan, required this.controller});
+  final WeeklyPlan plan;
+  final WeeklyPlannerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final backlog = plan.backlog;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Row(
+            children: [
+              Text('Backlog',
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleSmall
+                      ?.copyWith(fontWeight: FontWeight.bold)),
+              const SizedBox(width: 6),
+              if (backlog.isNotEmpty)
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primaryContainer,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text('${backlog.length}',
+                      style: Theme.of(context).textTheme.labelSmall),
+                ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: backlog.isEmpty
+              ? const Center(
+                  child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Text('All tasks scheduled',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(color: Colors.grey)),
+                ))
+              : ListView.builder(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  itemCount: backlog.length,
+                  itemBuilder: (context, i) => _BacklogTaskTile(
+                      task: backlog[i], controller: controller),
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+class _BacklogTaskTile extends StatelessWidget {
+  const _BacklogTaskTile({required this.task, required this.controller});
+  final Task task;
+  final WeeklyPlannerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Draggable<Task>(
+      data: task,
+      feedback: Material(
+        elevation: 4,
+        borderRadius: BorderRadius.circular(6),
+        child: Container(
+          width: 200,
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.primaryContainer,
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Text(task.title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall),
+        ),
+      ),
+      childWhenDragging: Opacity(
+        opacity: 0.4,
+        child: _taskCard(context),
+      ),
+      child: GestureDetector(
+        onTap: () => controller.selectTask(task.id),
+        child: _taskCard(context),
+      ),
+    );
+  }
+
+  Widget _taskCard(BuildContext context) {
+    final isSelected = controller.selectedTaskId == task.id;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: isSelected
+            ? Theme.of(context).colorScheme.primaryContainer
+            : Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(
+          color: isSelected
+              ? Theme.of(context).colorScheme.primary
+              : Colors.transparent,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(task.title,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall),
+          if (task.dueDate != null) ...[
+            const SizedBox(height: 4),
+            Text('Due ${task.dueDate}',
+                style: Theme.of(context)
+                    .textTheme
+                    .labelSmall
+                    ?.copyWith(color: Colors.grey)),
+          ],
+          if (task.sourceType != null) ...[
+            const SizedBox(height: 2),
+            _SourceChip(sourceType: task.sourceType!),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Day columns pane
+// ---------------------------------------------------------------------------
+
+class _DayColumnsPane extends StatelessWidget {
+  const _DayColumnsPane({required this.plan, required this.controller});
+  final WeeklyPlan plan;
+  final WeeklyPlannerController controller;
+
+  static const _dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: List.generate(plan.days.length, (i) {
+        final day = plan.days[i];
+        final scheduled = plan.tasksForDate(day.date);
+        return Expanded(
+          child: _DayColumn(
+            dayName: _dayNames[i],
+            date: day.date,
+            tasks: scheduled,
+            controller: controller,
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class _DayColumn extends StatefulWidget {
+  const _DayColumn({
+    required this.dayName,
+    required this.date,
+    required this.tasks,
+    required this.controller,
+  });
+  final String dayName;
+  final String date;
+  final List<Task> tasks;
+  final WeeklyPlannerController controller;
+
+  @override
+  State<_DayColumn> createState() => _DayColumnState();
+}
+
+class _DayColumnState extends State<_DayColumn> {
+  bool _hovering = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final today = _isToday(widget.date);
+    return DragTarget<Task>(
+      onWillAcceptWithDetails: (_) {
+        setState(() => _hovering = true);
+        return true;
+      },
+      onLeave: (_) => setState(() => _hovering = false),
+      onAcceptWithDetails: (details) {
+        setState(() => _hovering = false);
+        widget.controller.scheduleTask(details.data.id, widget.date);
+      },
+      builder: (context, candidateData, _) {
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          decoration: BoxDecoration(
+            color: _hovering
+                ? Theme.of(context)
+                    .colorScheme
+                    .primaryContainer
+                    .withValues(alpha: 0.3)
+                : null,
+            border: Border(
+              right: BorderSide(color: Theme.of(context).dividerColor),
+            ),
+          ),
+          child: Column(
+            children: [
+              // Day header
+              Container(
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                decoration: BoxDecoration(
+                  color: today
+                      ? Theme.of(context).colorScheme.primaryContainer
+                      : Theme.of(context).colorScheme.surfaceContainerLow,
+                  border: Border(
+                      bottom:
+                          BorderSide(color: Theme.of(context).dividerColor)),
+                ),
+                child: Column(
+                  children: [
+                    Text(widget.dayName,
+                        style: Theme.of(context)
+                            .textTheme
+                            .labelSmall
+                            ?.copyWith(fontWeight: FontWeight.bold)),
+                    Text(_shortDate(widget.date),
+                        style: Theme.of(context).textTheme.labelSmall),
+                  ],
+                ),
+              ),
+              // Tasks
+              Expanded(
+                child: widget.tasks.isEmpty
+                    ? Center(
+                        child: Text('—',
+                            style: TextStyle(color: Colors.grey[400])))
+                    : ListView.builder(
+                        padding: const EdgeInsets.all(6),
+                        itemCount: widget.tasks.length,
+                        itemBuilder: (context, i) => _ScheduledTaskTile(
+                          task: widget.tasks[i],
+                          controller: widget.controller,
+                        ),
+                      ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  bool _isToday(String date) {
+    final now = DateTime.now();
+    final today =
+        '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')}';
+    return date == today;
+  }
+
+  String _shortDate(String date) {
+    // YYYY-MM-DD → M/D
+    final parts = date.split('-');
+    if (parts.length != 3) return date;
+    return '${int.parse(parts[1])}/${int.parse(parts[2])}';
+  }
+}
+
+class _ScheduledTaskTile extends StatelessWidget {
+  const _ScheduledTaskTile({required this.task, required this.controller});
+  final Task task;
+  final WeeklyPlannerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final isSelected = controller.selectedTaskId == task.id;
+    return GestureDetector(
+      onTap: () => controller.selectTask(task.id),
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? Theme.of(context).colorScheme.primaryContainer
+              : Theme.of(context).colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(
+            color: isSelected
+                ? Theme.of(context).colorScheme.primary
+                : Colors.transparent,
+          ),
+        ),
+        child: Row(
+          children: [
+            if (task.locked)
+              Padding(
+                padding: const EdgeInsets.only(right: 4),
+                child: Icon(Icons.lock,
+                    size: 12, color: Theme.of(context).colorScheme.primary),
+              ),
+            Expanded(
+              child: Text(
+                task.title,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+            if (task.sourceType != null)
+              _SourceChip(sourceType: task.sourceType!),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Detail pane
+// ---------------------------------------------------------------------------
+
+class _DetailPane extends StatelessWidget {
+  const _DetailPane({required this.task, required this.controller});
+  final Task task;
+  final WeeklyPlannerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 8, 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text('Task Details',
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleSmall
+                        ?.copyWith(fontWeight: FontWeight.bold)),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close, size: 18),
+                onPressed: () => controller.selectTask(null),
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(task.title,
+                    style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 12),
+                _detailRow(context, 'Status', task.status.toUpperCase()),
+                if (task.dueDate != null)
+                  _detailRow(context, 'Due', task.dueDate!),
+                if (task.scheduledDate != null)
+                  _detailRow(context, 'Scheduled', task.scheduledDate!),
+                _detailRow(context, 'Locked', task.locked ? 'Yes' : 'No'),
+                if (task.sourceType != null)
+                  _detailRow(context, 'Source', task.sourceType!),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _detailRow(BuildContext context, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 80,
+            child: Text(label,
+                style: Theme.of(context)
+                    .textTheme
+                    .labelSmall
+                    ?.copyWith(color: Colors.grey)),
+          ),
+          Expanded(
+            child: Text(value, style: Theme.of(context).textTheme.bodySmall),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared widgets
+// ---------------------------------------------------------------------------
+
+class _SourceChip extends StatelessWidget {
+  const _SourceChip({required this.sourceType});
+  final String sourceType;
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, color) = switch (sourceType) {
+      'recurring_rule' => ('R', Colors.blue),
+      'project_step' => ('P', Colors.green),
+      _ => ('T', Colors.grey),
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(3),
+      ),
+      child: Text(label,
+          style: TextStyle(
+              fontSize: 10, fontWeight: FontWeight.bold, color: color)),
     );
   }
 }

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -14,6 +14,9 @@ import 'features/rhythms/repositories/rhythms_repository.dart';
 import 'features/tasks/controllers/tasks_controller.dart';
 import 'features/tasks/data/tasks_local_data_source.dart';
 import 'features/tasks/repositories/tasks_repository.dart';
+import 'features/weekly_planner/controllers/weekly_planner_controller.dart';
+import 'features/weekly_planner/data/weekly_plan_data_source.dart';
+import 'features/weekly_planner/repositories/weekly_plan_repository.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -53,6 +56,11 @@ class RhythmApp extends StatelessWidget {
         ChangeNotifierProvider(
           create: (_) => RhythmsController(
             RhythmsRepository(RhythmsDataSource()),
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => WeeklyPlannerController.create(
+            WeeklyPlanRepository(WeeklyPlanDataSource()),
           ),
         ),
       ],

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -59,7 +59,7 @@ class RhythmApp extends StatelessWidget {
           ),
         ),
         ChangeNotifierProvider(
-          create: (_) => WeeklyPlannerController.create(
+          create: (_) => WeeklyPlannerController(
             WeeklyPlanRepository(WeeklyPlanDataSource()),
           ),
         ),


### PR DESCRIPTION
## Summary
- **Backend**: `WeeklyPlanningService.assemblePlan()` merges one-off tasks, recurring instances, and project step instances into a 7-day (Mon–Sun) plan; `GET /weekly-plan?week=YYYY-WNN` and `PATCH /weekly-plan/tasks/:id` (schedule + lock); additive migration adds `scheduled_date` and `locked` to the tasks table
- **Flutter**: `WeeklyPlan` models + `WeeklyPlanDataSource` + `WeeklyPlanRepository`; `WeeklyPlannerController` with ISO week navigation (prev/next/today); three-pane `WeeklyPlannerView` — backlog (Draggable tasks), day columns Mon–Sun (DragTarget with today highlighted), and a task detail panel
- Closes issues #22, #23, #24, #25, #26, #27, #28

## Test plan
- [ ] Start API server (`npm run dev` in `apps/api_server`) — confirm `GET /weekly-plan` returns 7-day structure
- [ ] Run Flutter app (`flutter run -d macos`) — Weekly Planner is the first tab
- [ ] Verify week navigation (prev/next/today arrows) updates the week label and re-fetches
- [ ] Create a task with a due date in the current week — confirm it appears in the Backlog pane
- [ ] Drag a task from Backlog to a day column — confirm it moves out of backlog and into the column
- [ ] Click a task to open the detail panel; close with X

🤖 Generated with [Claude Code](https://claude.com/claude-code)