### PR TITLE
feat: Flutter light theme + configurable server URL (Rhythm 2.0 foundation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,227 @@
 4. **Only merge to `main` on GitHub after the user confirms testing is successful.**
 
 Never merge a PR automatically. Always leave it open for human review and sign-off.
+
+---
+
+## Project Overview
+
+Rhythm is a macOS desktop productivity app for church staff. It manages tasks, recurring rhythms, projects, messaging, and facility reservations.
+
+**Rhythm 2.0 goal:** Adopt the team-weaver React web app's light UI design inside the Flutter desktop app, and add new screens (Dashboard, Messages, Facilities). The Electron/React `apps/web` and `apps/electron` directories are a prototype/reference — they are NOT the shipping product. The Flutter app is the desktop client.
+
+---
+
+## Monorepo Structure
+
+```
+/Users/ajhochhalter/Documents/Rhythm/
+├── apps/
+│   ├── desktop_flutter/       ← macOS desktop app (Flutter) — THE SHIPPING CLIENT
+│   │   ├── lib/
+│   │   │   ├── main.dart      ← Entry point; MultiProvider setup; launches ServerConfigService
+│   │   │   └── app/
+│   │   │       ├── theme/
+│   │   │       │   └── app_theme.dart              ← Light theme (white bg, #4F6AF5 primary)
+│   │   │       ├── core/
+│   │   │       │   ├── constants/app_constants.dart ← apiBaseUrl fallback default
+│   │   │       │   ├── layout/
+│   │   │       │   │   ├── app_shell.dart           ← Root layout; server status gating; nav switching
+│   │   │       │   │   └── navigation_sidebar.dart  ← Light sidebar (#F8F9FA); nav items + gear
+│   │   │       │   ├── server/
+│   │   │       │   │   ├── api_server_service.dart  ← Spawns local Node server process; polls /health
+│   │   │       │   │   └── api_server_controller.dart ← ChangeNotifier; starting/ready/failed states
+│   │   │       │   └── services/
+│   │   │       │       └── server_config_service.dart ← Persists server URL via shared_preferences
+│   │   │       └── features/
+│   │   │           ├── tasks/
+│   │   │           │   ├── views/tasks_view.dart
+│   │   │           │   ├── views/automation_rules_view.dart
+│   │   │           │   ├── controllers/tasks_controller.dart
+│   │   │           │   ├── controllers/automation_rules_controller.dart
+│   │   │           │   ├── models/task.dart
+│   │   │           │   ├── models/recurring_task_rule.dart
+│   │   │           │   ├── repositories/tasks_repository.dart
+│   │   │           │   └── data/tasks_local_data_source.dart
+│   │   │           ├── rhythms/
+│   │   │           │   ├── views/rhythms_view.dart
+│   │   │           │   ├── controllers/rhythms_controller.dart
+│   │   │           │   ├── repositories/rhythms_repository.dart
+│   │   │           │   └── data/rhythms_data_source.dart
+│   │   │           ├── projects/
+│   │   │           │   ├── views/projects_view.dart
+│   │   │           │   ├── controllers/project_template_controller.dart
+│   │   │           │   ├── repositories/project_template_repository.dart
+│   │   │           │   └── data/project_template_data_source.dart (also projects_local_data_source.dart)
+│   │   │           ├── weekly_planner/
+│   │   │           │   ├── views/weekly_planner_view.dart
+│   │   │           │   ├── controllers/weekly_planner_controller.dart
+│   │   │           │   └── data/weekly_plan_data_source.dart
+│   │   │           ├── integrations/
+│   │   │           │   ├── views/integrations_view.dart
+│   │   │           │   ├── controllers/integrations_controller.dart
+│   │   │           │   └── data/integrations_data_source.dart
+│   │   │           ├── settings/
+│   │   │           │   └── views/settings_view.dart  ← Server URL config screen
+│   │   │           └── imports/
+│   │   │               └── views/import_dialog.dart
+│   │   ├── macos/Runner/
+│   │   │   ├── Release.entitlements   ← No app-sandbox (allows child process spawning)
+│   │   │   └── DebugProfile.entitlements
+│   │   └── pubspec.yaml               ← deps: flutter, http, provider, window_manager,
+│   │                                       shared_preferences, package_info_plus, url_launcher
+│   ├── api_server/                    ← Node.js/TypeScript Express API (SQLite via better-sqlite3)
+│   │   ├── src/
+│   │   │   ├── server.ts              ← Express app entry; PORT=4000
+│   │   │   ├── app.ts                 ← Route registrations
+│   │   │   ├── database/
+│   │   │   │   └── migrations.ts      ← All CREATE TABLE IF NOT EXISTS / ALTER TABLE migrations
+│   │   │   ├── models/                ← TypeScript interfaces for each entity
+│   │   │   ├── repositories/          ← SQLite query layer (one file per entity)
+│   │   │   ├── controllers/           ← Request handlers (one file per entity)
+│   │   │   └── routes/                ← Express routers (one file per entity)
+│   │   │       └── health_routes.ts   ← GET /health — used by Flutter to detect server readiness
+│   │   └── package.json               ← scripts: dev (tsx), build (tsc), start (node dist/)
+│   ├── web/                           ← React/Vite UI (team-weaver design reference + prototype)
+│   │   └── src/
+│   │       ├── hooks/useApi.ts        ← React Query hooks for all API endpoints
+│   │       └── pages/                 ← Tasks, Projects, Rhythms, Messages, Facilities, Dashboard
+│   └── electron/                      ← Electron wrapper for the web app (prototype only)
+├── tools/release/
+│   └── sign_and_notarize_macos.sh    ← Signs all .node/.dylib/binaries, notarizes .app
+├── .github/workflows/
+│   ├── desktop_release.yml           ← Flutter macOS build + sign + notarize + GitHub Release
+│   └── electron_release.yml          ← Electron build (prototype, not primary)
+└── CLAUDE.md                          ← This file
+```
+
+---
+
+## Flutter Architecture Pattern
+
+Every feature follows this exact layered pattern:
+
+```
+views/foo_view.dart          ← StatefulWidget; reads controller via context.watch/read
+controllers/foo_controller.dart  ← ChangeNotifier; status enum (idle/loading/error); methods
+repositories/foo_repository.dart ← Calls data source; maps DTOs to models
+data/foo_data_source.dart    ← HTTP calls; accepts baseUrl constructor param
+models/foo.dart              ← Plain Dart class with fromJson/toJson
+```
+
+**Provider wiring** (main.dart MultiProvider):
+- All controllers are `ChangeNotifierProvider`
+- `ServerConfigService` is also a `ChangeNotifierProvider`
+- Data sources get `serverConfigService.url` passed at construction time
+
+**Navigation** is index-based in `app_shell.dart`. The sidebar sets `_currentIndex`, the body switches on it.
+
+---
+
+## API Server Endpoints
+
+Base: `http://localhost:4000` (default, configurable)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | /health | Server health check |
+| GET/POST | /tasks | List / create tasks |
+| PATCH/DELETE | /tasks/:id | Update / delete task |
+| GET/POST | /recurring-rules | List / create rhythms |
+| PATCH/DELETE | /recurring-rules/:id | Update / delete rhythm |
+| GET/POST | /project-templates | List / create project templates |
+| GET/POST | /project-templates/:id/steps | List / add steps |
+| PATCH/DELETE | /project-templates/:id/steps/:stepId | Update / delete step |
+| GET/POST | /project-instances | List / create project instances |
+| GET/POST | /project-instances/:id/steps | Steps for an instance |
+| GET/POST | /automation-rules | Automation rules |
+| PATCH/DELETE | /automation-rules/:id | |
+| GET | /integrations | OAuth integration list |
+| GET/POST | /message-threads | Thread list / create thread |
+| GET/POST | /message-threads/:id/messages | Messages in thread / send message |
+| GET/POST | /facilities | Facility list / create facility |
+| GET/POST | /facilities/:id/reservations | Reservations / create reservation |
+| GET/POST | /users | User list / create user |
+
+---
+
+## Theme Tokens (Rhythm 2.0 Light Theme)
+
+```dart
+// Colors
+sidebar bg:        Color(0xFFF8F9FA)
+sidebar border:    Color(0xFFE5E7EB)
+content bg:        Color(0xFFFFFFFF)
+card bg:           Color(0xFFFFFFFF)
+card border:       Color(0xFFE5E7EB)
+primary:           Color(0xFF4F6AF5)
+primary tint:      Color(0x144F6AF5)  // selected nav item bg
+text primary:      Color(0xFF111827)
+text secondary:    Color(0xFF6B7280)
+text muted:        Color(0xFF9CA3AF)
+error:             Color(0xFFEF4444)
+success:           Color(0xFF10B981)
+divider:           Color(0xFFE5E7EB)
+```
+
+All new screens must use these tokens via `Theme.of(context).colorScheme` where possible, or the constants above.
+
+---
+
+## New Screens To Build (Rhythm 2.0)
+
+Three screens are planned as separate PRs. Nav placeholders exist in `app_shell.dart` as `_ComingSoonView`.
+
+### Dashboard (index 0)
+- Summary of open tasks (count + "due this week")
+- Active rhythms count
+- Active projects with their next step
+- Quick-add task button
+- All data from existing endpoints — no new API work needed
+
+### Messages (index 5)
+- Left panel: thread list (`GET /message-threads`) with title, unread dot (activity in last 24h), timestamp
+- Right panel: message list (`GET /message-threads/:id/messages`) + reply input
+- "New Message" button → dialog to create thread (`POST /message-threads`)
+- Reply sends `POST /message-threads/:id/messages`
+
+### Facilities (index 6)
+- Card grid of facilities (`GET /facilities`)
+- Each card: name, reservation count badge, Reserve button
+- Reserve opens dialog: title, reservedBy, startTime, endTime, notes → `POST /facilities/:id/reservations`
+- Top-level "Reserve Space" button with facility selector dropdown
+
+---
+
+## Local Development
+
+```bash
+# API server (dev)
+cd apps/api_server && npm run dev      # Runs on :4000, hot-reloads with tsx
+
+# Flutter desktop app
+cd apps/desktop_flutter && flutter run -d macos
+
+# React web prototype (reference only)
+cd apps/web && npm run dev             # Runs on :5173
+```
+
+**DB path (local):** `~/Library/Application Support/Rhythm/rhythm.db`
+
+---
+
+## CI / Release
+
+- **Trigger:** `workflow_dispatch` in `.github/workflows/desktop_release.yml`
+- **Secrets used:** `APPLE_CERT_BASE64`, `APPLE_CERT_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_NOTARY_KEY_ID`, `APPLE_NOTARY_KEY_ISSUER`, `APPLE_NOTARY_KEY_BASE64`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `PCO_APPLICATION_ID`, `PCO_SECRET`, `PCO_REDIRECT_URI`
+- **Steps:** flutter build → bundle api_server → sign all binaries → notarize → upload DMG
+
+---
+
+## Key Constraints
+
+- **No app-sandbox** — entitlements intentionally remove sandbox to allow `Process.start` (spawning the Node.js server). Non-App-Store distribution only.
+- **Login shell for Node discovery** — GUI apps on macOS strip PATH. Use `/bin/zsh -l -c 'which node'` not `/bin/sh`.
+- **`better-sqlite3` ABI** — Must be compiled with the same Node version the app will use at runtime. `prebuild-install` often downloads wrong binary. Use `node-gyp rebuild` if ABI mismatch.
+- **`dart format .`** — Always run before committing. CI fails on format violations (`--set-exit-if-changed`).
+- **`flutter analyze --no-fatal-infos`** — Must pass before opening a PR.

--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -68,16 +68,19 @@ class _ServerLoadingView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    final cs = Theme.of(context).colorScheme;
+    return Scaffold(
+      backgroundColor: const Color(0xFFFFFFFF),
       body: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            CircularProgressIndicator(),
-            SizedBox(height: 20),
+            CircularProgressIndicator(color: cs.primary),
+            const SizedBox(height: 20),
             Text(
-              'Starting Rhythm…',
-              style: TextStyle(fontSize: 16, color: Colors.black54),
+              'Starting Rhythm\u2026',
+              style: TextStyle(
+                  fontSize: 16, color: cs.onSurface.withValues(alpha: 0.6)),
             ),
           ],
         ),
@@ -97,21 +100,23 @@ class _ServerFailedView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     return Scaffold(
+      backgroundColor: const Color(0xFFFFFFFF),
       body: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(Icons.error_outline, size: 48, color: Colors.red),
+            Icon(Icons.error_outline, size: 48, color: cs.error),
             const SizedBox(height: 16),
-            const Text(
+            Text(
               'Could not start the Rhythm server.',
-              style: TextStyle(fontSize: 16),
+              style: TextStyle(fontSize: 16, color: cs.onSurface),
             ),
             const SizedBox(height: 8),
-            const Text(
+            Text(
               'Make sure Node.js is installed and try again.',
-              style: TextStyle(color: Colors.black54),
+              style: TextStyle(color: cs.onSurface.withValues(alpha: 0.6)),
             ),
             const SizedBox(height: 24),
             FilledButton(
@@ -129,6 +134,9 @@ class _ServerFailedView extends StatelessWidget {
 // Normal app content (shown once server is ready)
 // ---------------------------------------------------------------------------
 
+// New order: Dashboard(0), Tasks(1), Rhythms(2), Projects(3),
+//            Weekly Planner(4), Messages(5), Facilities(6),
+//            Automations(7), Integrations(8)
 class _AppContent extends StatelessWidget {
   const _AppContent({
     required this.selectedIndex,
@@ -138,13 +146,16 @@ class _AppContent extends StatelessWidget {
   final int selectedIndex;
   final ValueChanged<int> onItemSelected;
 
-  static const _views = [
-    WeeklyPlannerView(),
-    TasksView(),
-    RhythmsView(),
-    ProjectsView(),
-    AutomationRulesView(),
-    IntegrationsView(),
+  static const _views = <Widget>[
+    _ComingSoonView(label: 'Dashboard'), // 0
+    TasksView(), // 1
+    RhythmsView(), // 2
+    ProjectsView(), // 3
+    WeeklyPlannerView(), // 4
+    _ComingSoonView(label: 'Messages'), // 5
+    _ComingSoonView(label: 'Facilities'), // 6
+    AutomationRulesView(), // 7
+    IntegrationsView(), // 8
   ];
 
   @override
@@ -160,6 +171,26 @@ class _AppContent extends StatelessWidget {
           ),
           Expanded(child: _views[selectedIndex]),
         ],
+      ),
+    );
+  }
+}
+
+class _ComingSoonView extends StatelessWidget {
+  const _ComingSoonView({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Text(
+          '$label \u2014 Coming soon',
+          style: Theme.of(context)
+              .textTheme
+              .titleMedium
+              ?.copyWith(color: const Color(0xFF6B7280)),
+        ),
       ),
     );
   }

--- a/apps/desktop_flutter/lib/app/core/layout/navigation_sidebar.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/navigation_sidebar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../features/settings/views/settings_view.dart';
 import '../updates/update_controller.dart';
 
 class NavigationSidebar extends StatelessWidget {
@@ -15,10 +16,13 @@ class NavigationSidebar extends StatelessWidget {
   final UpdateController updateController;
 
   static const _items = [
-    _NavItem(icon: Icons.calendar_view_week, label: 'Weekly Planner'),
+    _NavItem(icon: Icons.dashboard_outlined, label: 'Dashboard'),
     _NavItem(icon: Icons.check_circle_outline, label: 'Tasks'),
     _NavItem(icon: Icons.repeat, label: 'Rhythms'),
     _NavItem(icon: Icons.folder_open, label: 'Projects'),
+    _NavItem(icon: Icons.calendar_view_week, label: 'Weekly Planner'),
+    _NavItem(icon: Icons.chat_bubble_outline, label: 'Messages'),
+    _NavItem(icon: Icons.meeting_room_outlined, label: 'Facilities'),
     _NavItem(icon: Icons.auto_awesome, label: 'Automations'),
     _NavItem(icon: Icons.link, label: 'Integrations'),
   ];
@@ -27,18 +31,26 @@ class NavigationSidebar extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       width: 240,
-      color: const Color(0xFF1F1F1F),
+      decoration: const BoxDecoration(
+        color: Color(0xFFF8F9FA),
+        border: Border(
+          right: BorderSide(color: Color(0xFFE5E7EB)),
+        ),
+      ),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Padding(
             padding: EdgeInsets.only(bottom: 24),
-            child: Text('Rhythm',
-                style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold)),
+            child: Text(
+              'Rhythm',
+              style: TextStyle(
+                color: Color(0xFF111827),
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
           ),
           for (int i = 0; i < _items.length; i++) ...[
             _NavItemTile(
@@ -50,6 +62,8 @@ class NavigationSidebar extends StatelessWidget {
           ],
           const Spacer(),
           _UpdatePanel(controller: updateController),
+          const SizedBox(height: 8),
+          _SettingsButton(),
         ],
       ),
     );
@@ -74,26 +88,58 @@ class _NavItemTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return InkWell(
       onTap: onTap,
-      borderRadius: BorderRadius.circular(8),
+      borderRadius: BorderRadius.circular(6),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
         decoration: BoxDecoration(
-          color: isSelected
-              ? Colors.white.withValues(alpha: 0.12)
-              : Colors.transparent,
-          borderRadius: BorderRadius.circular(8),
+          color: isSelected ? const Color(0x144F6AF5) : Colors.transparent,
+          borderRadius: BorderRadius.circular(6),
         ),
         child: Row(
           children: [
-            Icon(item.icon,
-                color: isSelected ? Colors.white : Colors.white60, size: 18),
+            Icon(
+              item.icon,
+              color: isSelected
+                  ? const Color(0xFF4F6AF5)
+                  : const Color(0xFF6B7280),
+              size: 18,
+            ),
             const SizedBox(width: 10),
             Text(
               item.label,
               style: TextStyle(
-                color: isSelected ? Colors.white : Colors.white70,
+                color: isSelected
+                    ? const Color(0xFF4F6AF5)
+                    : const Color(0xFF6B7280),
                 fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
               ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsButton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute<void>(builder: (_) => const SettingsView()),
+        );
+      },
+      borderRadius: BorderRadius.circular(6),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        child: const Row(
+          children: [
+            Icon(Icons.settings_outlined, color: Color(0xFF6B7280), size: 18),
+            SizedBox(width: 10),
+            Text(
+              'Settings',
+              style: TextStyle(color: Color(0xFF6B7280)),
             ),
           ],
         ),
@@ -118,9 +164,9 @@ class _UpdatePanel extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.06),
+        color: const Color(0xFFFFFFFF),
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.white12),
+        border: Border.all(color: const Color(0xFFE5E7EB)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -128,26 +174,26 @@ class _UpdatePanel extends StatelessWidget {
           const Text(
             'App updates',
             style: TextStyle(
-              color: Colors.white,
+              color: Color(0xFF111827),
               fontWeight: FontWeight.w600,
             ),
           ),
           const SizedBox(height: 6),
           Text(
             versionLabel,
-            style: const TextStyle(color: Colors.white70, fontSize: 12),
+            style: const TextStyle(color: Color(0xFF6B7280), fontSize: 12),
           ),
           const SizedBox(height: 10),
           if (controller.isChecking)
             const Text(
               'Checking GitHub releases...',
-              style: TextStyle(color: Colors.white70, fontSize: 12),
+              style: TextStyle(color: Color(0xFF6B7280), fontSize: 12),
             )
           else if (update != null) ...[
             Text(
               'Update ready: ${update.version}${update.prerelease ? ' beta' : ''}',
               style: const TextStyle(
-                color: Colors.white,
+                color: Color(0xFF111827),
                 fontSize: 12,
                 fontWeight: FontWeight.w600,
               ),
@@ -171,14 +217,13 @@ class _UpdatePanel extends StatelessWidget {
           ] else ...[
             const Text(
               'You are on the latest release.',
-              style: TextStyle(color: Colors.white70, fontSize: 12),
+              style: TextStyle(color: Color(0xFF6B7280), fontSize: 12),
             ),
             if (controller.errorMessage != null) ...[
               const SizedBox(height: 8),
               Text(
                 controller.errorMessage!,
-                style:
-                    const TextStyle(color: Colors.orangeAccent, fontSize: 11),
+                style: const TextStyle(color: Color(0xFFEF4444), fontSize: 11),
               ),
             ],
           ],
@@ -213,14 +258,14 @@ class _SidebarButton extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
         decoration: BoxDecoration(
-          color: outlined ? Colors.transparent : Colors.white,
+          color: outlined ? Colors.transparent : const Color(0xFF4F6AF5),
           borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: Colors.white24),
+          border: Border.all(color: const Color(0xFFE5E7EB)),
         ),
         child: Text(
           label,
           style: TextStyle(
-            color: outlined ? Colors.white : const Color(0xFF1F1F1F),
+            color: outlined ? const Color(0xFF6B7280) : Colors.white,
             fontSize: 12,
             fontWeight: FontWeight.w600,
           ),

--- a/apps/desktop_flutter/lib/app/core/services/server_config_service.dart
+++ b/apps/desktop_flutter/lib/app/core/services/server_config_service.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ServerConfigService extends ChangeNotifier {
+  static const _key = 'server_url';
+  static const defaultUrl = 'http://localhost:4000';
+
+  String _url = defaultUrl;
+  String get url => _url;
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _url = prefs.getString(_key) ?? defaultUrl;
+    notifyListeners();
+  }
+
+  Future<void> save(String url) async {
+    final prefs = await SharedPreferences.getInstance();
+    final cleaned = url.trimRight().replaceAll(RegExp(r'/$'), '');
+    await prefs.setString(_key, cleaned);
+    _url = cleaned;
+    notifyListeners();
+  }
+}

--- a/apps/desktop_flutter/lib/app/theme/app_theme.dart
+++ b/apps/desktop_flutter/lib/app/theme/app_theme.dart
@@ -3,6 +3,38 @@ import 'package:flutter/material.dart';
 class AppTheme {
   static ThemeData light() => ThemeData(
         useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF4F6AF5)),
+        scaffoldBackgroundColor: const Color(0xFFFFFFFF),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFF4F6AF5),
+          brightness: Brightness.light,
+          surface: const Color(0xFFFFFFFF),
+          onSurface: const Color(0xFF111827),
+          outline: const Color(0xFFE5E7EB),
+        ).copyWith(
+          error: const Color(0xFFEF4444),
+        ),
+        cardTheme: CardThemeData(
+          color: const Color(0xFFFFFFFF),
+          elevation: 0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+            side: const BorderSide(color: Color(0xFFE5E7EB)),
+          ),
+        ),
+        dividerColor: const Color(0xFFE5E7EB),
+        inputDecorationTheme: InputDecorationTheme(
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: const BorderSide(color: Color(0xFFE5E7EB)),
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: const BorderSide(color: Color(0xFFE5E7EB)),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(8),
+            borderSide: const BorderSide(color: Color(0xFF4F6AF5), width: 2),
+          ),
+        ),
       );
 }

--- a/apps/desktop_flutter/lib/features/integrations/data/integrations_data_source.dart
+++ b/apps/desktop_flutter/lib/features/integrations/data/integrations_data_source.dart
@@ -8,11 +8,14 @@ import '../models/planning_center_task_options.dart';
 import '../models/planning_center_task_preferences.dart';
 
 class IntegrationsDataSource {
-  final _accountsBase =
-      Uri.parse('${AppConstants.apiBaseUrl}/integrations/accounts');
+  IntegrationsDataSource({String? baseUrl})
+      : _baseUrl = baseUrl ?? AppConstants.apiBaseUrl;
+
+  final String _baseUrl;
 
   Future<List<IntegrationAccount>> fetchAccounts() async {
-    final response = await http.get(_accountsBase);
+    final response =
+        await http.get(Uri.parse('$_baseUrl/integrations/accounts'));
     _assertOk(response);
     final list = jsonDecode(response.body) as List<dynamic>;
     return list
@@ -21,22 +24,21 @@ class IntegrationsDataSource {
         .toList();
   }
 
-  Uri googleBeginUri() =>
-      Uri.parse('${AppConstants.apiBaseUrl}/auth/google/begin');
+  Uri googleBeginUri() => Uri.parse('$_baseUrl/auth/google/begin');
 
   Uri planningCenterBeginUri() =>
-      Uri.parse('${AppConstants.apiBaseUrl}/auth/planning-center/begin');
+      Uri.parse('$_baseUrl/auth/planning-center/begin');
 
   Future<void> syncGoogleCalendar() async {
     final response = await http.post(
-      Uri.parse('${AppConstants.apiBaseUrl}/integrations/google-calendar/sync'),
+      Uri.parse('$_baseUrl/integrations/google-calendar/sync'),
     );
     _assertOk(response);
   }
 
   Future<List<GmailSignal>> fetchGmailSignals() async {
     final response = await http.get(
-      Uri.parse('${AppConstants.apiBaseUrl}/integrations/gmail/signals'),
+      Uri.parse('$_baseUrl/integrations/gmail/signals'),
     );
     _assertOk(response);
     final list = jsonDecode(response.body) as List<dynamic>;
@@ -47,14 +49,14 @@ class IntegrationsDataSource {
 
   Future<void> syncGmail() async {
     final response = await http.post(
-      Uri.parse('${AppConstants.apiBaseUrl}/integrations/gmail/sync'),
+      Uri.parse('$_baseUrl/integrations/gmail/sync'),
     );
     _assertOk(response);
   }
 
   Future<void> syncPlanningCenter() async {
     final response = await http.post(
-      Uri.parse('${AppConstants.apiBaseUrl}/integrations/planning-center/sync'),
+      Uri.parse('$_baseUrl/integrations/planning-center/sync'),
     );
     _assertOk(response);
   }
@@ -63,7 +65,7 @@ class IntegrationsDataSource {
       fetchPlanningCenterTaskPreferences() async {
     final response = await http.get(
       Uri.parse(
-        '${AppConstants.apiBaseUrl}/integrations/planning-center/task-preferences',
+        '$_baseUrl/integrations/planning-center/task-preferences',
       ),
     );
     _assertOk(response);
@@ -75,7 +77,7 @@ class IntegrationsDataSource {
   Future<PlanningCenterTaskOptions> fetchPlanningCenterTaskOptions() async {
     final response = await http.get(
       Uri.parse(
-        '${AppConstants.apiBaseUrl}/integrations/planning-center/task-options',
+        '$_baseUrl/integrations/planning-center/task-options',
       ),
     );
     _assertOk(response);
@@ -89,7 +91,7 @@ class IntegrationsDataSource {
   ) async {
     final response = await http.put(
       Uri.parse(
-        '${AppConstants.apiBaseUrl}/integrations/planning-center/task-preferences',
+        '$_baseUrl/integrations/planning-center/task-preferences',
       ),
       headers: const {'Content-Type': 'application/json'},
       body: jsonEncode(preferences.toJson()),

--- a/apps/desktop_flutter/lib/features/projects/data/projects_local_data_source.dart
+++ b/apps/desktop_flutter/lib/features/projects/data/projects_local_data_source.dart
@@ -6,10 +6,13 @@ import '../models/project_template.dart';
 import '../models/project_template_step.dart';
 
 class ProjectsLocalDataSource {
-  final _base = Uri.parse('${AppConstants.apiBaseUrl}/project-templates');
+  ProjectsLocalDataSource({String? baseUrl})
+      : _baseUrl = baseUrl ?? AppConstants.apiBaseUrl;
+
+  final String _baseUrl;
 
   Future<List<ProjectTemplate>> fetchAll() async {
-    final response = await http.get(_base);
+    final response = await http.get(Uri.parse('$_baseUrl/project-templates'));
     _assertOk(response);
     final list = jsonDecode(response.body) as List<dynamic>;
     return list
@@ -20,7 +23,7 @@ class ProjectsLocalDataSource {
   Future<ProjectTemplate> create(String name,
       {String? description, String? anchorType}) async {
     final response = await http.post(
-      _base,
+      Uri.parse('$_baseUrl/project-templates'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         'name': name,
@@ -41,8 +44,7 @@ class ProjectsLocalDataSource {
     int? sortOrder,
   }) async {
     final response = await http.post(
-      Uri.parse(
-          '${AppConstants.apiBaseUrl}/project-templates/$templateId/steps'),
+      Uri.parse('$_baseUrl/project-templates/$templateId/steps'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         'title': title,
@@ -59,7 +61,7 @@ class ProjectsLocalDataSource {
   Future<ProjectTemplate> update(String id,
       {String? name, String? description}) async {
     final response = await http.patch(
-      Uri.parse('${AppConstants.apiBaseUrl}/project-templates/$id'),
+      Uri.parse('$_baseUrl/project-templates/$id'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         if (name != null) 'name': name,
@@ -79,8 +81,7 @@ class ProjectsLocalDataSource {
     String? offsetDescription,
   }) async {
     final response = await http.patch(
-      Uri.parse(
-          '${AppConstants.apiBaseUrl}/project-templates/$templateId/steps/$stepId'),
+      Uri.parse('$_baseUrl/project-templates/$templateId/steps/$stepId'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         if (title != null) 'title': title,
@@ -95,15 +96,14 @@ class ProjectsLocalDataSource {
 
   Future<void> deleteStep(String templateId, String stepId) async {
     final response = await http.delete(
-      Uri.parse(
-          '${AppConstants.apiBaseUrl}/project-templates/$templateId/steps/$stepId'),
+      Uri.parse('$_baseUrl/project-templates/$templateId/steps/$stepId'),
     );
     _assertOk(response);
   }
 
   Future<void> delete(String id) async {
-    final response = await http
-        .delete(Uri.parse('${AppConstants.apiBaseUrl}/project-templates/$id'));
+    final response =
+        await http.delete(Uri.parse('$_baseUrl/project-templates/$id'));
     _assertOk(response);
   }
 

--- a/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
+++ b/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
@@ -8,7 +8,7 @@ import '../models/project_instance.dart';
 import '../models/project_template.dart';
 import '../models/project_template_step.dart';
 import '../services/project_generation_service.dart';
-import '../../../app/core/constants/app_constants.dart';
+import '../../../app/core/services/server_config_service.dart';
 
 class ProjectsView extends StatefulWidget {
   const ProjectsView({super.key});
@@ -232,7 +232,7 @@ class _TemplateDetailState extends State<_TemplateDetail>
     try {
       final response = await http.get(
         Uri.parse(
-            '${AppConstants.apiBaseUrl}/project-instances?templateId=${widget.template.id}'),
+            '${context.read<ServerConfigService>().url}/project-instances?templateId=${widget.template.id}'),
       );
       if (response.statusCode >= 400) {
         setState(() => _instancesError = 'Failed to load instances');
@@ -262,7 +262,7 @@ class _TemplateDetailState extends State<_TemplateDetail>
       };
       final response = await http.patch(
         Uri.parse(
-            '${AppConstants.apiBaseUrl}/project-instances/steps/${step.id}'),
+            '${context.read<ServerConfigService>().url}/project-instances/steps/${step.id}'),
         headers: {'Content-Type': 'application/json'},
         body: jsonEncode(body),
       );
@@ -275,7 +275,8 @@ class _TemplateDetailState extends State<_TemplateDetail>
   Future<void> _deleteInstance(String instanceId) async {
     try {
       final response = await http.delete(
-        Uri.parse('${AppConstants.apiBaseUrl}/project-instances/$instanceId'),
+        Uri.parse(
+            '${context.read<ServerConfigService>().url}/project-instances/$instanceId'),
       );
       if (response.statusCode < 400) {
         await _loadInstances();
@@ -1301,7 +1302,7 @@ class _GenerateInstanceDialogState extends State<_GenerateInstanceDialog> {
     try {
       final response = await http.post(
         Uri.parse(
-            '${AppConstants.apiBaseUrl}/project-templates/${widget.template.id}/generate'),
+            '${context.read<ServerConfigService>().url}/project-templates/${widget.template.id}/generate'),
         headers: {'Content-Type': 'application/json'},
         body: jsonEncode({
           'anchorDate': dateStr,

--- a/apps/desktop_flutter/lib/features/rhythms/data/rhythms_data_source.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/data/rhythms_data_source.dart
@@ -5,10 +5,13 @@ import '../../../app/core/errors/app_error.dart';
 import '../../../features/tasks/models/recurring_task_rule.dart';
 
 class RhythmsDataSource {
-  final _base = Uri.parse('${AppConstants.apiBaseUrl}/recurring-rules');
+  RhythmsDataSource({String? baseUrl})
+      : _baseUrl = baseUrl ?? AppConstants.apiBaseUrl;
+
+  final String _baseUrl;
 
   Future<List<RecurringTaskRule>> fetchAll() async {
-    final response = await http.get(_base);
+    final response = await http.get(Uri.parse('$_baseUrl/recurring-rules'));
     _assertOk(response);
     final list = jsonDecode(response.body) as List<dynamic>;
     return list
@@ -24,7 +27,7 @@ class RhythmsDataSource {
     int? month,
   }) async {
     final response = await http.post(
-      _base,
+      Uri.parse('$_baseUrl/recurring-rules'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         'title': title,
@@ -49,7 +52,7 @@ class RhythmsDataSource {
     bool? enabled,
   }) async {
     final response = await http.patch(
-      Uri.parse('${AppConstants.apiBaseUrl}/recurring-rules/$id'),
+      Uri.parse('$_baseUrl/recurring-rules/$id'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         if (title != null) 'title': title,
@@ -66,8 +69,8 @@ class RhythmsDataSource {
   }
 
   Future<void> delete(String id) async {
-    final response = await http
-        .delete(Uri.parse('${AppConstants.apiBaseUrl}/recurring-rules/$id'));
+    final response =
+        await http.delete(Uri.parse('$_baseUrl/recurring-rules/$id'));
     _assertOk(response);
   }
 

--- a/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
+++ b/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../app/core/services/server_config_service.dart';
+
+class SettingsView extends StatefulWidget {
+  const SettingsView({super.key});
+
+  @override
+  State<SettingsView> createState() => _SettingsViewState();
+}
+
+class _SettingsViewState extends State<SettingsView> {
+  late final TextEditingController _urlController;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final svc = context.read<ServerConfigService>();
+    _urlController = TextEditingController(text: svc.url);
+  }
+
+  @override
+  void dispose() {
+    _urlController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final value = _urlController.text.trim();
+    if (value.isEmpty) return;
+    setState(() => _saving = true);
+    await context.read<ServerConfigService>().save(value);
+    setState(() => _saving = false);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Saved')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFFFFFFF),
+      appBar: AppBar(
+        title: const Text('Settings'),
+        backgroundColor: const Color(0xFFFFFFFF),
+        foregroundColor: const Color(0xFF111827),
+        elevation: 0,
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(1),
+          child: Container(color: const Color(0xFFE5E7EB), height: 1),
+        ),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          const Text(
+            'Server',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: Color(0xFF6B7280),
+              letterSpacing: 0.8,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: const Color(0xFFFFFFFF),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: const Color(0xFFE5E7EB)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'API Server URL',
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF111827),
+                  ),
+                ),
+                const SizedBox(height: 4),
+                const Text(
+                  'Use http://localhost:4000 for local, or your hosted server URL.',
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: Color(0xFF6B7280),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _urlController,
+                  decoration: const InputDecoration(
+                    hintText: 'http://localhost:4000',
+                    isDense: true,
+                  ),
+                  keyboardType: TextInputType.url,
+                  autocorrect: false,
+                  onFieldSubmitted: (_) => _save(),
+                ),
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: _saving ? null : _save,
+                  child: _saving
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(
+                              strokeWidth: 2, color: Colors.white),
+                        )
+                      : const Text('Save'),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/desktop_flutter/lib/features/tasks/data/automation_rules_data_source.dart
+++ b/apps/desktop_flutter/lib/features/tasks/data/automation_rules_data_source.dart
@@ -5,10 +5,13 @@ import '../../../app/core/errors/app_error.dart';
 import '../models/automation_rule.dart';
 
 class AutomationRulesDataSource {
-  final _base = Uri.parse('${AppConstants.apiBaseUrl}/automation-rules');
+  AutomationRulesDataSource({String? baseUrl})
+      : _baseUrl = baseUrl ?? AppConstants.apiBaseUrl;
+
+  final String _baseUrl;
 
   Future<List<AutomationRule>> fetchAll() async {
-    final response = await http.get(_base);
+    final response = await http.get(Uri.parse('$_baseUrl/automation-rules'));
     _assertOk(response);
     final list = jsonDecode(response.body) as List<dynamic>;
     return list
@@ -25,7 +28,7 @@ class AutomationRulesDataSource {
     bool enabled = true,
   }) async {
     final response = await http.post(
-      _base,
+      Uri.parse('$_baseUrl/automation-rules'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         'name': name,
@@ -51,7 +54,7 @@ class AutomationRulesDataSource {
     bool? enabled,
   }) async {
     final response = await http.patch(
-      Uri.parse('${AppConstants.apiBaseUrl}/automation-rules/$id'),
+      Uri.parse('$_baseUrl/automation-rules/$id'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         if (name != null) 'name': name,
@@ -68,8 +71,8 @@ class AutomationRulesDataSource {
   }
 
   Future<void> delete(String id) async {
-    final response = await http
-        .delete(Uri.parse('${AppConstants.apiBaseUrl}/automation-rules/$id'));
+    final response =
+        await http.delete(Uri.parse('$_baseUrl/automation-rules/$id'));
     _assertOk(response);
   }
 

--- a/apps/desktop_flutter/lib/features/tasks/data/tasks_local_data_source.dart
+++ b/apps/desktop_flutter/lib/features/tasks/data/tasks_local_data_source.dart
@@ -5,10 +5,13 @@ import '../../../app/core/errors/app_error.dart';
 import '../models/task.dart';
 
 class TasksLocalDataSource {
-  final _base = Uri.parse('${AppConstants.apiBaseUrl}/tasks');
+  TasksLocalDataSource({String? baseUrl})
+      : _baseUrl = baseUrl ?? AppConstants.apiBaseUrl;
+
+  final String _baseUrl;
 
   Future<List<Task>> fetchAll() async {
-    final response = await http.get(_base);
+    final response = await http.get(Uri.parse('$_baseUrl/tasks'));
     _assertOk(response);
     final list = jsonDecode(response.body) as List<dynamic>;
     return list.map((j) => Task.fromJson(j as Map<String, dynamic>)).toList();
@@ -16,7 +19,7 @@ class TasksLocalDataSource {
 
   Future<Task> create(String title, {String? notes, String? dueDate}) async {
     final response = await http.post(
-      _base,
+      Uri.parse('$_baseUrl/tasks'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         'title': title,
@@ -31,7 +34,7 @@ class TasksLocalDataSource {
   Future<Task> update(String id,
       {String? title, String? notes, String? dueDate, String? status}) async {
     final response = await http.patch(
-      Uri.parse('${AppConstants.apiBaseUrl}/tasks/$id'),
+      Uri.parse('$_baseUrl/tasks/$id'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         if (title != null) 'title': title,
@@ -45,8 +48,7 @@ class TasksLocalDataSource {
   }
 
   Future<void> delete(String id) async {
-    final response =
-        await http.delete(Uri.parse('${AppConstants.apiBaseUrl}/tasks/$id'));
+    final response = await http.delete(Uri.parse('$_baseUrl/tasks/$id'));
     _assertOk(response);
   }
 

--- a/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
@@ -26,7 +26,7 @@ class _AutomationRulesViewState extends State<AutomationRulesView> {
     return Consumer<AutomationRulesController>(
       builder: (context, controller, _) {
         return Scaffold(
-          backgroundColor: const Color(0xFFF8F9FA),
+          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
           body: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/apps/desktop_flutter/lib/features/weekly_planner/data/weekly_plan_data_source.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/data/weekly_plan_data_source.dart
@@ -6,10 +6,14 @@ import '../../tasks/models/task.dart';
 import '../models/weekly_plan.dart';
 
 class WeeklyPlanDataSource {
-  final _base = Uri.parse('${AppConstants.apiBaseUrl}/weekly-plan');
+  WeeklyPlanDataSource({String? baseUrl})
+      : _baseUrl = baseUrl ?? AppConstants.apiBaseUrl;
+
+  final String _baseUrl;
 
   Future<WeeklyPlan> fetchPlan(String weekLabel) async {
-    final uri = _base.replace(queryParameters: {'week': weekLabel});
+    final uri = Uri.parse('$_baseUrl/weekly-plan')
+        .replace(queryParameters: {'week': weekLabel});
     final response = await http.get(uri);
     _assertOk(response);
     return WeeklyPlan.fromJson(
@@ -19,7 +23,7 @@ class WeeklyPlanDataSource {
   Future<Task> scheduleTask(String taskId, String date,
       {bool locked = false}) async {
     final response = await http.patch(
-      Uri.parse('${AppConstants.apiBaseUrl}/weekly-plan/tasks/$taskId'),
+      Uri.parse('$_baseUrl/weekly-plan/tasks/$taskId'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({'scheduledDate': date, 'locked': locked}),
     );
@@ -36,8 +40,8 @@ class WeeklyPlanDataSource {
     final isProjectStep = sourceType == 'project_step';
     final response = await http.patch(
       Uri.parse(isProjectStep
-          ? '${AppConstants.apiBaseUrl}/project-instances/steps/$taskId'
-          : '${AppConstants.apiBaseUrl}/tasks/$taskId'),
+          ? '$_baseUrl/project-instances/steps/$taskId'
+          : '$_baseUrl/tasks/$taskId'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         if (notes != null) 'notes': notes,
@@ -66,7 +70,7 @@ class WeeklyPlanDataSource {
 
   Future<void> createTask(String title, {String? dueDate}) async {
     final response = await http.post(
-      Uri.parse('${AppConstants.apiBaseUrl}/tasks'),
+      Uri.parse('$_baseUrl/tasks'),
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({
         'title': title,

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -6,6 +6,7 @@ import 'app/core/constants/app_constants.dart';
 import 'app/core/layout/app_shell.dart';
 import 'app/core/server/api_server_controller.dart';
 import 'app/core/server/api_server_service.dart';
+import 'app/core/services/server_config_service.dart';
 import 'app/core/updates/update_controller.dart';
 import 'app/core/updates/update_service.dart';
 import 'app/theme/app_theme.dart';
@@ -43,53 +44,68 @@ void main() async {
     await windowManager.focus();
   });
 
+  // Load persisted server URL before runApp.
+  final serverConfigService = ServerConfigService();
+  await serverConfigService.load();
+
   // Create the server controller and kick off startup before runApp so the
   // service object is available immediately. The UI shows a loading screen
   // while the server boots.
   final serverController = ApiServerController(ApiServerService())
     ..initialize();
 
-  runApp(RhythmApp(serverController: serverController));
+  runApp(RhythmApp(
+    serverController: serverController,
+    serverConfigService: serverConfigService,
+  ));
 }
 
 class RhythmApp extends StatelessWidget {
-  const RhythmApp({super.key, required this.serverController});
+  const RhythmApp({
+    super.key,
+    required this.serverController,
+    required this.serverConfigService,
+  });
 
   final ApiServerController serverController;
+  final ServerConfigService serverConfigService;
 
   @override
   Widget build(BuildContext context) {
+    final baseUrl = serverConfigService.url;
     return MultiProvider(
       providers: [
         ChangeNotifierProvider.value(value: serverController),
+        ChangeNotifierProvider.value(value: serverConfigService),
         ChangeNotifierProvider(
           create: (_) => TasksController(
-            TasksRepository(TasksLocalDataSource()),
+            TasksRepository(TasksLocalDataSource(baseUrl: baseUrl)),
           ),
         ),
         ChangeNotifierProvider(
           create: (_) => AutomationRulesController(
-            AutomationRulesRepository(AutomationRulesDataSource()),
+            AutomationRulesRepository(
+                AutomationRulesDataSource(baseUrl: baseUrl)),
           ),
         ),
         ChangeNotifierProvider(
           create: (_) => ProjectTemplateController(
-            ProjectsRepository(ProjectsLocalDataSource()),
+            ProjectsRepository(ProjectsLocalDataSource(baseUrl: baseUrl)),
           ),
         ),
         ChangeNotifierProvider(
           create: (_) => RhythmsController(
-            RhythmsRepository(RhythmsDataSource()),
+            RhythmsRepository(RhythmsDataSource(baseUrl: baseUrl)),
           ),
         ),
         ChangeNotifierProvider(
           create: (_) => WeeklyPlannerController(
-            WeeklyPlanRepository(WeeklyPlanDataSource()),
+            WeeklyPlanRepository(WeeklyPlanDataSource(baseUrl: baseUrl)),
           ),
         ),
         ChangeNotifierProvider(
           create: (_) => IntegrationsController(
-            IntegrationsRepository(IntegrationsDataSource()),
+            IntegrationsRepository(IntegrationsDataSource(baseUrl: baseUrl)),
           ),
         ),
         ChangeNotifierProvider(

--- a/apps/desktop_flutter/pubspec.yaml
+++ b/apps/desktop_flutter/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   provider: ^6.1.2
   url_launcher: ^6.3.1
   window_manager: ^0.3.8
+  shared_preferences: ^2.3.0
 
 dev_dependencies:
   flutter_test:

--- a/apps/web/src/hooks/useApi.ts
+++ b/apps/web/src/hooks/useApi.ts
@@ -1,0 +1,95 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../lib/api';
+
+export function useTasks() {
+  return useQuery({ queryKey: ['tasks'], queryFn: () => api.get('/tasks').then(r => r.data) });
+}
+
+export function useCreateTask() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: any) => api.post('/tasks', data).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['tasks'] }),
+  });
+}
+
+export function useRecurringRules() {
+  return useQuery({ queryKey: ['recurring-rules'], queryFn: () => api.get('/recurring-rules').then(r => r.data) });
+}
+
+export function useUpdateRecurringRule() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...data }: any) => api.patch(`/recurring-rules/${id}`, data).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['recurring-rules'] }),
+  });
+}
+
+export function useCreateRecurringRule() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: any) => api.post('/recurring-rules', data).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['recurring-rules'] }),
+  });
+}
+
+export function useProjectInstances() {
+  return useQuery({ queryKey: ['project-instances'], queryFn: () => api.get('/project-instances').then(r => r.data) });
+}
+
+export function useProjectTemplates() {
+  return useQuery({ queryKey: ['project-templates'], queryFn: () => api.get('/project-templates').then(r => r.data) });
+}
+
+export function useFacilities() {
+  return useQuery({ queryKey: ['facilities'], queryFn: () => api.get('/facilities').then(r => r.data) });
+}
+
+export function useFacilityReservations(facilityId: number) {
+  return useQuery({
+    queryKey: ['reservations', facilityId],
+    queryFn: () => api.get(`/facilities/${facilityId}/reservations`).then(r => r.data),
+  });
+}
+
+export function useCreateReservation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ facilityId, ...data }: { facilityId: number; title: string; reservedBy: string; startTime: string; endTime: string; notes?: string }) =>
+      api.post(`/facilities/${facilityId}/reservations`, data).then(r => r.data),
+    onSuccess: (_: unknown, { facilityId }: { facilityId: number }) =>
+      qc.invalidateQueries({ queryKey: ['reservations', facilityId] }),
+  });
+}
+
+export function useMessageThreads() {
+  return useQuery({ queryKey: ['message-threads'], queryFn: () => api.get('/message-threads').then(r => r.data) });
+}
+
+export function useCreateMessageThread() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { title: string }) => api.post('/message-threads', data).then(r => r.data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['message-threads'] }),
+  });
+}
+
+export function useThreadMessages(threadId: number | null) {
+  return useQuery({
+    queryKey: ['messages', threadId],
+    queryFn: () => api.get(`/message-threads/${threadId}/messages`).then(r => r.data),
+    enabled: threadId !== null,
+  });
+}
+
+export function useSendMessage() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ threadId, ...data }: { threadId: number; senderName: string; body: string }) =>
+      api.post(`/message-threads/${threadId}/messages`, data).then(r => r.data),
+    onSuccess: (_: unknown, { threadId }: { threadId: number }) => {
+      qc.invalidateQueries({ queryKey: ['messages', threadId] });
+      qc.invalidateQueries({ queryKey: ['message-threads'] });
+    },
+  });
+}

--- a/apps/web/src/pages/Messages.tsx
+++ b/apps/web/src/pages/Messages.tsx
@@ -1,0 +1,386 @@
+import { useState } from "react";
+import { PenSquare, Search, Send, Loader2, AlertCircle, MessageSquare } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { PageHeader } from "@/components/PageHeader";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { motion } from "framer-motion";
+import {
+  useMessageThreads,
+  useCreateMessageThread,
+  useThreadMessages,
+  useSendMessage,
+} from "@/hooks/useApi";
+
+function formatTimestamp(dateStr: string): string {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (diffDays === 0) {
+    return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  } else if (diffDays === 1) {
+    return "Yesterday";
+  } else if (diffDays < 7) {
+    return date.toLocaleDateString([], { weekday: "short" });
+  }
+  return date.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+function isRecent(dateStr: string): boolean {
+  if (!dateStr) return false;
+  const date = new Date(dateStr);
+  const diffMs = Date.now() - date.getTime();
+  return diffMs < 1000 * 60 * 60 * 24; // within 24 hours
+}
+
+interface ThreadPanelProps {
+  thread: { id: number; title: string } | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function ThreadPanel({ thread, open, onOpenChange }: ThreadPanelProps) {
+  const [replyBody, setReplyBody] = useState("");
+  const [senderName, setSenderName] = useState("Me");
+
+  const { data: messages, isLoading: messagesLoading } = useThreadMessages(
+    thread?.id ?? null
+  );
+  const sendMessage = useSendMessage();
+
+  function handleSend() {
+    if (!thread || !replyBody.trim()) return;
+    sendMessage.mutate(
+      { threadId: thread.id, senderName: senderName, body: replyBody.trim() } as { threadId: number; senderName: string; body: string },
+      {
+        onSuccess: () => {
+          setReplyBody("");
+        },
+      }
+    );
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-md flex flex-col p-0">
+        <SheetHeader className="px-6 py-4 border-b border-border/60 shrink-0">
+          <SheetTitle className="text-base">{thread?.title ?? ""}</SheetTitle>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4 min-h-0">
+          {messagesLoading && (
+            <div className="flex items-center justify-center h-24">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          )}
+          {!messagesLoading && messages && messages.length === 0 && (
+            <p className="text-sm text-muted-foreground text-center py-8">
+              No messages yet. Start the conversation below.
+            </p>
+          )}
+          {!messagesLoading &&
+            messages &&
+            messages.map((msg: { id: number; senderName: string; body: string; createdAt: string }) => (
+              <div key={msg.id} className="flex gap-3">
+                <Avatar className="h-8 w-8 shrink-0">
+                  <AvatarFallback className="text-xs font-semibold bg-primary/10 text-primary">
+                    {getInitials(msg.senderName ?? "?")}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-sm font-semibold">{msg.senderName}</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {formatTimestamp(msg.createdAt)}
+                    </span>
+                  </div>
+                  <p className="text-sm text-foreground/90 mt-0.5 whitespace-pre-wrap break-words">
+                    {msg.body}
+                  </p>
+                </div>
+              </div>
+            ))}
+        </div>
+
+        <div className="shrink-0 border-t border-border/60 px-6 py-4 space-y-2">
+          <div className="flex gap-2 items-center">
+            <Label htmlFor="sender-name" className="text-xs text-muted-foreground whitespace-nowrap">
+              From:
+            </Label>
+            <Input
+              id="sender-name"
+              value={senderName}
+              onChange={(e) => setSenderName(e.target.value)}
+              className="h-7 text-xs bg-secondary/50"
+            />
+          </div>
+          <div className="flex gap-2 items-end">
+            <Textarea
+              placeholder="Write a reply… (Cmd+Enter to send)"
+              value={replyBody}
+              onChange={(e) => setReplyBody(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="resize-none text-sm min-h-[72px]"
+            />
+            <Button
+              size="sm"
+              onClick={handleSend}
+              disabled={!replyBody.trim() || sendMessage.isPending}
+              className="shrink-0 self-end"
+            >
+              {sendMessage.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+interface NewThreadDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function NewThreadDialog({ open, onOpenChange }: NewThreadDialogProps) {
+  const [title, setTitle] = useState("");
+  const createThread = useCreateMessageThread();
+
+  function handleCreate() {
+    if (!title.trim()) return;
+    createThread.mutate(
+      { title: title.trim() },
+      {
+        onSuccess: () => {
+          setTitle("");
+          onOpenChange(false);
+        },
+      }
+    );
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleCreate();
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New Message Thread</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3 py-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="thread-title">Thread title</Label>
+            <Input
+              id="thread-title"
+              placeholder="e.g. Easter planning, Staff update…"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onKeyDown={handleKeyDown}
+              autoFocus
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleCreate}
+            disabled={!title.trim() || createThread.isPending}
+          >
+            {createThread.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-1.5" />
+            ) : null}
+            Create Thread
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default function Messages() {
+  const { data: threads, isLoading, isError, error } = useMessageThreads();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedThread, setSelectedThread] = useState<{ id: number; title: string } | null>(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [newThreadDialogOpen, setNewThreadDialogOpen] = useState(false);
+
+  function handleThreadClick(thread: { id: number; title: string }) {
+    setSelectedThread(thread);
+    setSheetOpen(true);
+  }
+
+  const filteredThreads = (threads ?? []).filter((t: { title: string }) =>
+    t.title.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  return (
+    <motion.div
+      className="p-4 sm:p-6 lg:p-8 space-y-6 max-w-4xl"
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35 }}
+    >
+      <PageHeader title="Messages" description="Direct messages and project threads.">
+        <Button size="sm" onClick={() => setNewThreadDialogOpen(true)}>
+          <PenSquare className="h-4 w-4 mr-1.5" /> New Message
+        </Button>
+      </PageHeader>
+
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="Search threads..."
+          className="pl-9 bg-card"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center h-48">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex items-center gap-2 text-destructive p-4">
+          <AlertCircle className="h-5 w-5 shrink-0" />
+          <p className="text-sm font-medium">
+            Failed to load messages: {(error as Error)?.message ?? "Unknown error"}
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !isError && (
+        <Card className="shadow-sm border-border/60">
+          <CardContent className="p-2">
+            {filteredThreads.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-12 gap-2 text-muted-foreground">
+                <MessageSquare className="h-8 w-8" />
+                <p className="text-sm">
+                  {searchQuery ? "No threads match your search." : "No message threads yet."}
+                </p>
+              </div>
+            ) : (
+              <div className="divide-y divide-border/50">
+                {filteredThreads.map(
+                  (thread: {
+                    id: number;
+                    title: string;
+                    updatedAt: string;
+                    lastMessage?: { senderName: string; body: string; createdAt: string };
+                  }) => {
+                    const unread = thread.lastMessage
+                      ? isRecent(thread.lastMessage.createdAt)
+                      : false;
+                    const senderInitials = thread.lastMessage?.senderName
+                      ? getInitials(thread.lastMessage.senderName)
+                      : "?";
+
+                    return (
+                      <div
+                        key={thread.id}
+                        className="flex items-start gap-3 p-3 rounded-lg hover:bg-secondary/50 transition-colors cursor-pointer"
+                        onClick={() => handleThreadClick({ id: thread.id, title: thread.title })}
+                      >
+                        <div className="relative shrink-0">
+                          <Avatar className="h-10 w-10">
+                            <AvatarFallback className="text-xs font-semibold bg-primary/10 text-primary">
+                              {senderInitials}
+                            </AvatarFallback>
+                          </Avatar>
+                          {unread && (
+                            <span className="absolute -top-0.5 -right-0.5 h-3 w-3 rounded-full bg-primary border-2 border-card" />
+                          )}
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <p
+                              className={`text-sm truncate ${
+                                unread
+                                  ? "font-semibold text-foreground"
+                                  : "font-medium text-muted-foreground"
+                              }`}
+                            >
+                              {thread.lastMessage?.senderName ?? thread.title}
+                            </p>
+                            <span className="text-[10px] text-muted-foreground ml-auto whitespace-nowrap shrink-0">
+                              {formatTimestamp(thread.updatedAt)}
+                            </span>
+                          </div>
+                          <p
+                            className={`text-xs mt-0.5 truncate ${
+                              unread ? "text-foreground" : "text-muted-foreground"
+                            }`}
+                          >
+                            {thread.lastMessage?.body ?? thread.title}
+                          </p>
+                        </div>
+                      </div>
+                    );
+                  }
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      <ThreadPanel
+        thread={selectedThread}
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+      />
+
+      <NewThreadDialog
+        open={newThreadDialogOpen}
+        onOpenChange={setNewThreadDialogOpen}
+      />
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Light theme facelift**: Full light theme replacing the dark UI — white scaffold/cards, `#F8F9FA` sidebar, `#E5E7EB` borders, `#4F6AF5` primary accent, semantic `#111827`/`#6B7280` text colors. `app_theme.dart` rebuilt with `CardTheme`, `dividerColor`, and `inputDecorationTheme` tokens.
- **New nav order + placeholders**: Sidebar reordered to Dashboard, Tasks, Rhythms, Projects, Weekly Planner, Messages, Facilities, Automations, Integrations. Dashboard, Messages, and Facilities route to "Coming soon" placeholder screens.
- **Settings gear button**: Gear icon at the bottom of the sidebar navigates to a new `SettingsView`.
- **Server URL setting**: New `ServerConfigService` (ChangeNotifier + `shared_preferences`) persists the API base URL. A `SettingsView` screen lets users edit and save it. All data sources updated to accept an optional `baseUrl` constructor param; `main.dart` passes `serverConfigService.url` at startup.
- **Light theme fixes**: Removed hardcoded dark colors in `automation_rules_view.dart` and `app_shell.dart` loading/error screens.

## Test plan

- [ ] Launch app — sidebar should be light gray (`#F8F9FA`) with dark text and blue selected state
- [ ] Click each nav item — Dashboard / Messages / Facilities show "Coming soon"
- [ ] Click the Settings gear — opens Settings screen with current server URL pre-filled
- [ ] Edit the URL and click Save — snackbar appears; value persists after restart
- [ ] Tasks, Rhythms, Projects, Weekly Planner, Automations, Integrations all load and function normally
- [ ] `flutter analyze --no-fatal-infos` and `dart format .` both pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)