### PR TITLE
fix: sign nested frameworks with Hardened Runtime for notarization

### DIFF
--- a/tools/release/sign_and_notarize_macos.sh
+++ b/tools/release/sign_and_notarize_macos.sh
@@ -73,7 +73,18 @@ if [[ -z "${IDENTITY_SHA}" ]]; then
   exit 1
 fi
 
-codesign --force --deep --options runtime \
+# Sign nested frameworks and binaries from the inside out with Hardened Runtime.
+# codesign --deep does NOT propagate --options runtime to nested items, so we
+# must sign each one explicitly before signing the top-level bundle.
+while IFS= read -r -d '' item; do
+  codesign --force --options runtime --timestamp \
+    --sign "${IDENTITY_SHA}" \
+    "${item}"
+done < <(find "${APP_PATH}/Contents/Frameworks" \
+  \( -name "*.framework" -o -name "*.dylib" -o -name "*.so" \) \
+  -print0 | sort -rz)
+
+codesign --force --options runtime --timestamp \
   --entitlements "${ENTITLEMENTS_PATH}" \
   --sign "${IDENTITY_SHA}" \
   "${APP_PATH}"


### PR DESCRIPTION
## Summary
- `codesign --deep` does **not** propagate `--options runtime` or `--timestamp` to nested items
- All embedded Flutter frameworks (`FlutterMacOS`, `App`, `window_manager`, `screen_retriever`, `url_launcher_macos`, `package_info_plus`) and the main binary were rejected by Apple notarization:
  - "The binary is not signed with a valid Developer ID certificate"
  - "The signature does not include a secure timestamp"
- Replaces `--deep` with an explicit inside-out signing loop over all `.framework`/`.dylib`/`.so` items in `Contents/Frameworks` before signing the top-level bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)