### PR TITLE
feat: fix sticky error state, add delete confirmation, and add due-date sort

### DIFF
--- a/apps/desktop_flutter/lib/features/tasks/controllers/tasks_controller.dart
+++ b/apps/desktop_flutter/lib/features/tasks/controllers/tasks_controller.dart
@@ -31,12 +31,20 @@ class TasksController extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> createTask(String title,
-      {String? notes, String? dueDate}) async {
+  Future<void> createTask(
+    String title, {
+    String? notes,
+    String? dueDate,
+  }) async {
     try {
-      final task =
-          await _repository.create(title, notes: notes, dueDate: dueDate);
+      final task = await _repository.create(
+        title,
+        notes: notes,
+        dueDate: dueDate,
+      );
       _tasks = [..._tasks, task];
+      _status = TasksStatus.idle;
+      _errorMessage = null;
       notifyListeners();
     } catch (e) {
       _errorMessage = e.toString();
@@ -45,12 +53,22 @@ class TasksController extends ChangeNotifier {
     }
   }
 
-  Future<void> updateTask(String id,
-      {String? title, String? notes, String? dueDate}) async {
+  Future<void> updateTask(
+    String id, {
+    String? title,
+    String? notes,
+    String? dueDate,
+  }) async {
     try {
-      final updated = await _repository.update(id,
-          title: title, notes: notes, dueDate: dueDate);
+      final updated = await _repository.update(
+        id,
+        title: title,
+        notes: notes,
+        dueDate: dueDate,
+      );
       _tasks = _tasks.map((t) => t.id == id ? updated : t).toList();
+      _status = TasksStatus.idle;
+      _errorMessage = null;
       notifyListeners();
     } catch (e) {
       _errorMessage = e.toString();
@@ -65,6 +83,8 @@ class TasksController extends ChangeNotifier {
     try {
       final updated = await _repository.update(id, status: newStatus);
       _tasks = _tasks.map((t) => t.id == id ? updated : t).toList();
+      _status = TasksStatus.idle;
+      _errorMessage = null;
       notifyListeners();
     } catch (e) {
       _errorMessage = e.toString();
@@ -77,6 +97,8 @@ class TasksController extends ChangeNotifier {
     try {
       await _repository.delete(id);
       _tasks = _tasks.where((t) => t.id != id).toList();
+      _status = TasksStatus.idle;
+      _errorMessage = null;
       notifyListeners();
     } catch (e) {
       _errorMessage = e.toString();

--- a/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
@@ -17,6 +17,7 @@ class _TasksViewState extends State<TasksView> {
   final _notesController = TextEditingController();
   String? _selectedDueDate;
   bool _showCompleted = false;
+  bool _sortByDueDate = false;
 
   @override
   void initState() {
@@ -42,7 +43,8 @@ class _TasksViewState extends State<TasksView> {
     );
     if (picked != null) {
       setState(
-          () => _selectedDueDate = picked.toIso8601String().substring(0, 10));
+        () => _selectedDueDate = picked.toIso8601String().substring(0, 10),
+      );
     }
   }
 
@@ -51,10 +53,10 @@ class _TasksViewState extends State<TasksView> {
     if (title.isEmpty) return;
     final notes = _notesController.text.trim();
     await context.read<TasksController>().createTask(
-          title,
-          notes: notes.isEmpty ? null : notes,
-          dueDate: _selectedDueDate,
-        );
+      title,
+      notes: notes.isEmpty ? null : notes,
+      dueDate: _selectedDueDate,
+    );
     _titleController.clear();
     _notesController.clear();
     setState(() => _selectedDueDate = null);
@@ -82,12 +84,22 @@ class _TasksViewState extends State<TasksView> {
   }
 
   Widget _buildHeader(BuildContext context) {
+    final primaryColor = Theme.of(context).colorScheme.primary;
     return Padding(
       padding: const EdgeInsets.fromLTRB(24, 24, 24, 8),
       child: Row(
         children: [
           Text('Tasks', style: Theme.of(context).textTheme.headlineSmall),
           const Spacer(),
+          IconButton(
+            icon: Icon(
+              Icons.calendar_today,
+              size: 18,
+              color: _sortByDueDate ? primaryColor : null,
+            ),
+            tooltip: _sortByDueDate ? 'Sorted by due date' : 'Sort by due date',
+            onPressed: () => setState(() => _sortByDueDate = !_sortByDueDate),
+          ),
           TextButton.icon(
             onPressed: () => setState(() => _showCompleted = !_showCompleted),
             icon: Icon(
@@ -102,9 +114,17 @@ class _TasksViewState extends State<TasksView> {
   }
 
   Widget _buildTaskList(TasksController controller) {
-    final visibleTasks = _showCompleted
-        ? controller.tasks
+    var visibleTasks = _showCompleted
+        ? controller.tasks.toList()
         : controller.tasks.where((task) => task.status != 'done').toList();
+    if (_sortByDueDate) {
+      visibleTasks.sort((a, b) {
+        if (a.dueDate == null && b.dueDate == null) return 0;
+        if (a.dueDate == null) return 1;
+        if (b.dueDate == null) return -1;
+        return a.dueDate!.compareTo(b.dueDate!);
+      });
+    }
     if (controller.status == TasksStatus.loading && controller.tasks.isEmpty) {
       return const Center(child: CircularProgressIndicator());
     }
@@ -164,11 +184,35 @@ class _TasksViewState extends State<TasksView> {
           IconButton(
             icon: const Icon(Icons.delete_outline, size: 18),
             tooltip: 'Delete',
-            onPressed: () => controller.deleteTask(task.id),
+            onPressed: () => _confirmDelete(task, controller),
           ),
         ],
       ),
     );
+  }
+
+  Future<void> _confirmDelete(Task task, TasksController controller) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete task?'),
+        content: Text('Delete "${task.title}"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) controller.deleteTask(task.id);
   }
 
   Future<void> _showEditDialog(Task task, TasksController controller) async {
@@ -285,14 +329,18 @@ class _EditTaskDialogState extends State<_EditTaskDialog> {
             TextField(
               controller: _titleController,
               decoration: const InputDecoration(
-                  labelText: 'Title', border: OutlineInputBorder()),
+                labelText: 'Title',
+                border: OutlineInputBorder(),
+              ),
               autofocus: true,
             ),
             const SizedBox(height: 12),
             TextField(
               controller: _notesController,
               decoration: const InputDecoration(
-                  labelText: 'Notes (optional)', border: OutlineInputBorder()),
+                labelText: 'Notes (optional)',
+                border: OutlineInputBorder(),
+              ),
               minLines: 2,
               maxLines: 5,
             ),
@@ -318,15 +366,17 @@ class _EditTaskDialogState extends State<_EditTaskDialog> {
       ),
       actions: [
         TextButton(
-            onPressed: _saving ? null : () => Navigator.pop(context),
-            child: const Text('Cancel')),
+          onPressed: _saving ? null : () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
         FilledButton(
           onPressed: _saving ? null : _save,
           child: _saving
               ? const SizedBox(
                   width: 16,
                   height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2))
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
               : const Text('Save'),
         ),
       ],


### PR DESCRIPTION
## Summary

- **#109 — Fix sticky error state**: After every successful mutation (`createTask`, `updateTask`, `toggleDone`, `deleteTask`) in `TasksController`, `_status` is now reset to `TasksStatus.idle` and `_errorMessage` is cleared before `notifyListeners()`. Previously a failed call would leave the error banner visible indefinitely even after subsequent successes.

- **#110 — Delete confirmation dialog**: Tapping the delete icon in the Tasks list now shows an `AlertDialog` ("Delete task?") with Cancel and Delete buttons before calling `controller.deleteTask()`. The Delete button is styled with the error color, matching the pattern from `RhythmsView._confirmDelete`.

- **#111 — Due-date sorting**: A `calendar_today` icon button has been added to the Tasks header row. Tapping it toggles `_sortByDueDate`; the icon renders in the theme primary color when active. When sorting is on, the visible task list is sorted by `dueDate` ascending with null due dates sorted last.

## Test plan

- [ ] Trigger a network error on a task mutation; confirm error banner appears
- [ ] Perform a successful mutation after the error; confirm error banner clears
- [ ] Tap the delete icon on a task; confirm confirmation dialog appears
- [ ] Confirm Cancel does not delete the task; confirm Delete does
- [ ] Tap the sort icon; confirm tasks reorder by due date (nulls at bottom)
- [ ] Tap again; confirm sort is deactivated and tasks return to insertion order
- [ ] `flutter analyze --no-fatal-infos` passes with no issues

Closes #109, Closes #110, Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)