### PR TITLE
feat: auto-launch API server when app opens

### DIFF
--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:window_manager/window_manager.dart';
+
 import '../../../features/integrations/views/integrations_view.dart';
 import '../../../features/projects/views/projects_view.dart';
 import '../../../features/rhythms/views/rhythms_view.dart';
 import '../../../features/tasks/views/automation_rules_view.dart';
 import '../../../features/tasks/views/tasks_view.dart';
 import '../../../features/weekly_planner/views/weekly_planner_view.dart';
+import '../server/api_server_controller.dart';
 import '../updates/update_controller.dart';
 import 'navigation_sidebar.dart';
 
@@ -16,8 +19,124 @@ class AppShell extends StatefulWidget {
   State<AppShell> createState() => _AppShellState();
 }
 
-class _AppShellState extends State<AppShell> {
+class _AppShellState extends State<AppShell> with WindowListener {
   int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    windowManager.addListener(this);
+    // Intercept the close event so we can stop the server cleanly first.
+    windowManager.setPreventClose(true);
+  }
+
+  @override
+  void dispose() {
+    windowManager.removeListener(this);
+    super.dispose();
+  }
+
+  @override
+  void onWindowClose() async {
+    context.read<ApiServerController>().dispose();
+    await windowManager.destroy();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final serverStatus = context.watch<ApiServerController>().status;
+
+    return switch (serverStatus) {
+      ServerStatus.starting => const _ServerLoadingView(),
+      ServerStatus.failed => _ServerFailedView(
+          onRetry: () => context.read<ApiServerController>().retry(),
+        ),
+      ServerStatus.ready => _AppContent(
+          selectedIndex: _selectedIndex,
+          onItemSelected: (i) => setState(() => _selectedIndex = i),
+        ),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server loading splash
+// ---------------------------------------------------------------------------
+
+class _ServerLoadingView extends StatelessWidget {
+  const _ServerLoadingView();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(height: 20),
+            Text(
+              'Starting Rhythm…',
+              style: TextStyle(fontSize: 16, color: Colors.black54),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server failed view
+// ---------------------------------------------------------------------------
+
+class _ServerFailedView extends StatelessWidget {
+  const _ServerFailedView({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: Colors.red),
+            const SizedBox(height: 16),
+            const Text(
+              'Could not start the Rhythm server.',
+              style: TextStyle(fontSize: 16),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Make sure Node.js is installed and try again.',
+              style: TextStyle(color: Colors.black54),
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: onRetry,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Normal app content (shown once server is ready)
+// ---------------------------------------------------------------------------
+
+class _AppContent extends StatelessWidget {
+  const _AppContent({
+    required this.selectedIndex,
+    required this.onItemSelected,
+  });
+
+  final int selectedIndex;
+  final ValueChanged<int> onItemSelected;
 
   static const _views = [
     WeeklyPlannerView(),
@@ -35,11 +154,11 @@ class _AppShellState extends State<AppShell> {
       body: Row(
         children: [
           NavigationSidebar(
-            selectedIndex: _selectedIndex,
-            onItemSelected: (i) => setState(() => _selectedIndex = i),
+            selectedIndex: selectedIndex,
+            onItemSelected: onItemSelected,
             updateController: updateController,
           ),
-          Expanded(child: _views[_selectedIndex]),
+          Expanded(child: _views[selectedIndex]),
         ],
       ),
     );

--- a/apps/desktop_flutter/lib/app/core/server/api_server_controller.dart
+++ b/apps/desktop_flutter/lib/app/core/server/api_server_controller.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/foundation.dart';
+
+import 'api_server_service.dart';
+
+enum ServerStatus { starting, ready, failed }
+
+class ApiServerController extends ChangeNotifier {
+  ApiServerController(this._service);
+
+  final ApiServerService _service;
+  ServerStatus _status = ServerStatus.starting;
+
+  ServerStatus get status => _status;
+  bool get isReady => _status == ServerStatus.ready;
+
+  Future<void> initialize() async {
+    _status = ServerStatus.starting;
+    notifyListeners();
+
+    final ok = await _service.start();
+
+    _status = ok ? ServerStatus.ready : ServerStatus.failed;
+    notifyListeners();
+  }
+
+  Future<void> retry() => initialize();
+
+  @override
+  void dispose() {
+    _service.stop();
+    super.dispose();
+  }
+}

--- a/apps/desktop_flutter/lib/app/core/server/api_server_service.dart
+++ b/apps/desktop_flutter/lib/app/core/server/api_server_service.dart
@@ -1,0 +1,191 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+
+/// Manages the lifecycle of the local Node.js API server process.
+class ApiServerService {
+  Process? _process;
+
+  bool get isRunning => _process != null;
+
+  /// Finds the node binary, starts the server process, and waits for it to
+  /// become healthy. Returns true if the server started successfully.
+  Future<bool> start() async {
+    final node = await _findNode();
+    if (node == null) {
+      stderr.writeln('[ApiServerService] Could not find node binary.');
+      return false;
+    }
+
+    final serverInfo = await _findServer(node);
+    if (serverInfo == null) {
+      stderr.writeln('[ApiServerService] Could not locate api_server.');
+      return false;
+    }
+
+    final dbPath = _dbPath();
+    stdout.writeln(
+        '[ApiServerService] Starting: ${serverInfo.executable} ${serverInfo.args.join(' ')}');
+    stdout.writeln('[ApiServerService] DB path: $dbPath');
+
+    _process = await Process.start(
+      serverInfo.executable,
+      serverInfo.args,
+      workingDirectory: serverInfo.workingDir,
+      environment: {
+        ...Platform.environment,
+        'PORT': '4000',
+        'DB_PATH': dbPath,
+      },
+    );
+
+    _process!.stdout
+        .transform(const SystemEncoding().decoder)
+        .listen((line) => stdout.write('[api_server] $line'));
+    _process!.stderr
+        .transform(const SystemEncoding().decoder)
+        .listen((line) => stderr.write('[api_server] $line'));
+
+    _process!.exitCode.then((code) {
+      stdout.writeln('[ApiServerService] Server exited with code $code');
+      _process = null;
+    });
+
+    return _waitForReady();
+  }
+
+  /// Terminates the server process.
+  void stop() {
+    _process?.kill(ProcessSignal.sigterm);
+    _process = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  Future<bool> _waitForReady() async {
+    const maxAttempts = 40; // up to ~8 seconds
+    const delay = Duration(milliseconds: 200);
+    final uri = Uri.parse('http://localhost:4000/health');
+
+    for (var i = 0; i < maxAttempts; i++) {
+      await Future<void>.delayed(delay);
+      try {
+        final response = await http.get(uri).timeout(const Duration(seconds: 1));
+        if (response.statusCode == 200) {
+          stdout.writeln('[ApiServerService] Server is ready.');
+          return true;
+        }
+      } catch (_) {
+        // Not ready yet — keep polling.
+      }
+    }
+
+    stderr.writeln('[ApiServerService] Server did not become ready in time.');
+    return false;
+  }
+
+  Future<String?> _findNode() async {
+    // First, ask the shell.
+    try {
+      final result = await Process.run('/bin/sh', ['-c', 'which node']);
+      if (result.exitCode == 0) {
+        final path = (result.stdout as String).trim();
+        if (path.isNotEmpty && File(path).existsSync()) return path;
+      }
+    } catch (_) {}
+
+    // Fall back to common macOS install locations.
+    const candidates = [
+      '/opt/homebrew/bin/node', // Apple Silicon Homebrew
+      '/usr/local/bin/node', // Intel Homebrew / nvm
+      '/usr/bin/node',
+    ];
+    for (final path in candidates) {
+      if (File(path).existsSync()) return path;
+    }
+
+    return null;
+  }
+
+  Future<_ServerInfo?> _findServer(String nodePath) async {
+    final exe = Platform.resolvedExecutable;
+    // exe = .../Rhythm.app/Contents/MacOS/Rhythm
+
+    // 1. Production: dist/server.js bundled inside the .app Resources folder.
+    final resourcesDir = '${_dirname(_dirname(exe))}/Resources';
+    final bundledScript = '$resourcesDir/api_server/dist/server.js';
+    if (File(bundledScript).existsSync()) {
+      return _ServerInfo(
+        executable: nodePath,
+        args: [bundledScript],
+        workingDir: '$resourcesDir/api_server',
+      );
+    }
+
+    // 2. Development: walk up from the executable to find the workspace root.
+    //    exe lives deep inside build/macos/Build/Products/*/Rhythm.app/...
+    var dir = _dirname(exe);
+    for (var i = 0; i < 12; i++) {
+      final candidate = '$dir/apps/api_server';
+      if (Directory(candidate).existsSync()) {
+        // Prefer a pre-built dist if available.
+        final distScript = '$candidate/dist/server.js';
+        if (File(distScript).existsSync()) {
+          return _ServerInfo(
+            executable: nodePath,
+            args: [distScript],
+            workingDir: candidate,
+          );
+        }
+        // Fall back to npx tsx (dev convenience — no build step needed).
+        final npx = await _findNpx(nodePath);
+        return _ServerInfo(
+          executable: npx,
+          args: ['tsx', 'src/server.ts'],
+          workingDir: candidate,
+        );
+      }
+      final parent = _dirname(dir);
+      if (parent == dir) break;
+      dir = parent;
+    }
+
+    return null;
+  }
+
+  Future<String> _findNpx(String nodePath) async {
+    // npx lives next to node.
+    final nodeDir = _dirname(nodePath);
+    final candidate = '$nodeDir/npx';
+    if (File(candidate).existsSync()) return candidate;
+    // Fallback: let the shell find it.
+    return 'npx';
+  }
+
+  String _dbPath() {
+    final home = Platform.environment['HOME'] ?? '.';
+    final supportDir = '$home/Library/Application Support/Rhythm';
+    Directory(supportDir).createSync(recursive: true);
+    return '$supportDir/rhythm.db';
+  }
+
+  String _dirname(String path) {
+    final idx = path.lastIndexOf('/');
+    return idx > 0 ? path.substring(0, idx) : '/';
+  }
+}
+
+class _ServerInfo {
+  /// The executable to invoke (node path, or the npx path).
+  final String executable;
+  final List<String> args;
+  final String workingDir;
+
+  const _ServerInfo({
+    required this.executable,
+    required this.args,
+    required this.workingDir,
+  });
+}

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -4,15 +4,17 @@ import 'package:window_manager/window_manager.dart';
 
 import 'app/core/constants/app_constants.dart';
 import 'app/core/layout/app_shell.dart';
-import 'app/theme/app_theme.dart';
+import 'app/core/server/api_server_controller.dart';
+import 'app/core/server/api_server_service.dart';
 import 'app/core/updates/update_controller.dart';
 import 'app/core/updates/update_service.dart';
-import 'features/projects/controllers/project_template_controller.dart';
-import 'features/projects/data/projects_local_data_source.dart';
-import 'features/projects/repositories/projects_repository.dart';
+import 'app/theme/app_theme.dart';
 import 'features/integrations/controllers/integrations_controller.dart';
 import 'features/integrations/data/integrations_data_source.dart';
 import 'features/integrations/repositories/integrations_repository.dart';
+import 'features/projects/controllers/project_template_controller.dart';
+import 'features/projects/data/projects_local_data_source.dart';
+import 'features/projects/repositories/projects_repository.dart';
 import 'features/rhythms/controllers/rhythms_controller.dart';
 import 'features/rhythms/data/rhythms_data_source.dart';
 import 'features/rhythms/repositories/rhythms_repository.dart';
@@ -41,16 +43,25 @@ void main() async {
     await windowManager.focus();
   });
 
-  runApp(const RhythmApp());
+  // Create the server controller and kick off startup before runApp so the
+  // service object is available immediately. The UI shows a loading screen
+  // while the server boots.
+  final serverController = ApiServerController(ApiServerService())
+    ..initialize();
+
+  runApp(RhythmApp(serverController: serverController));
 }
 
 class RhythmApp extends StatelessWidget {
-  const RhythmApp({super.key});
+  const RhythmApp({super.key, required this.serverController});
+
+  final ApiServerController serverController;
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        ChangeNotifierProvider.value(value: serverController),
         ChangeNotifierProvider(
           create: (_) => TasksController(
             TasksRepository(TasksLocalDataSource()),

--- a/apps/desktop_flutter/macos/Runner/DebugProfile.entitlements
+++ b/apps/desktop_flutter/macos/Runner/DebugProfile.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/apps/desktop_flutter/macos/Runner/Release.entitlements
+++ b/apps/desktop_flutter/macos/Runner/Release.entitlements
@@ -2,9 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
 	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- `ApiServerService` spawns the Node.js server on app start — uses `dist/server.js` if built, falls back to `npx tsx src/server.ts` for dev convenience
- `ApiServerController` (ChangeNotifier) exposes `starting / ready / failed` states and polls `/health` until the server responds (up to ~8s)
- `AppShell` shows a loading splash → app content → or error+retry depending on state; intercepts window close via `WindowListener` to stop the server cleanly
- DB is stored at `~/Library/Application Support/Rhythm/rhythm.db` (consistent path regardless of cwd)
- Removed `app-sandbox` entitlement — required to allow child process spawning; fine for non-App-Store distribution

## Test plan
- [ ] `flutter run -d macos` — app should show "Starting Rhythm…" briefly then load normally (no manual `npm run dev` needed)
- [ ] Kill the Flutter app — `node` process should exit too (check Activity Monitor)
- [ ] Delete `apps/api_server/dist/` and re-run — should fall back to `npx tsx src/server.ts`
- [ ] With Node not on PATH — should show the failed/retry screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)