### PR TITLE
feat: Phase 5 desktop distribution and beta releases

### DIFF
--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -1,0 +1,81 @@
+name: Desktop Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version without the v prefix'
+        required: true
+        type: string
+      prerelease:
+        description: 'Mark the GitHub release as a prerelease'
+        required: true
+        default: true
+        type: boolean
+      release_notes:
+        description: 'Optional release notes override'
+        required: false
+        type: string
+
+jobs:
+  build-macos-release:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: apps/desktop_flutter
+    env:
+      RELEASE_VERSION: ${{ inputs.version }}
+      RELEASE_TAG: v${{ inputs.version }}
+      APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Verify desktop app
+        run: |
+          dart format --output=none --set-exit-if-changed .
+          flutter analyze --no-fatal-infos
+          flutter test
+
+      - name: Build macOS release
+        run: >
+          flutter build macos --release
+          --build-name="$RELEASE_VERSION"
+          --build-number="${{ github.run_number }}"
+
+      - name: Package macOS artifacts
+        run: ../../tools/release/package_macos.sh
+
+      - name: Sign and notarize when Apple secrets are present
+        run: ../../tools/release/sign_and_notarize_macos.sh
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: rhythm-macos-${{ inputs.version }}
+          path: dist/*
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: Rhythm ${{ env.RELEASE_TAG }}
+          prerelease: ${{ inputs.prerelease }}
+          generate_release_notes: ${{ inputs.release_notes == '' }}
+          body: ${{ inputs.release_notes }}
+          files: |
+            apps/desktop_flutter/dist/*.zip
+            apps/desktop_flutter/dist/*.dmg

--- a/apps/desktop_flutter/README.md
+++ b/apps/desktop_flutter/README.md
@@ -14,6 +14,11 @@ flutter pub get
 flutter run -d macos
 ```
 
+## Beta Distribution
+- Use the `Desktop Release` GitHub Actions workflow to build downloadable tester artifacts.
+- The app now checks GitHub Releases for updates and can open the latest download from inside the sidebar.
+- Apple signing and notarization setup is documented in [docs/release/macos_distribution.md](/Users/ajhochhalter/Documents/Rhythm/docs/release/macos_distribution.md).
+
 ## Notes
 - Avoid placing domain logic in controllers.
 - Keep desktop layout components reusable (`app_shell`, `navigation_sidebar`, split view patterns).

--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../../features/integrations/views/integrations_view.dart';
 import '../../../features/projects/views/projects_view.dart';
 import '../../../features/rhythms/views/rhythms_view.dart';
 import '../../../features/tasks/views/automation_rules_view.dart';
 import '../../../features/tasks/views/tasks_view.dart';
 import '../../../features/weekly_planner/views/weekly_planner_view.dart';
+import '../updates/update_controller.dart';
 import 'navigation_sidebar.dart';
 
 class AppShell extends StatefulWidget {
@@ -28,12 +30,14 @@ class _AppShellState extends State<AppShell> {
 
   @override
   Widget build(BuildContext context) {
+    final updateController = context.watch<UpdateController>();
     return Scaffold(
       body: Row(
         children: [
           NavigationSidebar(
             selectedIndex: _selectedIndex,
             onItemSelected: (i) => setState(() => _selectedIndex = i),
+            updateController: updateController,
           ),
           Expanded(child: _views[_selectedIndex]),
         ],

--- a/apps/desktop_flutter/lib/app/core/layout/navigation_sidebar.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/navigation_sidebar.dart
@@ -1,14 +1,18 @@
 import 'package:flutter/material.dart';
 
+import '../updates/update_controller.dart';
+
 class NavigationSidebar extends StatelessWidget {
   const NavigationSidebar({
     super.key,
     required this.selectedIndex,
     required this.onItemSelected,
+    required this.updateController,
   });
 
   final int selectedIndex;
   final ValueChanged<int> onItemSelected;
+  final UpdateController updateController;
 
   static const _items = [
     _NavItem(icon: Icons.calendar_view_week, label: 'Weekly Planner'),
@@ -44,6 +48,8 @@ class NavigationSidebar extends StatelessWidget {
             ),
             const SizedBox(height: 4),
           ],
+          const Spacer(),
+          _UpdatePanel(controller: updateController),
         ],
       ),
     );
@@ -90,6 +96,134 @@ class _NavItemTile extends StatelessWidget {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UpdatePanel extends StatelessWidget {
+  const _UpdatePanel({required this.controller});
+
+  final UpdateController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final update = controller.availableUpdate;
+    final versionLabel = controller.currentVersion == null
+        ? 'Version unknown'
+        : 'v${controller.currentVersion}';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.white12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'App updates',
+            style: TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            versionLabel,
+            style: const TextStyle(color: Colors.white70, fontSize: 12),
+          ),
+          const SizedBox(height: 10),
+          if (controller.isChecking)
+            const Text(
+              'Checking GitHub releases...',
+              style: TextStyle(color: Colors.white70, fontSize: 12),
+            )
+          else if (update != null) ...[
+            Text(
+              'Update ready: ${update.version}${update.prerelease ? ' beta' : ''}',
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _SidebarButton(
+                  label: 'Download',
+                  onTap: controller.openDownload,
+                ),
+                _SidebarButton(
+                  label: 'Notes',
+                  onTap: controller.openReleaseNotes,
+                  outlined: true,
+                ),
+              ],
+            ),
+          ] else ...[
+            const Text(
+              'You are on the latest release.',
+              style: TextStyle(color: Colors.white70, fontSize: 12),
+            ),
+            if (controller.errorMessage != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                controller.errorMessage!,
+                style:
+                    const TextStyle(color: Colors.orangeAccent, fontSize: 11),
+              ),
+            ],
+          ],
+          const SizedBox(height: 8),
+          _SidebarButton(
+            label: 'Check now',
+            onTap: controller.checkForUpdates,
+            outlined: true,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SidebarButton extends StatelessWidget {
+  const _SidebarButton({
+    required this.label,
+    required this.onTap,
+    this.outlined = false,
+  });
+
+  final String label;
+  final Future<void> Function() onTap;
+  final bool outlined;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+        decoration: BoxDecoration(
+          color: outlined ? Colors.transparent : Colors.white,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Colors.white24),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: outlined ? Colors.white : const Color(0xFF1F1F1F),
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+          ),
         ),
       ),
     );

--- a/apps/desktop_flutter/lib/app/core/updates/app_update_info.dart
+++ b/apps/desktop_flutter/lib/app/core/updates/app_update_info.dart
@@ -1,0 +1,19 @@
+class AppUpdateInfo {
+  const AppUpdateInfo({
+    required this.version,
+    required this.name,
+    required this.htmlUrl,
+    required this.downloadUrl,
+    required this.publishedAt,
+    required this.prerelease,
+    this.notes,
+  });
+
+  final String version;
+  final String name;
+  final String htmlUrl;
+  final String downloadUrl;
+  final DateTime publishedAt;
+  final bool prerelease;
+  final String? notes;
+}

--- a/apps/desktop_flutter/lib/app/core/updates/update_controller.dart
+++ b/apps/desktop_flutter/lib/app/core/updates/update_controller.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/foundation.dart';
+
+import 'app_update_info.dart';
+import 'update_service.dart';
+
+class UpdateController extends ChangeNotifier {
+  UpdateController(this._service);
+
+  final UpdateService _service;
+
+  bool _isChecking = false;
+  String? _currentVersion;
+  AppUpdateInfo? _availableUpdate;
+  String? _errorMessage;
+
+  bool get isChecking => _isChecking;
+  String? get currentVersion => _currentVersion;
+  AppUpdateInfo? get availableUpdate => _availableUpdate;
+  String? get errorMessage => _errorMessage;
+
+  Future<void> initialize() async {
+    _currentVersion ??= await _service.getCurrentVersion();
+    notifyListeners();
+    await checkForUpdates();
+  }
+
+  Future<void> checkForUpdates() async {
+    _isChecking = true;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      _currentVersion ??= await _service.getCurrentVersion();
+      _availableUpdate = await _service.fetchAvailableUpdate();
+    } catch (error) {
+      _errorMessage = error.toString();
+    } finally {
+      _isChecking = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> openDownload() async {
+    final update = _availableUpdate;
+    if (update == null) return;
+    await _service.openDownload(update);
+  }
+
+  Future<void> openReleaseNotes() async {
+    final update = _availableUpdate;
+    if (update == null) return;
+    await _service.openReleaseNotes(update);
+  }
+}

--- a/apps/desktop_flutter/lib/app/core/updates/update_service.dart
+++ b/apps/desktop_flutter/lib/app/core/updates/update_service.dart
@@ -1,0 +1,143 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'app_update_info.dart';
+
+class UpdateService {
+  UpdateService({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  static final Uri _releasesUri = Uri.parse(
+    'https://api.github.com/repos/ajhochy/Rhythm/releases?per_page=10',
+  );
+
+  Future<String> getCurrentVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    if (info.buildNumber.trim().isEmpty || info.buildNumber == '0') {
+      return info.version;
+    }
+    return '${info.version}+${info.buildNumber}';
+  }
+
+  Future<AppUpdateInfo?> fetchAvailableUpdate() async {
+    final currentVersion = _normalizeVersion(await getCurrentVersion());
+    final response = await _client.get(
+      _releasesUri,
+      headers: const {
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'Rhythm-Desktop',
+      },
+    );
+
+    if (response.statusCode >= 400) {
+      throw Exception('Failed to check releases (${response.statusCode}).');
+    }
+
+    final releases = jsonDecode(response.body) as List<dynamic>;
+    for (final item in releases.cast<Map<String, dynamic>>()) {
+      if (item['draft'] == true) continue;
+      final version = _normalizeVersion(
+        (item['tag_name'] as String?) ?? (item['name'] as String? ?? ''),
+      );
+      if (_compareVersions(version, currentVersion) <= 0) continue;
+
+      final assets =
+          (item['assets'] as List<dynamic>? ?? []).cast<Map<String, dynamic>>();
+      final preferredAsset = _pickPreferredAsset(assets);
+      final htmlUrl = item['html_url'] as String?;
+      if (htmlUrl == null) continue;
+
+      return AppUpdateInfo(
+        version: version,
+        name: (item['name'] as String?)?.trim().isNotEmpty == true
+            ? item['name'] as String
+            : version,
+        htmlUrl: htmlUrl,
+        downloadUrl:
+            preferredAsset?['browser_download_url'] as String? ?? htmlUrl,
+        publishedAt: DateTime.tryParse(item['published_at'] as String? ?? '') ??
+            DateTime.now(),
+        prerelease: item['prerelease'] == true,
+        notes: item['body'] as String?,
+      );
+    }
+
+    return null;
+  }
+
+  Future<void> openDownload(AppUpdateInfo update) async {
+    final uri = Uri.parse(update.downloadUrl);
+    if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      throw Exception('Unable to open download URL.');
+    }
+  }
+
+  Future<void> openReleaseNotes(AppUpdateInfo update) async {
+    final uri = Uri.parse(update.htmlUrl);
+    if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      throw Exception('Unable to open release notes URL.');
+    }
+  }
+
+  static Map<String, dynamic>? _pickPreferredAsset(
+    List<Map<String, dynamic>> assets,
+  ) {
+    for (final suffix in ['.dmg', '.zip', '.pkg']) {
+      for (final asset in assets) {
+        final name = (asset['name'] as String?)?.toLowerCase() ?? '';
+        if (name.endsWith(suffix)) return asset;
+      }
+    }
+    return assets.isEmpty ? null : assets.first;
+  }
+
+  static String _normalizeVersion(String version) {
+    final plusIndex = version.indexOf('+');
+    final withoutBuild =
+        plusIndex == -1 ? version.trim() : version.substring(0, plusIndex);
+    return withoutBuild.replaceFirst(RegExp(r'^[^0-9]*'), '');
+  }
+
+  static int _compareVersions(String left, String right) {
+    final leftParts = _VersionParts.parse(left);
+    final rightParts = _VersionParts.parse(right);
+
+    final maxLength = leftParts.numbers.length > rightParts.numbers.length
+        ? leftParts.numbers.length
+        : rightParts.numbers.length;
+    for (var index = 0; index < maxLength; index++) {
+      final leftNumber =
+          index < leftParts.numbers.length ? leftParts.numbers[index] : 0;
+      final rightNumber =
+          index < rightParts.numbers.length ? rightParts.numbers[index] : 0;
+      if (leftNumber != rightNumber) return leftNumber.compareTo(rightNumber);
+    }
+
+    if (leftParts.isPrerelease != rightParts.isPrerelease) {
+      return leftParts.isPrerelease ? -1 : 1;
+    }
+
+    return left.compareTo(right);
+  }
+}
+
+class _VersionParts {
+  const _VersionParts({required this.numbers, required this.isPrerelease});
+
+  final List<int> numbers;
+  final bool isPrerelease;
+
+  factory _VersionParts.parse(String raw) {
+    final prerelease = raw.contains('-');
+    final numericPart = raw.split('-').first;
+    final numbers = numericPart
+        .split('.')
+        .map((part) => int.tryParse(part) ?? 0)
+        .toList(growable: false);
+    return _VersionParts(numbers: numbers, isPrerelease: prerelease);
+  }
+}

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -5,6 +5,8 @@ import 'package:window_manager/window_manager.dart';
 import 'app/core/constants/app_constants.dart';
 import 'app/core/layout/app_shell.dart';
 import 'app/theme/app_theme.dart';
+import 'app/core/updates/update_controller.dart';
+import 'app/core/updates/update_service.dart';
 import 'features/projects/controllers/project_template_controller.dart';
 import 'features/projects/data/projects_local_data_source.dart';
 import 'features/projects/repositories/projects_repository.dart';
@@ -78,6 +80,9 @@ class RhythmApp extends StatelessWidget {
           create: (_) => IntegrationsController(
             IntegrationsRepository(IntegrationsDataSource()),
           ),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => UpdateController(UpdateService())..initialize(),
         ),
       ],
       child: MaterialApp(

--- a/apps/desktop_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/desktop_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,14 @@
 import FlutterMacOS
 import Foundation
 
+import package_info_plus
 import screen_retriever
+import url_launcher_macos
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/apps/desktop_flutter/macos/Podfile.lock
+++ b/apps/desktop_flutter/macos/Podfile.lock
@@ -1,26 +1,38 @@
 PODS:
   - FlutterMacOS (1.0.0)
+  - package_info_plus (0.0.1):
+    - FlutterMacOS
   - screen_retriever (0.0.1):
+    - FlutterMacOS
+  - url_launcher_macos (0.0.1):
     - FlutterMacOS
   - window_manager (0.2.0):
     - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - screen_retriever (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
     :path: Flutter/ephemeral
+  package_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   screen_retriever:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever/macos
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
   window_manager:
     :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   screen_retriever: 4f97c103641aab8ce183fa5af3b87029df167936
+  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
   window_manager: 1d01fa7ac65a6e6f83b965471b1a7fdd3f06166c
 
 PODFILE CHECKSUM: 7eb978b976557c8c1cd717d8185ec483fd090a82

--- a/apps/desktop_flutter/macos/Runner/Configs/AppInfo.xcconfig
+++ b/apps/desktop_flutter/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,10 +5,10 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = rhythm_desktop
+PRODUCT_NAME = Rhythm
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.rhythmDesktop
+PRODUCT_BUNDLE_IDENTIFIER = org.visaliacrc.rhythm
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2026 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2026 CR - AJ Hochhalter. All rights reserved.

--- a/apps/desktop_flutter/pubspec.yaml
+++ b/apps/desktop_flutter/pubspec.yaml
@@ -10,7 +10,9 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.2.0
+  package_info_plus: ^8.0.2
   provider: ^6.1.2
+  url_launcher: ^6.3.1
   window_manager: ^0.3.8
 
 dev_dependencies:

--- a/docs/release/macos_distribution.md
+++ b/docs/release/macos_distribution.md
@@ -1,0 +1,98 @@
+# macOS Distribution And Test Releases
+
+This document covers the remaining Phase 5 distribution work for Rhythm desktop:
+- building downloadable tester artifacts from GitHub
+- wiring Apple signing and notarization
+- enabling in-app update checks against GitHub releases
+
+## What The Repo Now Supports
+
+- `Desktop Release` GitHub Actions workflow for building macOS releases
+- zipped `.app` and `.dmg` artifacts uploaded to the workflow run
+- optional GitHub Release publishing for tester downloads
+- optional Apple codesign + notarization if the required secrets are configured
+- in-app update checks that look for the latest published GitHub release
+
+## Required Apple Setup
+
+Before notarized tester builds will work, configure a real bundle identity and Apple credentials.
+
+### 1. Set a real bundle identifier
+
+Update [AppInfo.xcconfig](/Users/ajhochhalter/Documents/Rhythm/apps/desktop_flutter/macos/Runner/Configs/AppInfo.xcconfig):
+
+- `PRODUCT_BUNDLE_IDENTIFIER`
+- optionally `PRODUCT_COPYRIGHT`
+
+This should match the app identifier you register in Apple Developer.
+
+### 2. Create the Developer ID certificate
+
+In Apple Developer:
+- create or confirm a `Developer ID Application` certificate
+- install it into Keychain Access on your Mac
+- export it from Keychain Access as a `.p12`
+- choose a password when exporting
+
+### 3. Create an app-specific password
+
+In Apple ID account settings:
+- create an app-specific password for notarization
+
+### 4. Add GitHub repository secrets
+
+Add these repository secrets:
+
+- `APPLE_CERTIFICATE_BASE64`
+  - base64-encoded contents of the exported `.p12`
+- `APPLE_CERTIFICATE_PASSWORD`
+  - password used when exporting the `.p12`
+- `APPLE_SIGNING_IDENTITY`
+  - example: `Developer ID Application: Your Name (TEAMID)`
+- `APPLE_ID`
+  - Apple ID email used for notarization
+- `APPLE_APP_SPECIFIC_PASSWORD`
+  - app-specific password from Apple ID settings
+- `APPLE_TEAM_ID`
+  - Apple Developer team ID
+
+To create the base64 value:
+
+```bash
+base64 -i DeveloperIDApplication.p12 | pbcopy
+```
+
+## Running A Tester Release
+
+1. Open GitHub Actions.
+2. Run `Desktop Release`.
+3. Enter a version like `0.2.0-beta.1` or `0.2.0`.
+4. Set `prerelease=true` for beta builds.
+5. Wait for the workflow to:
+   - run analyze and tests
+   - build the macOS app
+   - package `.zip` and `.dmg`
+   - sign/notarize if Apple secrets are configured
+   - publish a GitHub release
+
+## Tester Download Flow
+
+The release workflow publishes downloadable artifacts to GitHub Releases.
+That gives you a stable URL for:
+- direct tester downloads
+- in-app update checks
+
+## In-App Updates
+
+Rhythm desktop now checks the GitHub Releases feed and surfaces:
+- current installed version
+- available update version
+- download button
+- release notes link
+
+This is intentionally simple for the first beta cycle:
+- no silent install
+- no Sparkle integration yet
+- no background auto-apply
+
+It is enough for beta testers to update from inside the app without manually browsing the repo.

--- a/tools/release/package_macos.sh
+++ b/tools/release/package_macos.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APP_DIR="${ROOT_DIR}/apps/desktop_flutter/build/macos/Build/Products/Release"
+DIST_DIR="${ROOT_DIR}/apps/desktop_flutter/dist"
+DISPLAY_NAME="Rhythm"
+
+mkdir -p "${DIST_DIR}"
+rm -f "${DIST_DIR}"/*.zip "${DIST_DIR}"/*.dmg
+
+APP_PATH="$(find "${APP_DIR}" -maxdepth 1 -name '*.app' -print -quit)"
+if [[ -z "${APP_PATH}" ]]; then
+  echo "No macOS app bundle found in ${APP_DIR}" >&2
+  exit 1
+fi
+
+ARCHIVE_BASENAME="${DISPLAY_NAME}-macOS"
+ZIP_PATH="${DIST_DIR}/${ARCHIVE_BASENAME}.zip"
+DMG_PATH="${DIST_DIR}/${ARCHIVE_BASENAME}.dmg"
+
+ditto -c -k --sequesterRsrc --keepParent "${APP_PATH}" "${ZIP_PATH}"
+hdiutil create \
+  -volname "${DISPLAY_NAME}" \
+  -srcfolder "${APP_PATH}" \
+  -ov \
+  -format UDZO \
+  "${DMG_PATH}"
+
+echo "Packaged ${ZIP_PATH}"
+echo "Packaged ${DMG_PATH}"

--- a/tools/release/sign_and_notarize_macos.sh
+++ b/tools/release/sign_and_notarize_macos.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APP_DIR="${ROOT_DIR}/apps/desktop_flutter/build/macos/Build/Products/Release"
+DIST_DIR="${ROOT_DIR}/apps/desktop_flutter/dist"
+ENTITLEMENTS_PATH="${ROOT_DIR}/apps/desktop_flutter/macos/Runner/Release.entitlements"
+
+APP_PATH="$(find "${APP_DIR}" -maxdepth 1 -name '*.app' -print -quit)"
+DMG_PATH="$(find "${DIST_DIR}" -maxdepth 1 -name '*.dmg' -print -quit)"
+
+required_vars=(
+  APPLE_CERTIFICATE_BASE64
+  APPLE_CERTIFICATE_PASSWORD
+  APPLE_SIGNING_IDENTITY
+  APPLE_ID
+  APPLE_APP_SPECIFIC_PASSWORD
+  APPLE_TEAM_ID
+)
+
+for name in "${required_vars[@]}"; do
+  if [[ -z "${!name:-}" ]]; then
+    echo "Skipping codesign/notarization because ${name} is not set."
+    exit 0
+  fi
+done
+
+if [[ -z "${APP_PATH}" || -z "${DMG_PATH}" ]]; then
+  echo "Missing app bundle or DMG for signing." >&2
+  exit 1
+fi
+
+KEYCHAIN_NAME="build-signing.keychain-db"
+KEYCHAIN_PASSWORD="$(uuidgen)"
+CERT_PATH="$(mktemp -t rhythm-cert).p12"
+
+cleanup() {
+  rm -f "${CERT_PATH}"
+  security delete-keychain "${KEYCHAIN_NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "${APPLE_CERTIFICATE_BASE64}" | base64 --decode > "${CERT_PATH}"
+
+security create-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+security set-keychain-settings -lut 21600 "${KEYCHAIN_NAME}"
+security unlock-keychain -p "${KEYCHAIN_PASSWORD}" "${KEYCHAIN_NAME}"
+security import "${CERT_PATH}" \
+  -k "${KEYCHAIN_NAME}" \
+  -P "${APPLE_CERTIFICATE_PASSWORD}" \
+  -T /usr/bin/codesign \
+  -T /usr/bin/security \
+  -T /usr/bin/productbuild
+security list-keychain -d user -s "${KEYCHAIN_NAME}" login.keychain-db
+security set-key-partition-list \
+  -S apple-tool:,apple:,codesign: \
+  -s \
+  -k "${KEYCHAIN_PASSWORD}" \
+  "${KEYCHAIN_NAME}"
+
+codesign --force --deep --options runtime \
+  --entitlements "${ENTITLEMENTS_PATH}" \
+  --sign "${APPLE_SIGNING_IDENTITY}" \
+  "${APP_PATH}"
+
+codesign --force --sign "${APPLE_SIGNING_IDENTITY}" "${DMG_PATH}"
+
+xcrun notarytool submit "${DMG_PATH}" \
+  --apple-id "${APPLE_ID}" \
+  --password "${APPLE_APP_SPECIFIC_PASSWORD}" \
+  --team-id "${APPLE_TEAM_ID}" \
+  --wait
+
+xcrun stapler staple "${APP_PATH}"
+xcrun stapler staple "${DMG_PATH}"
+
+echo "Signed and notarized ${APP_PATH} and ${DMG_PATH}"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for macOS beta release packaging and GitHub Releases publishing
- add Apple signing and notarization scripts plus setup docs
- add in-app update checks and download links for tester builds
- update macOS app metadata to use the Rhythm bundle identifier

## Testing
- flutter analyze --no-fatal-infos
- flutter test
- flutter build macos --release
- ./tools/release/package_macos.sh

Closes #41
Closes #67
Closes #68
Closes #69