### PR TITLE
feat: bundle API server into .app and fix node discovery

### DIFF
--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -50,11 +50,25 @@ jobs:
           flutter analyze --no-fatal-infos
           flutter test
 
+      - name: Build API server
+        working-directory: apps/api_server
+        run: |
+          npm ci --omit=dev
+          npm run build
+
       - name: Build macOS release
         run: >
           flutter build macos --release
           --build-name="$RELEASE_VERSION"
           --build-number="${{ github.run_number }}"
+
+      - name: Bundle API server into app
+        run: |
+          APP="build/macos/Build/Products/Release/Rhythm.app"
+          DEST="$APP/Contents/Resources/api_server"
+          mkdir -p "$DEST"
+          cp -r ../api_server/dist "$DEST/"
+          cp -r ../api_server/node_modules "$DEST/"
 
       - name: Package macOS artifacts
         run: ../../tools/release/package_macos.sh

--- a/apps/desktop_flutter/lib/app/core/server/api_server_service.dart
+++ b/apps/desktop_flutter/lib/app/core/server/api_server_service.dart
@@ -88,16 +88,21 @@ class ApiServerService {
   }
 
   Future<String?> _findNode() async {
-    // First, ask the shell.
-    try {
-      final result = await Process.run('/bin/sh', ['-c', 'which node']);
-      if (result.exitCode == 0) {
-        final path = (result.stdout as String).trim();
-        if (path.isNotEmpty && File(path).existsSync()) return path;
-      }
-    } catch (_) {}
+    // GUI apps on macOS launch with a minimal PATH (/usr/bin:/bin:...) so
+    // plain `which node` misses Homebrew and nvm. Use a login shell so that
+    // ~/.zprofile / ~/.bash_profile are sourced and the full PATH is available.
+    for (final shell in ['/bin/zsh', '/bin/bash']) {
+      if (!File(shell).existsSync()) continue;
+      try {
+        final result = await Process.run(shell, ['-l', '-c', 'which node']);
+        if (result.exitCode == 0) {
+          final path = (result.stdout as String).trim();
+          if (path.isNotEmpty && File(path).existsSync()) return path;
+        }
+      } catch (_) {}
+    }
 
-    // Fall back to common macOS install locations.
+    // Hard-coded fallbacks for common macOS install locations.
     const candidates = [
       '/opt/homebrew/bin/node', // Apple Silicon Homebrew
       '/usr/local/bin/node', // Intel Homebrew / nvm


### PR DESCRIPTION
## Summary
- **Root cause**: the distributed `.app` had no server code inside it — `_findServer()` was only finding the dev workspace path, which doesn't exist on a user's machine
- **CI**: adds two steps between `flutter build macos` and packaging — builds the api_server (`npm ci --omit=dev && npm run build`) then copies `dist/` + `node_modules/` into `Contents/Resources/api_server/` inside the built `.app`
- **Node discovery**: switches from `/bin/sh -c 'which node'` (gets minimal GUI PATH) to `/bin/zsh -l -c 'which node'` (login shell, sources `~/.zprofile` so Homebrew/nvm are visible)

## Test plan
- [ ] Install DMG → launch app → should show "Starting Rhythm…" then load (no manual server needed)
- [ ] Confirm `Contents/Resources/api_server/dist/server.js` exists in the `.app`
- [ ] Quit app → node process exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)