### PR TITLE
feat: Facilities screen with card grid and reservation dialog

### DIFF
--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:window_manager/window_manager.dart';
 
+import '../../../features/facilities/views/facilities_view.dart';
 import '../../../features/integrations/views/integrations_view.dart';
 import '../../../features/projects/views/projects_view.dart';
 import '../../../features/rhythms/views/rhythms_view.dart';
@@ -153,7 +154,7 @@ class _AppContent extends StatelessWidget {
     ProjectsView(), // 3
     WeeklyPlannerView(), // 4
     _ComingSoonView(label: 'Messages'), // 5
-    _ComingSoonView(label: 'Facilities'), // 6
+    FacilitiesView(), // 6
     AutomationRulesView(), // 7
     IntegrationsView(), // 8
   ];

--- a/apps/desktop_flutter/lib/features/facilities/controllers/facilities_controller.dart
+++ b/apps/desktop_flutter/lib/features/facilities/controllers/facilities_controller.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/facility.dart';
+import '../models/reservation.dart';
+import '../repositories/facilities_repository.dart';
+
+enum FacilitiesStatus { idle, loading, error }
+
+class FacilitiesController extends ChangeNotifier {
+  FacilitiesController(this._repository);
+
+  final FacilitiesRepository _repository;
+
+  List<Facility> _facilities = [];
+  Map<int, List<Reservation>> _reservationsByFacility = {};
+  FacilitiesStatus _status = FacilitiesStatus.idle;
+  String? _errorMessage;
+
+  List<Facility> get facilities => _facilities;
+  Map<int, List<Reservation>> get reservationsByFacility =>
+      _reservationsByFacility;
+  FacilitiesStatus get status => _status;
+  String? get errorMessage => _errorMessage;
+
+  Future<void> loadFacilities() async {
+    _status = FacilitiesStatus.loading;
+    _errorMessage = null;
+    notifyListeners();
+
+    try {
+      _facilities = await _repository.getFacilities();
+
+      // Load reservations for all facilities in parallel.
+      final results = await Future.wait(
+        _facilities.map((f) => _repository.getReservations(f.id)),
+      );
+      final map = <int, List<Reservation>>{};
+      for (var i = 0; i < _facilities.length; i++) {
+        map[_facilities[i].id] = results[i];
+      }
+      _reservationsByFacility = map;
+      _status = FacilitiesStatus.idle;
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = FacilitiesStatus.error;
+    }
+    notifyListeners();
+  }
+
+  Future<void> createReservation(
+    int facilityId, {
+    required String title,
+    required String reservedBy,
+    String? startTime,
+    String? endTime,
+    String? notes,
+  }) async {
+    final body = <String, dynamic>{
+      'title': title,
+      'reservedBy': reservedBy,
+      if (startTime != null && startTime.isNotEmpty) 'startTime': startTime,
+      if (endTime != null && endTime.isNotEmpty) 'endTime': endTime,
+      if (notes != null && notes.isNotEmpty) 'notes': notes,
+    };
+
+    final reservation = await _repository.createReservation(facilityId, body);
+
+    // Update the reservations map for this facility.
+    final updated =
+        List<Reservation>.from(_reservationsByFacility[facilityId] ?? [])
+          ..add(reservation);
+    _reservationsByFacility = {
+      ..._reservationsByFacility,
+      facilityId: updated,
+    };
+    notifyListeners();
+  }
+}

--- a/apps/desktop_flutter/lib/features/facilities/data/facilities_data_source.dart
+++ b/apps/desktop_flutter/lib/features/facilities/data/facilities_data_source.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../../../app/core/constants/app_constants.dart';
+import '../../../app/core/errors/app_error.dart';
+import '../models/facility.dart';
+import '../models/reservation.dart';
+
+class FacilitiesDataSource {
+  FacilitiesDataSource({String? baseUrl})
+      : _baseUrl = baseUrl ?? AppConstants.apiBaseUrl;
+
+  final String _baseUrl;
+
+  Future<List<Facility>> getFacilities() async {
+    final response = await http.get(Uri.parse('$_baseUrl/facilities'));
+    _assertOk(response);
+    final list = jsonDecode(response.body) as List<dynamic>;
+    return list
+        .map((j) => Facility.fromJson(j as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<Reservation>> getReservations(int facilityId) async {
+    final response = await http
+        .get(Uri.parse('$_baseUrl/facilities/$facilityId/reservations'));
+    _assertOk(response);
+    final list = jsonDecode(response.body) as List<dynamic>;
+    return list
+        .map((j) => Reservation.fromJson(j as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<Reservation> createReservation(
+      int facilityId, Map<String, dynamic> body) async {
+    final response = await http.post(
+      Uri.parse('$_baseUrl/facilities/$facilityId/reservations'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(body),
+    );
+    _assertOk(response);
+    return Reservation.fromJson(
+        jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  void _assertOk(http.Response response) {
+    if (response.statusCode >= 400) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>?;
+      final message =
+          (body?['error'] as Map<String, dynamic>?)?['message'] as String? ??
+              'Request failed';
+      throw AppError(message);
+    }
+  }
+}

--- a/apps/desktop_flutter/lib/features/facilities/models/facility.dart
+++ b/apps/desktop_flutter/lib/features/facilities/models/facility.dart
@@ -1,0 +1,22 @@
+class Facility {
+  const Facility({
+    required this.id,
+    required this.name,
+    this.description,
+    this.location,
+  });
+
+  final int id;
+  final String name;
+  final String? description;
+  final String? location;
+
+  factory Facility.fromJson(Map<String, dynamic> json) {
+    return Facility(
+      id: json['id'] as int,
+      name: json['name'] as String,
+      description: json['description'] as String?,
+      location: json['location'] as String?,
+    );
+  }
+}

--- a/apps/desktop_flutter/lib/features/facilities/models/reservation.dart
+++ b/apps/desktop_flutter/lib/features/facilities/models/reservation.dart
@@ -1,0 +1,31 @@
+class Reservation {
+  const Reservation({
+    required this.id,
+    required this.facilityId,
+    required this.title,
+    required this.reservedBy,
+    this.startTime,
+    this.endTime,
+    this.notes,
+  });
+
+  final int id;
+  final int facilityId;
+  final String title;
+  final String reservedBy;
+  final String? startTime;
+  final String? endTime;
+  final String? notes;
+
+  factory Reservation.fromJson(Map<String, dynamic> json) {
+    return Reservation(
+      id: json['id'] as int,
+      facilityId: json['facilityId'] as int,
+      title: json['title'] as String,
+      reservedBy: json['reservedBy'] as String,
+      startTime: json['startTime'] as String?,
+      endTime: json['endTime'] as String?,
+      notes: json['notes'] as String?,
+    );
+  }
+}

--- a/apps/desktop_flutter/lib/features/facilities/repositories/facilities_repository.dart
+++ b/apps/desktop_flutter/lib/features/facilities/repositories/facilities_repository.dart
@@ -1,0 +1,18 @@
+import '../data/facilities_data_source.dart';
+import '../models/facility.dart';
+import '../models/reservation.dart';
+
+class FacilitiesRepository {
+  FacilitiesRepository(this._dataSource);
+
+  final FacilitiesDataSource _dataSource;
+
+  Future<List<Facility>> getFacilities() => _dataSource.getFacilities();
+
+  Future<List<Reservation>> getReservations(int facilityId) =>
+      _dataSource.getReservations(facilityId);
+
+  Future<Reservation> createReservation(
+          int facilityId, Map<String, dynamic> body) =>
+      _dataSource.createReservation(facilityId, body);
+}

--- a/apps/desktop_flutter/lib/features/facilities/views/facilities_view.dart
+++ b/apps/desktop_flutter/lib/features/facilities/views/facilities_view.dart
@@ -1,0 +1,499 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../app/core/widgets/error_banner.dart';
+import '../controllers/facilities_controller.dart';
+import '../models/facility.dart';
+
+class FacilitiesView extends StatefulWidget {
+  const FacilitiesView({super.key});
+
+  @override
+  State<FacilitiesView> createState() => _FacilitiesViewState();
+}
+
+class _FacilitiesViewState extends State<FacilitiesView> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<FacilitiesController>().loadFacilities();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<FacilitiesController>(
+      builder: (context, controller, _) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _FacilitiesHeader(
+              onReserve: () => _showReserveDialog(context, controller),
+            ),
+            if (controller.status == FacilitiesStatus.error &&
+                controller.errorMessage != null)
+              ErrorBanner(
+                message: controller.errorMessage!,
+                onRetry: controller.loadFacilities,
+              ),
+            Expanded(child: _FacilitiesGrid(controller: controller)),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _showReserveDialog(
+      BuildContext context, FacilitiesController controller) async {
+    await showDialog<void>(
+      context: context,
+      builder: (_) => _ReservationDialog(
+        controller: controller,
+        facilities: controller.facilities,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Header
+// ---------------------------------------------------------------------------
+
+class _FacilitiesHeader extends StatelessWidget {
+  const _FacilitiesHeader({required this.onReserve});
+
+  final VoidCallback onReserve;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
+      child: Row(
+        children: [
+          Text('Facilities', style: Theme.of(context).textTheme.headlineSmall),
+          const Spacer(),
+          FilledButton.icon(
+            onPressed: onReserve,
+            icon: const Icon(Icons.add, size: 18),
+            label: const Text('Reserve Space'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Facility Card Grid
+// ---------------------------------------------------------------------------
+
+class _FacilitiesGrid extends StatelessWidget {
+  const _FacilitiesGrid({required this.controller});
+
+  final FacilitiesController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    if (controller.status == FacilitiesStatus.loading &&
+        controller.facilities.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (controller.facilities.isEmpty) {
+      return const Center(
+        child: Text('No facilities yet.'),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: GridView.builder(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 3,
+          crossAxisSpacing: 16,
+          mainAxisSpacing: 16,
+          childAspectRatio: 1.4,
+        ),
+        itemCount: controller.facilities.length,
+        itemBuilder: (context, i) {
+          final facility = controller.facilities[i];
+          final reservations =
+              controller.reservationsByFacility[facility.id] ?? [];
+          return _FacilityCard(
+            facility: facility,
+            reservationCount: reservations.length,
+            controller: controller,
+          );
+        },
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Facility Card
+// ---------------------------------------------------------------------------
+
+class _FacilityCard extends StatelessWidget {
+  const _FacilityCard({
+    required this.facility,
+    required this.reservationCount,
+    required this.controller,
+  });
+
+  final Facility facility;
+  final int reservationCount;
+  final FacilitiesController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    const cardBorder = Color(0xFFE5E7EB);
+    const textPrimary = Color(0xFF111827);
+    const textMuted = Color(0xFF9CA3AF);
+
+    return Card(
+      elevation: 0,
+      color: Colors.white,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(10),
+        side: const BorderSide(color: cardBorder),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Name
+            Text(
+              facility.name,
+              style: const TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+                color: textPrimary,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+
+            // Description
+            if (facility.description != null &&
+                facility.description!.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(
+                facility.description!,
+                style: const TextStyle(fontSize: 13, color: textMuted),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+
+            if (facility.location != null && facility.location!.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Row(
+                children: [
+                  const Icon(Icons.location_on_outlined,
+                      size: 13, color: textMuted),
+                  const SizedBox(width: 3),
+                  Expanded(
+                    child: Text(
+                      facility.location!,
+                      style: const TextStyle(fontSize: 12, color: textMuted),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+
+            const Spacer(),
+
+            // Reservation count badge + Reserve button
+            Row(
+              children: [
+                _ReservationBadge(count: reservationCount),
+                const Spacer(),
+                OutlinedButton(
+                  onPressed: () => _showReserveDialog(context),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: cs.primary,
+                    side: BorderSide(color: cs.primary),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                    textStyle: const TextStyle(fontSize: 13),
+                    minimumSize: Size.zero,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  child: const Text('Reserve'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _showReserveDialog(BuildContext context) async {
+    await showDialog<void>(
+      context: context,
+      builder: (_) => _ReservationDialog(
+        controller: controller,
+        facilities: controller.facilities,
+        preselectedFacility: facility,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reservation count badge
+// ---------------------------------------------------------------------------
+
+class _ReservationBadge extends StatelessWidget {
+  const _ReservationBadge({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    if (count == 0) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          color: const Color(0xFFDCFCE7),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: const Text(
+          'Available',
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w500,
+            color: Color(0xFF16A34A),
+          ),
+        ),
+      );
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: cs.primary.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        '$count ${count == 1 ? 'reservation' : 'reservations'}',
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w500,
+          color: cs.primary,
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reservation Dialog
+// ---------------------------------------------------------------------------
+
+class _ReservationDialog extends StatefulWidget {
+  const _ReservationDialog({
+    required this.controller,
+    required this.facilities,
+    this.preselectedFacility,
+  });
+
+  final FacilitiesController controller;
+  final List<Facility> facilities;
+  final Facility? preselectedFacility;
+
+  @override
+  State<_ReservationDialog> createState() => _ReservationDialogState();
+}
+
+class _ReservationDialogState extends State<_ReservationDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _reservedByController = TextEditingController();
+  final _startTimeController = TextEditingController();
+  final _endTimeController = TextEditingController();
+  final _notesController = TextEditingController();
+
+  Facility? _selectedFacility;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedFacility = widget.preselectedFacility ??
+        (widget.facilities.isNotEmpty ? widget.facilities.first : null);
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _reservedByController.dispose();
+    _startTimeController.dispose();
+    _endTimeController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isTopLevel = widget.preselectedFacility == null;
+
+    return AlertDialog(
+      title: const Text('Reserve Space'),
+      content: SizedBox(
+        width: 440,
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Facility selector (top-level button only)
+              if (isTopLevel && widget.facilities.isNotEmpty) ...[
+                DropdownButtonFormField<Facility>(
+                  value: _selectedFacility,
+                  decoration: const InputDecoration(
+                    labelText: 'Facility',
+                    border: OutlineInputBorder(),
+                  ),
+                  items: widget.facilities
+                      .map(
+                        (f) => DropdownMenuItem(
+                          value: f,
+                          child: Text(f.name),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: (v) => setState(() => _selectedFacility = v),
+                  validator: (v) =>
+                      v == null ? 'Please select a facility' : null,
+                ),
+                const SizedBox(height: 16),
+              ],
+
+              // Title
+              TextFormField(
+                controller: _titleController,
+                autofocus: !isTopLevel,
+                decoration: const InputDecoration(
+                  labelText: 'Title *',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (v) => (v == null || v.trim().isEmpty)
+                    ? 'Title is required'
+                    : null,
+              ),
+              const SizedBox(height: 16),
+
+              // Reserved By
+              TextFormField(
+                controller: _reservedByController,
+                decoration: const InputDecoration(
+                  labelText: 'Reserved By *',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (v) => (v == null || v.trim().isEmpty)
+                    ? 'Reserved By is required'
+                    : null,
+              ),
+              const SizedBox(height: 16),
+
+              // Start / End time row
+              Row(
+                children: [
+                  Expanded(
+                    child: TextFormField(
+                      controller: _startTimeController,
+                      decoration: const InputDecoration(
+                        labelText: 'Start Time',
+                        hintText: 'e.g. 2026-04-01 09:00',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: TextFormField(
+                      controller: _endTimeController,
+                      decoration: const InputDecoration(
+                        labelText: 'End Time',
+                        hintText: 'e.g. 2026-04-01 11:00',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+
+              // Notes
+              TextFormField(
+                controller: _notesController,
+                decoration: const InputDecoration(
+                  labelText: 'Notes',
+                  border: OutlineInputBorder(),
+                ),
+                maxLines: 3,
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _saving ? null : () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _saving ? null : _submit,
+          child: _saving
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Submit'),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _submit() async {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+    if (_selectedFacility == null) return;
+
+    setState(() => _saving = true);
+    try {
+      await widget.controller.createReservation(
+        _selectedFacility!.id,
+        title: _titleController.text.trim(),
+        reservedBy: _reservedByController.text.trim(),
+        startTime: _startTimeController.text.trim(),
+        endTime: _endTimeController.text.trim(),
+        notes: _notesController.text.trim(),
+      );
+      if (mounted) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Reservation created')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _saving = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error: $e')),
+        );
+      }
+    }
+  }
+}

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -10,6 +10,9 @@ import 'app/core/services/server_config_service.dart';
 import 'app/core/updates/update_controller.dart';
 import 'app/core/updates/update_service.dart';
 import 'app/theme/app_theme.dart';
+import 'features/facilities/controllers/facilities_controller.dart';
+import 'features/facilities/data/facilities_data_source.dart';
+import 'features/facilities/repositories/facilities_repository.dart';
 import 'features/integrations/controllers/integrations_controller.dart';
 import 'features/integrations/data/integrations_data_source.dart';
 import 'features/integrations/repositories/integrations_repository.dart';
@@ -101,6 +104,11 @@ class RhythmApp extends StatelessWidget {
         ChangeNotifierProvider(
           create: (_) => WeeklyPlannerController(
             WeeklyPlanRepository(WeeklyPlanDataSource(baseUrl: baseUrl)),
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => FacilitiesController(
+            FacilitiesRepository(FacilitiesDataSource(baseUrl: baseUrl)),
           ),
         ),
         ChangeNotifierProvider(

--- a/apps/desktop_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/desktop_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,14 @@ import Foundation
 
 import package_info_plus
 import screen_retriever
+import shared_preferences_foundation
 import url_launcher_macos
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }


### PR DESCRIPTION
## Summary

- Adds `Facility` and `Reservation` models with `fromJson` factories
- Implements `FacilitiesDataSource` (HTTP) → `FacilitiesRepository` → `FacilitiesController` (ChangeNotifier) following the established layered architecture pattern
- `FacilitiesView` renders a responsive 3-column card grid; each card shows facility name, description, location, a reservation count badge ("Available" or "N reservations"), and a per-card "Reserve" outlined button
- Top-level "Reserve Space" button includes a facility selector dropdown
- Reservation dialog validates required fields (Title, Reserved By), accepts optional Start Time, End Time, Notes, posts to `POST /facilities/:id/reservations`, shows success snackbar, and updates the card count immediately
- Wires `FacilitiesController` into `MultiProvider` in `main.dart`
- Replaces `_ComingSoonView(label: 'Facilities')` at nav index 6 in `app_shell.dart` with `FacilitiesView()`
- All Rhythm 2.0 theme tokens applied (white cards, `#E5E7EB` borders, `#4F6AF5` primary, muted text colors)

## Test plan

- [ ] `flutter pub get` passes
- [ ] `dart format .` produces no changes
- [ ] `flutter analyze --no-fatal-infos` reports no issues
- [ ] Navigate to Facilities tab (index 6) — grid loads facilities from API
- [ ] Loading spinner shown while fetching; error banner + retry on failure
- [ ] Each card displays name (bold), description/location (muted), reservation count badge
- [ ] Clicking per-card "Reserve" opens dialog with facility pre-selected
- [ ] Clicking top-level "Reserve Space" opens dialog with facility dropdown
- [ ] Form validation: submitting empty Title or Reserved By shows inline error
- [ ] Successful submission shows "Reservation created" snackbar; badge count increments

🤖 Generated with [Claude Code](https://claude.com/claude-code)