### PR TITLE
fix: correctly parse notarytool status to surface rejection diagnostics

### DIFF
--- a/tools/release/sign_and_notarize_macos.sh
+++ b/tools/release/sign_and_notarize_macos.sh
@@ -90,8 +90,8 @@ xcrun notarytool submit "${DMG_PATH}" \
   --wait \
   > "${NOTARY_OUTPUT}"
 
-SUBMISSION_ID="$(awk '/id:/ { print $2; exit }' "${NOTARY_OUTPUT}")"
-NOTARY_STATUS="$(awk '/status:/ { print $2; exit }' "${NOTARY_OUTPUT}")"
+SUBMISSION_ID="$(awk '/^[[:space:]]+id:/ { print $2; exit }' "${NOTARY_OUTPUT}")"
+NOTARY_STATUS="$(awk '/^[[:space:]]+status:/ { print $2; exit }' "${NOTARY_OUTPUT}")"
 
 cat "${NOTARY_OUTPUT}"
 


### PR DESCRIPTION
## Summary
- `awk '/status:/'` was matching `Current status: Invalid.......Processing complete` before the indented `  status: Invalid` summary line
- `NOTARY_STATUS` was set to `"status:"` instead of `"Invalid"`, so the diagnostic log branch was never entered
- Job fell through to `xcrun stapler` which fails with exit 65 when notarization is invalid

Anchors both awk patterns on leading whitespace so they only match the indented summary fields from `notarytool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)