### PR TITLE
fix: sign .node native addons and extend notarytool timeout to 30m

### DIFF
--- a/tools/release/sign_and_notarize_macos.sh
+++ b/tools/release/sign_and_notarize_macos.sh
@@ -76,12 +76,14 @@ fi
 # Sign nested frameworks and binaries from the inside out with Hardened Runtime.
 # codesign --deep does NOT propagate --options runtime to nested items, so we
 # must sign each one explicitly before signing the top-level bundle.
+# This includes .node native addons (e.g. better_sqlite3.node) bundled in
+# Contents/Resources — Apple requires all native binaries to be signed.
 while IFS= read -r -d '' item; do
   codesign --force --options runtime --timestamp \
     --sign "${IDENTITY_SHA}" \
     "${item}"
-done < <(find "${APP_PATH}/Contents/Frameworks" \
-  \( -name "*.framework" -o -name "*.dylib" -o -name "*.so" \) \
+done < <(find "${APP_PATH}/Contents" \
+  \( -name "*.framework" -o -name "*.dylib" -o -name "*.so" -o -name "*.node" \) \
   -print0 | sort -rz)
 
 codesign --force --options runtime --timestamp \
@@ -112,6 +114,7 @@ xcrun notarytool submit "${DMG_PATH}" \
   --password "${APPLE_APP_SPECIFIC_PASSWORD}" \
   --team-id "${APPLE_TEAM_ID}" \
   --wait \
+  --timeout 30m \
   > "${NOTARY_OUTPUT}"
 
 SUBMISSION_ID="$(awk '/^[[:space:]]+id:/ { print $2; exit }' "${NOTARY_OUTPUT}")"


### PR DESCRIPTION
## Summary
- **Root cause 1**: `better_sqlite3.node` (the native SQLite addon bundled in `Contents/Resources/api_server/node_modules/`) was not being code-signed — Apple rejects notarization for any unsigned native binary anywhere in the bundle. Fixed by expanding the `find` in the signing script from `Contents/Frameworks` to all of `Contents/`.
- **Root cause 2**: `notarytool submit --wait` timed out with a network error, likely because the larger app (with `node_modules`) takes longer to upload. Added `--timeout 30m`.

## Test plan
- [ ] Build succeeds and notarization completes without timeout
- [ ] `codesign -vvv` shows `better_sqlite3.node` is signed
- [ ] Stapled DMG installs and launches without Gatekeeper warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)