### PR TITLE
feat: wire Projects page to live API data

### DIFF
--- a/apps/web/src/hooks/useApi.ts
+++ b/apps/web/src/hooks/useApi.ts
@@ -1,0 +1,95 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../lib/api';
+
+export function useTasks() {
+  return useQuery({ queryKey: ['tasks'], queryFn: () => api.get('/tasks').then(r => r.data) });
+}
+
+export function useCreateTask() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: any) => api.post('/tasks', data).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tasks'] }),
+  });
+}
+
+export function useRecurringRules() {
+  return useQuery({ queryKey: ['recurring-rules'], queryFn: () => api.get('/recurring-rules').then(r => r.data) });
+}
+
+export function useUpdateRecurringRule() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...data }: any) => api.patch(`/recurring-rules/${id}`, data).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['recurring-rules'] }),
+  });
+}
+
+export function useCreateRecurringRule() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: any) => api.post('/recurring-rules', data).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['recurring-rules'] }),
+  });
+}
+
+export function useProjectInstances() {
+  return useQuery({ queryKey: ['project-instances'], queryFn: () => api.get('/project-instances').then(r => r.data) });
+}
+
+export function useProjectTemplates() {
+  return useQuery({ queryKey: ['project-templates'], queryFn: () => api.get('/project-templates').then(r => r.data) });
+}
+
+export function useFacilities() {
+  return useQuery({ queryKey: ['facilities'], queryFn: () => api.get('/facilities').then(r => r.data) });
+}
+
+export function useFacilityReservations(facilityId: number) {
+  return useQuery({
+    queryKey: ['reservations', facilityId],
+    queryFn: () => api.get(`/facilities/${facilityId}/reservations`).then(r => r.data),
+  });
+}
+
+export function useCreateReservation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ facilityId, ...data }: { facilityId: number; title: string; reservedBy: string; startTime: string; endTime: string; notes?: string }) =>
+      api.post(`/facilities/${facilityId}/reservations`, data).then(r => r.data),
+    onSuccess: (_: unknown, { facilityId }: { facilityId: number }) =>
+      qc.invalidateQueries({ queryKey: ['reservations', facilityId] }),
+  });
+}
+
+export function useMessageThreads() {
+  return useQuery({ queryKey: ['message-threads'], queryFn: () => api.get('/message-threads').then(r => r.data) });
+}
+
+export function useCreateMessageThread() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { title: string }) => api.post('/message-threads', data).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['message-threads'] }),
+  });
+}
+
+export function useThreadMessages(threadId: number | null) {
+  return useQuery({
+    queryKey: ['messages', threadId],
+    queryFn: () => api.get(`/message-threads/${threadId}/messages`).then(r => r.data),
+    enabled: threadId !== null,
+  });
+}
+
+export function useSendMessage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ threadId, ...data }: { threadId: number; senderName: string; body: string }) =>
+      api.post(`/message-threads/${threadId}/messages`, data).then(r => r.data),
+    onSuccess: (_: unknown, { threadId }: { threadId: number }) => {
+      qc.invalidateQueries({ queryKey: ['messages', threadId] });
+      qc.invalidateQueries({ queryKey: ['message-threads'] });
+    },
+  });
+}

--- a/apps/web/src/pages/Projects.tsx
+++ b/apps/web/src/pages/Projects.tsx
@@ -1,0 +1,111 @@
+import { Plus, Loader2 } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/PageHeader";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { useProjectInstances } from "@/hooks/useApi";
+import { motion } from "framer-motion";
+
+const statusColors: Record<string, string> = {
+  active: "bg-success/10 text-success",
+  planning: "bg-info/10 text-info",
+  complete: "bg-secondary text-secondary-foreground",
+};
+
+interface ApiStep {
+  id: number;
+  title: string;
+  dueDate: string;
+  status: "open" | "done";
+}
+
+interface ApiProject {
+  id: number;
+  name: string;
+  status: "active" | "complete";
+  anchorDate: string;
+  templateId: number;
+  steps: ApiStep[];
+}
+
+export default function Projects() {
+  const { data: projects, isLoading, isError } = useProjectInstances();
+
+  return (
+    <motion.div
+      className="p-4 sm:p-6 lg:p-8 space-y-6 max-w-4xl"
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35 }}
+    >
+      <PageHeader title="Projects" description="Track collaborative work across the team.">
+        <Button size="sm">
+          <Plus className="h-4 w-4 mr-1.5" /> New Project
+        </Button>
+      </PageHeader>
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {isError && (
+        <p className="text-sm text-destructive">Failed to load projects. Please try again.</p>
+      )}
+
+      {!isLoading && !isError && (
+        <div className="space-y-4">
+          {(projects as ApiProject[])?.map((project) => {
+            const steps: ApiStep[] = project.steps ?? [];
+            const stepsTotal = steps.length;
+            const stepsComplete = steps.filter((s) => s.status === "done").length;
+            const progress = stepsTotal > 0 ? Math.round((stepsComplete / stepsTotal) * 100) : 0;
+            const nextStep = steps.find((s) => s.status === "open");
+
+            return (
+              <Card key={project.id} className="shadow-sm border-border/60 hover:shadow-md transition-shadow cursor-pointer">
+                <CardContent className="p-5">
+                  <div className="flex items-start justify-between mb-3">
+                    <div className="min-w-0">
+                      <h3 className="text-base font-semibold text-foreground truncate">{project.name}</h3>
+                      {project.anchorDate && (
+                        <p className="text-xs text-muted-foreground">
+                          Due {new Date(project.anchorDate).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                        </p>
+                      )}
+                    </div>
+                    <Badge className={`${statusColors[project.status] ?? "bg-secondary text-secondary-foreground"} text-[10px] font-medium border-0 shrink-0 capitalize`}>
+                      {project.status}
+                    </Badge>
+                  </div>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="text-muted-foreground">{stepsComplete} of {stepsTotal} steps</span>
+                      <span className="font-medium text-foreground">{progress}%</span>
+                    </div>
+                    <Progress value={progress} className="h-2" />
+                  </div>
+
+                  {nextStep && (
+                    <div className="mt-3 px-3 py-2 rounded-lg bg-accent/50 border border-accent">
+                      <p className="text-xs text-muted-foreground">
+                        Next step: <span className="font-medium text-foreground">{nextStep.title}</span>
+                      </p>
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+
+          {!projects?.length && (
+            <p className="text-sm text-muted-foreground text-center py-8">No projects yet.</p>
+          )}
+        </div>
+      )}
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary
- Projects page: replaces mockProjects with useProjectInstances()
- Computes progress, stepsComplete, stepsTotal, nextStep from API step data
- Shows loading spinner and error state
- Hides owner avatar (no owner field in API yet)
- Adds useProjectTemplates() hook to useApi.ts

🤖 Generated with Claude Code