### PR TITLE
Overhaul external automations workflow

### DIFF
--- a/.github/workflows/desktop_ci.yml
+++ b/.github/workflows/desktop_ci.yml
@@ -23,7 +23,16 @@ jobs:
       - run: dart format --output=none --set-exit-if-changed .
       - run: flutter analyze --no-fatal-infos
       - run: flutter test
-      - name: Build macOS debug app
+      - name: Configure macOS debug build
         run: >
-          flutter build macos --debug
+          flutter build macos --debug --config-only
           --dart-define=GOOGLE_DESKTOP_CLIENT_ID="$GOOGLE_DESKTOP_CLIENT_ID"
+      - name: Build macOS debug app
+        working-directory: apps/desktop_flutter/macos
+        run: >
+          xcodebuild -workspace Runner.xcworkspace -scheme Runner
+          -configuration Debug
+          CODE_SIGNING_ALLOWED=NO
+          CODE_SIGNING_REQUIRED=NO
+          CODE_SIGN_IDENTITY=""
+          build

--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -91,6 +91,17 @@ jobs:
             "$PCO_APPLICATION_ID" "$PCO_SECRET" "$PCO_REDIRECT_URI" \
             > "$DEST/.env"
 
+      - name: Verify bundled API payload
+        working-directory: apps/desktop_flutter
+        run: |
+          DEST="build/macos/Build/Products/Release/Rhythm.app/Contents/Resources/api_server"
+          test -f "$DEST/dist/server.js"
+          test -f "$DEST/package.json"
+          test -f "$DEST/package-lock.json"
+          test -f "$DEST/.env"
+          test -d "$DEST/node_modules"
+          test -f "$DEST/node_modules/better-sqlite3/package.json"
+
       - name: Package macOS artifacts
         working-directory: apps/desktop_flutter
         run: ../../tools/release/package_macos.sh

--- a/apps/api_server/src/__tests__/auth_and_messaging.test.ts
+++ b/apps/api_server/src/__tests__/auth_and_messaging.test.ts
@@ -41,6 +41,7 @@ describe('Auth and ownership flows', () => {
           sub: 'google-sub-1',
           email: 'alice@example.com',
           name: 'Alice',
+          picture: 'https://example.com/alice.png',
         }),
       } as never,
     );
@@ -50,6 +51,7 @@ describe('Auth and ownership flows', () => {
     expect(session.sessionToken).toBeTruthy();
     expect(session.user.email).toBe('alice@example.com');
     expect(session.user.googleSub).toBe('google-sub-1');
+    expect(session.user.photoUrl).toBe('https://example.com/alice.png');
     expect(authService.getUserForSessionToken(session.sessionToken)?.id).toBe(
       session.user.id,
     );
@@ -67,6 +69,30 @@ describe('Auth and ownership flows', () => {
     expect(visibleToAlice).toContain('Shared task');
     expect(visibleToAlice).toContain('Alice private task');
     expect(visibleToAlice).not.toContain('Bob private task');
+  });
+
+  it('invalidates the server session on logout', async () => {
+    const authService = new AuthService(
+      usersRepo,
+      sessionsRepo,
+      {
+        verifyIdToken: async (): Promise<GoogleIdentity> => ({
+          sub: 'google-sub-logout',
+          email: 'alice@example.com',
+          name: 'Alice',
+          picture: null,
+        }),
+      } as never,
+    );
+
+    const session = await authService.loginWithGoogleIdToken('fake-id-token');
+    expect(authService.getUserForSessionToken(session.sessionToken)?.email).toBe(
+      'alice@example.com',
+    );
+
+    authService.logout(session.sessionToken);
+
+    expect(authService.getUserForSessionToken(session.sessionToken)).toBeNull();
   });
 
   it('tracks unread messages until the thread is marked read', () => {
@@ -92,5 +118,63 @@ describe('Auth and ownership flows', () => {
     const bobThreadsAfterRead = messagesRepo.findAllThreadsForUser(bob.id);
     expect(bobThreadsAfterRead[0].unreadCount).toBe(0);
     expect(bobThreadsAfterRead[0].isUnread).toBe(false);
+  });
+
+  it('reuses the existing direct thread for the same two participants', () => {
+    const alice = usersRepo.create({ name: 'Alice', email: 'alice@example.com' });
+    const bob = usersRepo.create({ name: 'Bob', email: 'bob@example.com' });
+
+    const first = messagesRepo.createThread({
+      createdBy: alice.id,
+      participantIds: [bob.id],
+    });
+    const second = messagesRepo.createThread({
+      createdBy: alice.id,
+      participantIds: [bob.id],
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(messagesRepo.findAllThreadsForUser(alice.id)).toHaveLength(1);
+    expect(second.participants.map((participant) => participant.email)).toEqual([
+      'alice@example.com',
+      'bob@example.com',
+    ]);
+  });
+
+  it('sends a direct notification message without creating duplicate threads', () => {
+    const alice = usersRepo.create({ name: 'Alice', email: 'alice@example.com' });
+    const bob = usersRepo.create({ name: 'Bob', email: 'bob@example.com' });
+
+    const first = messagesRepo.sendDirectMessage(
+      alice.id,
+      bob.id,
+      'Your facility reservation was deleted by Alice.',
+    );
+    const second = messagesRepo.sendDirectMessage(
+      alice.id,
+      bob.id,
+      'Go to Facilities to resubmit a reservation.',
+    );
+
+    const bobThreads = messagesRepo.findAllThreadsForUser(bob.id);
+    expect(bobThreads).toHaveLength(1);
+    expect(bobThreads[0].unreadCount).toBe(2);
+
+    const messages = messagesRepo.findMessagesByThread(first.threadId, bob.id);
+    expect(messages.map((message) => message.body)).toEqual([
+      'Your facility reservation was deleted by Alice.',
+      'Go to Facilities to resubmit a reservation.',
+    ]);
+    expect(second.threadId).toBe(first.threadId);
+  });
+
+  it('creates or reuses a dedicated Rhythm Bot user', () => {
+    const first = usersRepo.findOrCreateSystemBot();
+    const second = usersRepo.findOrCreateSystemBot();
+
+    expect(first.name).toBe('Rhythm Bot');
+    expect(first.email).toBe('rhythm-bot@rhythm.local');
+    expect(first.role).toBe('system');
+    expect(second.id).toBe(first.id);
   });
 });

--- a/apps/api_server/src/app.ts
+++ b/apps/api_server/src/app.ts
@@ -3,6 +3,7 @@ import express from 'express';
 
 import { errorHandler } from './middleware/error_handler';
 import { authRouter } from './routes/auth_routes';
+import { automationCatalogRouter } from './routes/automation_catalog_routes';
 import { automationRulesRouter } from './routes/automation_rules_routes';
 import { facilitiesRouter } from './routes/facilities_routes';
 import { healthRouter } from './routes/health_routes';
@@ -23,6 +24,7 @@ export function createApp() {
 
   app.use('/health', healthRouter);
   app.use('/auth', authRouter);
+  app.use('/automation-catalog', automationCatalogRouter);
   app.use('/automation-rules', automationRulesRouter);
   app.use('/integrations', integrationsRouter);
   app.use('/tasks', tasksRouter);

--- a/apps/api_server/src/controllers/automation_catalog_controller.ts
+++ b/apps/api_server/src/controllers/automation_catalog_controller.ts
@@ -1,0 +1,30 @@
+import type { NextFunction, Request, Response } from 'express';
+import { AutomationCatalogService } from '../services/automation_catalog_service';
+
+const service = new AutomationCatalogService();
+
+export class AutomationCatalogController {
+  getTriggers(_req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(service.getTriggers());
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  getActions(_req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(service.getActions());
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  getProviders(_req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(service.getProviders());
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/apps/api_server/src/controllers/automation_catalog_controller.ts
+++ b/apps/api_server/src/controllers/automation_catalog_controller.ts
@@ -1,12 +1,14 @@
 import type { NextFunction, Request, Response } from 'express';
+import { IntegrationAccountsRepository } from '../repositories/integration_accounts_repository';
 import { AutomationCatalogService } from '../services/automation_catalog_service';
 
 const service = new AutomationCatalogService();
+const accountsRepo = new IntegrationAccountsRepository();
 
 export class AutomationCatalogController {
   getTriggers(_req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(service.getTriggers());
+      res.json(service.getTriggersForAccounts(accountsRepo.findAll()));
     } catch (err) {
       next(err);
     }
@@ -22,7 +24,7 @@ export class AutomationCatalogController {
 
   getProviders(_req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(service.getProviders());
+      res.json(service.getProvidersForAccounts(accountsRepo.findAll()));
     } catch (err) {
       next(err);
     }

--- a/apps/api_server/src/controllers/automation_rules_controller.ts
+++ b/apps/api_server/src/controllers/automation_rules_controller.ts
@@ -1,29 +1,15 @@
 import type { NextFunction, Request, Response } from 'express';
 import { AppError } from '../errors/app_error';
 import { AutomationRulesRepository } from '../repositories/automation_rules_repository';
-import type {
-  AutomationActionType,
-  AutomationTriggerType,
-} from '../models/automation_rule';
-
-const VALID_TRIGGER_TYPES: AutomationTriggerType[] = [
-  'project_step_due',
-  'task_due',
-  'plan_assembly',
-];
-
-const VALID_ACTION_TYPES: AutomationActionType[] = [
-  'auto_schedule',
-  'send_notification',
-  'tag_task',
-];
+import { AutomationCatalogService } from '../services/automation_catalog_service';
 
 const repo = new AutomationRulesRepository();
+const catalog = new AutomationCatalogService();
 
 export class AutomationRulesController {
-  getAll(_req: Request, res: Response, next: NextFunction) {
+  getAll(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(repo.findAll());
+      res.json(repo.findAll(req.auth?.user.id));
     } catch (err) {
       next(err);
     }
@@ -31,7 +17,23 @@ export class AutomationRulesController {
 
   getById(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(repo.findById(req.params.id));
+      res.json(repo.findById(req.params.id, req.auth?.user.id));
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  getPreview(req: Request, res: Response, next: NextFunction) {
+    try {
+      const rule = repo.findById(req.params.id, req.auth?.user.id);
+      res.json({
+        ruleId: rule.id,
+        previewSample: rule.previewSample,
+        lastMatchedAt: rule.lastMatchedAt,
+        lastEvaluatedAt: rule.lastEvaluatedAt,
+        matchCountLastRun: rule.matchCountLastRun,
+        summary: `${rule.name}: ${rule.triggerKey} -> ${rule.actionType}`,
+      });
     } catch (err) {
       next(err);
     }
@@ -39,36 +41,50 @@ export class AutomationRulesController {
 
   create(req: Request, res: Response, next: NextFunction) {
     try {
-      const { name, triggerType, triggerConfig, actionType, actionConfig, enabled } =
-        req.body as Record<string, unknown>;
+      const {
+        name,
+        source,
+        triggerKey,
+        triggerConfig,
+        actionType,
+        actionConfig,
+        enabled,
+        sourceAccountId,
+      } = req.body as Record<string, unknown>;
 
       if (!name || typeof name !== 'string') {
         throw AppError.badRequest('name is required');
       }
-      if (!triggerType || !VALID_TRIGGER_TYPES.includes(triggerType as AutomationTriggerType)) {
-        throw AppError.badRequest(
-          `triggerType must be one of: ${VALID_TRIGGER_TYPES.join(', ')}`,
-        );
+      if (!source || typeof source !== 'string') {
+        throw AppError.badRequest('source is required');
       }
-      if (!actionType || !VALID_ACTION_TYPES.includes(actionType as AutomationActionType)) {
-        throw AppError.badRequest(
-          `actionType must be one of: ${VALID_ACTION_TYPES.join(', ')}`,
-        );
+      if (!triggerKey || !catalog.isValidTriggerKey(String(triggerKey))) {
+        throw AppError.badRequest('triggerKey is invalid');
+      }
+      const trigger = catalog.findTrigger(String(triggerKey));
+      if (trigger == null || trigger.source !== source) {
+        throw AppError.badRequest('triggerKey does not belong to source');
+      }
+      if (!actionType || !catalog.isValidActionType(String(actionType))) {
+        throw AppError.badRequest('actionType is invalid');
       }
 
       const rule = repo.create({
         name,
-        triggerType: triggerType as AutomationTriggerType,
+        source: source as never,
+        triggerKey: triggerKey as never,
         triggerConfig:
           triggerConfig && typeof triggerConfig === 'object'
             ? (triggerConfig as Record<string, unknown>)
             : undefined,
-        actionType: actionType as AutomationActionType,
+        actionType: actionType as never,
         actionConfig:
           actionConfig && typeof actionConfig === 'object'
             ? (actionConfig as Record<string, unknown>)
             : undefined,
         enabled: typeof enabled === 'boolean' ? enabled : true,
+        ownerId: req.auth?.user.id ?? null,
+        sourceAccountId: typeof sourceAccountId === 'string' ? sourceAccountId : null,
       });
 
       res.status(201).json(rule);
@@ -79,9 +95,55 @@ export class AutomationRulesController {
 
   update(req: Request, res: Response, next: NextFunction) {
     try {
+      const body = req.body as Record<string, unknown>;
+      if (
+        body.triggerKey &&
+        (!catalog.isValidTriggerKey(String(body.triggerKey)) ||
+          (body.source &&
+            catalog.findTrigger(String(body.triggerKey))?.source !== body.source))
+      ) {
+        throw AppError.badRequest('triggerKey is invalid');
+      }
+      if (
+        body.actionType &&
+        !catalog.isValidActionType(String(body.actionType))
+      ) {
+        throw AppError.badRequest('actionType is invalid');
+      }
       const rule = repo.update(
         req.params.id,
-        req.body as Record<string, unknown>,
+        {
+          name: typeof body.name === 'string' ? body.name : undefined,
+          source: typeof body.source === 'string' ? (body.source as never) : undefined,
+          triggerKey:
+            typeof body.triggerKey === 'string'
+              ? (body.triggerKey as never)
+              : undefined,
+          triggerConfig:
+            body.triggerConfig && typeof body.triggerConfig === 'object'
+              ? (body.triggerConfig as Record<string, unknown>)
+              : body.triggerConfig === null
+                ? null
+                : undefined,
+          actionType:
+            typeof body.actionType === 'string'
+              ? (body.actionType as never)
+              : undefined,
+          actionConfig:
+            body.actionConfig && typeof body.actionConfig === 'object'
+              ? (body.actionConfig as Record<string, unknown>)
+              : body.actionConfig === null
+                ? null
+                : undefined,
+          enabled: typeof body.enabled === 'boolean' ? body.enabled : undefined,
+          sourceAccountId:
+            typeof body.sourceAccountId === 'string'
+              ? body.sourceAccountId
+              : body.sourceAccountId === null
+                ? null
+                : undefined,
+        },
+        req.auth?.user.id,
       );
       res.json(rule);
     } catch (err) {
@@ -91,7 +153,7 @@ export class AutomationRulesController {
 
   remove(req: Request, res: Response, next: NextFunction) {
     try {
-      repo.delete(req.params.id);
+      repo.delete(req.params.id, req.auth?.user.id);
       res.status(204).send();
     } catch (err) {
       next(err);

--- a/apps/api_server/src/controllers/automation_rules_controller.ts
+++ b/apps/api_server/src/controllers/automation_rules_controller.ts
@@ -6,6 +6,61 @@ import { AutomationCatalogService } from '../services/automation_catalog_service
 const repo = new AutomationRulesRepository();
 const catalog = new AutomationCatalogService();
 
+function describeSource(source: string): string {
+  return (
+    catalog.getProviders().find((item) => item.source === source)?.label ?? source
+  );
+}
+
+function summarizeConfig(config: Record<string, unknown> | null): string[] {
+  if (config == null) return [];
+  const items: string[] = [];
+  const pushIfString = (label: string, value: unknown) => {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      items.push(`${label} ${value.trim()}`);
+    }
+  };
+  const pushIfNumber = (label: string, value: unknown, suffix = '') => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      items.push(`${label} ${value}${suffix}`);
+    }
+  };
+
+  pushIfString('team', config.teamId);
+  pushIfString('position', config.positionName);
+  pushIfString('service', config.serviceType);
+  pushIfString('match', config.textQuery);
+  pushIfString('sender', config.sender);
+  pushIfString('subject', config.subjectContains);
+  pushIfString('label', config.label);
+  pushIfString('template', config.templateName);
+  pushIfString('tag', config.tag);
+  pushIfNumber('within', config.leadDays, ' days');
+  pushIfNumber('window', config.dateWindowDays, ' days');
+  pushIfNumber('received within', config.hoursSinceReceived, ' hours');
+  if (config.allDayOnly == true) items.push('all-day only');
+  return items;
+}
+
+function buildPreviewSummary(rule: ReturnType<AutomationRulesRepository['findById']>): string {
+  const trigger = catalog.findTrigger(rule.triggerKey);
+  const action = catalog.getActions().find((item) => item.key === rule.actionType);
+  const parts = [
+    `When ${trigger?.label ?? rule.triggerKey}`,
+    `from ${describeSource(rule.source)}`,
+  ];
+  const triggerDetails = summarizeConfig(rule.triggerConfig);
+  if (triggerDetails.length > 0) {
+    parts.push(`with ${triggerDetails.join(', ')}`);
+  }
+  parts.push(`then ${action?.label.toLowerCase() ?? rule.actionType}`);
+  const actionDetails = summarizeConfig(rule.actionConfig);
+  if (actionDetails.length > 0) {
+    parts.push(`using ${actionDetails.join(', ')}`);
+  }
+  return `${parts.join(' ')}.`;
+}
+
 export class AutomationRulesController {
   getAll(req: Request, res: Response, next: NextFunction) {
     try {
@@ -32,7 +87,7 @@ export class AutomationRulesController {
         lastMatchedAt: rule.lastMatchedAt,
         lastEvaluatedAt: rule.lastEvaluatedAt,
         matchCountLastRun: rule.matchCountLastRun,
-        summary: `${rule.name}: ${rule.triggerKey} -> ${rule.actionType}`,
+        summary: buildPreviewSummary(rule),
       });
     } catch (err) {
       next(err);

--- a/apps/api_server/src/controllers/facilities_controller.ts
+++ b/apps/api_server/src/controllers/facilities_controller.ts
@@ -1,8 +1,12 @@
 import type { NextFunction, Request, Response } from 'express';
 import { AppError } from '../errors/app_error';
 import { FacilitiesRepository } from '../repositories/facilities_repository';
+import { MessagesRepository } from '../repositories/messages_repository';
+import { UsersRepository } from '../repositories/users_repository';
 
 const repo = new FacilitiesRepository();
+const messagesRepo = new MessagesRepository();
+const usersRepo = new UsersRepository();
 
 export class FacilitiesController {
   getAll(_req: Request, res: Response, next: NextFunction) {
@@ -78,6 +82,53 @@ export class FacilitiesController {
         notes: notes as string | null | undefined,
       });
       res.status(201).json(reservation);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  updateReservation(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { title, start_time, end_time, notes } =
+        req.body as Record<string, unknown>;
+      const reservation = repo.updateReservation(
+        Number(req.params.id),
+        Number(req.params.reservationId),
+        {
+          ...(typeof title === 'string' ? { title } : {}),
+          ...(typeof start_time === 'string' ? { start_time } : {}),
+          ...(typeof end_time === 'string' ? { end_time } : {}),
+          ...(notes !== undefined ? { notes: (notes as string | null) ?? null } : {}),
+          reserved_by: req.auth?.user.name ?? 'Unknown user',
+          reserved_by_user_id: req.auth?.user.id ?? null,
+        },
+      );
+      res.json(reservation);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  deleteReservation(req: Request, res: Response, next: NextFunction) {
+    try {
+      const deletedReservation = repo.deleteReservation(
+        Number(req.params.id),
+        Number(req.params.reservationId),
+      );
+      const actor = req.auth?.user;
+      if (
+        actor != null &&
+        deletedReservation.reservedByUserId != null &&
+        deletedReservation.reservedByUserId !== actor.id
+      ) {
+        const bot = usersRepo.findOrCreateSystemBot();
+        messagesRepo.sendDirectMessage(
+          bot.id,
+          deletedReservation.reservedByUserId,
+          `Your facility reservation was deleted by ${actor.name}. Go to Facilities to resubmit a reservation.`,
+        );
+      }
+      res.status(204).send();
     } catch (err) {
       next(err);
     }

--- a/apps/api_server/src/controllers/integrations_controller.ts
+++ b/apps/api_server/src/controllers/integrations_controller.ts
@@ -4,37 +4,50 @@ import type {
   IntegrationProvider,
 } from '../models/integration_account';
 import { IntegrationAccountsRepository } from '../repositories/integration_accounts_repository';
+import { AutomationCatalogService } from '../services/automation_catalog_service';
 import { IntegrationsService } from '../services/integrations_service';
 
 const repo = new IntegrationAccountsRepository();
 const service = new IntegrationsService();
+const catalog = new AutomationCatalogService();
 
 function toAccountDto(
   provider: IntegrationProvider,
   account: IntegrationAccount | null,
 ) {
+  const providerMeta = catalog
+    .getProviders()
+    .find((item) => item.source === provider);
   if (!account) {
     return {
       id: provider,
       provider,
+      providerDisplayName: providerMeta?.label ?? provider,
+      accountLabel: null,
       email: null,
       displayName: null,
       status: 'error',
       expiresAt: null,
       lastSyncedAt: null,
       errorMessage: null,
+      availableTriggerFamilies: providerMeta?.triggerKeys ?? [],
+      syncSupportMode: providerMeta?.syncSupport ?? 'manual',
     };
   }
 
   return {
     id: account.id,
     provider: account.provider,
+    providerDisplayName: providerMeta?.label ?? account.provider,
+    accountLabel: account.displayName ?? account.email,
     email: account.email,
     displayName: account.displayName,
     status: account.status,
     expiresAt: account.expiresAt,
     lastSyncedAt: account.lastSyncedAt,
     errorMessage: account.errorMessage,
+    availableTriggerFamilies: providerMeta?.triggerKeys ?? [],
+    syncSupportMode: providerMeta?.syncSupport ?? 'manual',
   };
 }
 

--- a/apps/api_server/src/controllers/integrations_controller.ts
+++ b/apps/api_server/src/controllers/integrations_controller.ts
@@ -26,7 +26,7 @@ function toAccountDto(
       accountLabel: null,
       email: null,
       displayName: null,
-      status: 'error',
+      status: 'disconnected',
       expiresAt: null,
       lastSyncedAt: null,
       errorMessage: null,

--- a/apps/api_server/src/controllers/messages_controller.ts
+++ b/apps/api_server/src/controllers/messages_controller.ts
@@ -15,12 +15,11 @@ export class MessagesController {
 
   createThread(req: Request, res: Response, next: NextFunction) {
     try {
-      const { title, participantIds } = req.body as Record<string, unknown>;
+      const { participantIds } = req.body as Record<string, unknown>;
       if (!Array.isArray(participantIds) || participantIds.length === 0) {
         throw AppError.badRequest('participantIds is required');
       }
       const thread = repo.createThread({
-        title: typeof title === 'string' ? title : null,
         createdBy: req.auth!.user.id,
         participantIds: participantIds.map((value) => Number(value)),
       });

--- a/apps/api_server/src/controllers/recurring_rules_controller.ts
+++ b/apps/api_server/src/controllers/recurring_rules_controller.ts
@@ -82,7 +82,7 @@ export class RecurringRulesController {
 
   remove(req: Request, res: Response, next: NextFunction) {
     try {
-      repo.delete(req.params.id);
+      repo.delete(req.params.id, req.auth?.user.id);
       res.status(204).send();
     } catch (err) {
       next(err);

--- a/apps/api_server/src/controllers/tasks_controller.ts
+++ b/apps/api_server/src/controllers/tasks_controller.ts
@@ -55,7 +55,7 @@ export class TasksController {
 
   remove(req: Request, res: Response, next: NextFunction) {
     try {
-      repo.delete(req.params.id);
+      repo.delete(req.params.id, req.auth?.user.id);
       res.status(204).send();
     } catch (err) {
       next(err);

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -133,11 +133,27 @@ export function runMigrations(db: Database.Database): void {
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
+    CREATE TABLE IF NOT EXISTS automation_signals (
+      id TEXT PRIMARY KEY,
+      provider TEXT NOT NULL,
+      signal_type TEXT NOT NULL,
+      external_id TEXT NOT NULL,
+      dedupe_key TEXT NOT NULL UNIQUE,
+      occurred_at TEXT,
+      synced_at TEXT NOT NULL,
+      source_account_id TEXT,
+      source_label TEXT,
+      payload_json TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
     CREATE TABLE IF NOT EXISTS users (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL,
       email TEXT NOT NULL UNIQUE,
       google_sub TEXT UNIQUE,
+      photo_url TEXT,
       role TEXT NOT NULL DEFAULT 'member',
       password_hash TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -242,9 +258,58 @@ export function runMigrations(db: Database.Database): void {
     db.exec(`ALTER TABLE users ADD COLUMN google_sub TEXT`);
     db.exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_users_google_sub ON users(google_sub) WHERE google_sub IS NOT NULL`);
   }
+  if (!userCols.includes('photo_url')) {
+    db.exec(`ALTER TABLE users ADD COLUMN photo_url TEXT`);
+  }
 
   const reservationCols = (db.pragma('table_info(reservations)') as { name: string }[]).map((c) => c.name);
   if (!reservationCols.includes('reserved_by_user_id')) {
     db.exec(`ALTER TABLE reservations ADD COLUMN reserved_by_user_id INTEGER REFERENCES users(id)`);
   }
+
+  const automationRuleCols = (db.pragma('table_info(automation_rules)') as { name: string }[]).map((c) => c.name);
+  if (!automationRuleCols.includes('owner_id')) {
+    db.exec(`ALTER TABLE automation_rules ADD COLUMN owner_id INTEGER REFERENCES users(id)`);
+  }
+  if (!automationRuleCols.includes('source')) {
+    db.exec(`ALTER TABLE automation_rules ADD COLUMN source TEXT`);
+  }
+  if (!automationRuleCols.includes('trigger_key')) {
+    db.exec(`ALTER TABLE automation_rules ADD COLUMN trigger_key TEXT`);
+  }
+  if (!automationRuleCols.includes('source_account_id')) {
+    db.exec(`ALTER TABLE automation_rules ADD COLUMN source_account_id TEXT REFERENCES integration_accounts(id)`);
+  }
+  if (!automationRuleCols.includes('last_evaluated_at')) {
+    db.exec(`ALTER TABLE automation_rules ADD COLUMN last_evaluated_at TEXT`);
+  }
+  if (!automationRuleCols.includes('last_matched_at')) {
+    db.exec(`ALTER TABLE automation_rules ADD COLUMN last_matched_at TEXT`);
+  }
+  if (!automationRuleCols.includes('match_count_last_run')) {
+    db.exec(`ALTER TABLE automation_rules ADD COLUMN match_count_last_run INTEGER NOT NULL DEFAULT 0`);
+  }
+  if (!automationRuleCols.includes('preview_sample')) {
+    db.exec(`ALTER TABLE automation_rules ADD COLUMN preview_sample TEXT`);
+  }
+  db.exec(`
+    UPDATE automation_rules
+    SET source = CASE trigger_type
+      WHEN 'project_step_due' THEN 'rhythm'
+      WHEN 'task_due' THEN 'rhythm'
+      WHEN 'plan_assembly' THEN 'rhythm'
+      ELSE COALESCE(source, 'rhythm')
+    END
+    WHERE source IS NULL
+  `);
+  db.exec(`
+    UPDATE automation_rules
+    SET trigger_key = CASE trigger_type
+      WHEN 'project_step_due' THEN 'rhythm.project_step_due'
+      WHEN 'task_due' THEN 'rhythm.task_due'
+      WHEN 'plan_assembly' THEN 'rhythm.plan_assembly'
+      ELSE COALESCE(trigger_key, trigger_type)
+    END
+    WHERE trigger_key IS NULL
+  `);
 }

--- a/apps/api_server/src/errors/app_error.ts
+++ b/apps/api_server/src/errors/app_error.ts
@@ -20,6 +20,10 @@ export class AppError extends Error {
     return new AppError(401, 'UNAUTHORIZED', message);
   }
 
+  static conflict(message: string): AppError {
+    return new AppError(409, 'CONFLICT', message);
+  }
+
   static internal(message = 'Internal server error'): AppError {
     return new AppError(500, 'INTERNAL_ERROR', message);
   }

--- a/apps/api_server/src/integrations/planning_center/planning_center_service.ts
+++ b/apps/api_server/src/integrations/planning_center/planning_center_service.ts
@@ -26,6 +26,14 @@ interface PlanningCenterTaskSignal {
   scheduledDate: string;
   dedupeKey: string;
   teamId: string | null;
+  teamName: string | null;
+  positionName: string;
+  signalType: 'needed_position_open' | 'team_member_declined' | 'team_member_unconfirmed';
+  serviceTypeName: string;
+  planId: string;
+  planTitle: string;
+  planDate: string;
+  daysUntil: number;
 }
 
 interface PlanningCenterProjectSignal {
@@ -33,11 +41,22 @@ interface PlanningCenterProjectSignal {
   name: string;
   serviceTypeName: string;
   planId: string;
+  title: string;
+  daysUntil: number;
+}
+
+interface PlanningCenterPlanSignal {
+  planId: string;
+  title: string;
+  serviceTypeName: string;
+  planDate: string;
+  daysUntil: number;
 }
 
 interface PlanningCenterAutomationSignals {
   tasks: PlanningCenterTaskSignal[];
   specialProjects: PlanningCenterProjectSignal[];
+  upcomingPlans: PlanningCenterPlanSignal[];
   planCount: number;
 }
 
@@ -167,6 +186,7 @@ export class PlanningCenterService {
     const serviceTypes = await this.fetchServiceTypes(account, preferences);
     const tasks: PlanningCenterTaskSignal[] = [];
     const specialProjects: PlanningCenterProjectSignal[] = [];
+    const upcomingPlans: PlanningCenterPlanSignal[] = [];
     let planCount = 0;
 
     for (const serviceType of serviceTypes) {
@@ -175,7 +195,14 @@ export class PlanningCenterService {
 
       for (const plan of plans) {
         const planLeadDays = daysUntil(plan.planDate);
-        const [neededSignals, declineSignals] = await Promise.all([
+        upcomingPlans.push({
+          planId: plan.id,
+          title: plan.title,
+          serviceTypeName: plan.serviceTypeName,
+          planDate: plan.planDate,
+          daysUntil: planLeadDays,
+        });
+        const [neededSignals, declineSignals, unconfirmedSignals] = await Promise.all([
           planLeadDays <= env.pcoNeededTaskWindowDays
               ? this.fetchNeededPositionSignals(account, plan)
               .then((signals) =>
@@ -194,12 +221,22 @@ export class PlanningCenterService {
                 ),
               )
               : Promise.resolve([]),
+          planLeadDays <= env.pcoDeclineTaskWindowDays
+              ? this.fetchUnconfirmedSignals(account, plan)
+              .then((signals) =>
+                signals.filter((signal) =>
+                  teamAllowed(signal.teamId, preferences) &&
+                  positionAllowed(signal.positionName, preferences),
+                ),
+              )
+              : Promise.resolve([]),
         ]);
         const declinedKeys = new Set(
           declineSignals.map((signal) => signal.dedupeKey),
         );
         tasks.push(
           ...declineSignals,
+          ...unconfirmedSignals.filter((signal) => !declinedKeys.has(signal.dedupeKey)),
           ...neededSignals.filter((signal) => !declinedKeys.has(signal.dedupeKey)),
         );
 
@@ -213,12 +250,14 @@ export class PlanningCenterService {
             name: plan.title,
             serviceTypeName: plan.serviceTypeName,
             planId: plan.id,
+            title: plan.title,
+            daysUntil: planLeadDays,
           });
         }
       }
     }
 
-    return { tasks, specialProjects, planCount };
+    return { tasks, specialProjects, upcomingPlans, planCount };
   }
 
   specialServiceTemplateName(): string {
@@ -397,7 +436,14 @@ export class PlanningCenterService {
         scheduledDate: mondayOfServiceWeek(plan.planDate),
         dedupeKey: roleKey(plan.id, positionName),
         teamId: resource.relationships?.team?.data?.id ?? null,
+        teamName: null,
         positionName,
+        signalType: 'needed_position_open',
+        serviceTypeName: plan.serviceTypeName,
+        planId: plan.id,
+        planTitle: plan.title,
+        planDate: plan.planDate,
+        daysUntil: daysUntil(plan.planDate),
       });
     }
 
@@ -458,9 +504,67 @@ export class PlanningCenterService {
         scheduledDate: mondayOfServiceWeek(plan.planDate),
         dedupeKey: key,
         teamId: entry.teamId,
+        teamName: null,
         positionName: entry.positionName,
+        signalType: 'team_member_declined',
+        serviceTypeName: plan.serviceTypeName,
+        planId: plan.id,
+        planTitle: plan.title,
+        planDate: plan.planDate,
+        daysUntil: daysUntil(plan.planDate),
       };
     });
+  }
+
+  private async fetchUnconfirmedSignals(
+    account: IntegrationAccount,
+    plan: PlanSummary,
+  ): Promise<Array<PlanningCenterTaskSignal & { positionName: string }>> {
+    const payload = await this.getJson(
+      account,
+      `/services/v2/service_types/${plan.serviceTypeId}/plans/${plan.id}/team_members?per_page=100`,
+    );
+
+    return (payload.data ?? [])
+      .map((resource) => {
+        const attrs = resource.attributes ?? {};
+        const status = (asString(attrs.status) ?? '').toLowerCase();
+        if (status != 'unconfirmed' && status != 'u') return null;
+
+        const personName =
+          asString(attrs.person_name) ??
+          asString(attrs.name) ??
+          asString(attrs.team_member_name) ??
+          'Someone';
+        const positionName =
+          asString(attrs.team_position_name) ??
+          asString(attrs.position_name) ??
+          'position';
+
+        return {
+          sourceId: `planning_center:unconfirmed:${plan.id}:${resource.id}`,
+          title: `Confirm ${positionName} for ${plan.title}`,
+          notes:
+            `${personName} is still unconfirmed for the ${positionName}` +
+            ` assignment in Planning Center for ${plan.serviceTypeName} on ${plan.planDate}.`,
+          dueDate: plan.planDate,
+          scheduledDate: mondayOfServiceWeek(plan.planDate),
+          dedupeKey: `${roleKey(plan.id, positionName)}:unconfirmed:${resource.id}`,
+          teamId: resource.relationships?.team?.data?.id ?? null,
+          teamName: null,
+          positionName,
+          signalType: 'team_member_unconfirmed' as const,
+          serviceTypeName: plan.serviceTypeName,
+          planId: plan.id,
+          planTitle: plan.title,
+          planDate: plan.planDate,
+          daysUntil: daysUntil(plan.planDate),
+        };
+      })
+      .filter(
+        (signal): signal is PlanningCenterTaskSignal & { positionName: string } =>
+          signal != null,
+      );
   }
 
   private async getJson(

--- a/apps/api_server/src/integrations/planning_center/planning_center_service.ts
+++ b/apps/api_server/src/integrations/planning_center/planning_center_service.ts
@@ -525,11 +525,12 @@ export class PlanningCenterService {
       `/services/v2/service_types/${plan.serviceTypeId}/plans/${plan.id}/team_members?per_page=100`,
     );
 
-    return (payload.data ?? [])
-      .map((resource) => {
+    const signals: Array<PlanningCenterTaskSignal & { positionName: string }> =
+      [];
+    for (const resource of payload.data ?? []) {
         const attrs = resource.attributes ?? {};
         const status = (asString(attrs.status) ?? '').toLowerCase();
-        if (status != 'unconfirmed' && status != 'u') return null;
+        if (status != 'unconfirmed' && status != 'u') continue;
 
         const personName =
           asString(attrs.person_name) ??
@@ -541,7 +542,7 @@ export class PlanningCenterService {
           asString(attrs.position_name) ??
           'position';
 
-        return {
+        signals.push({
           sourceId: `planning_center:unconfirmed:${plan.id}:${resource.id}`,
           title: `Confirm ${positionName} for ${plan.title}`,
           notes:
@@ -559,12 +560,10 @@ export class PlanningCenterService {
           planTitle: plan.title,
           planDate: plan.planDate,
           daysUntil: daysUntil(plan.planDate),
-        };
-      })
-      .filter(
-        (signal): signal is PlanningCenterTaskSignal & { positionName: string } =>
-          signal != null,
-      );
+        });
+    }
+
+    return signals;
   }
 
   private async getJson(

--- a/apps/api_server/src/models/automation_catalog.ts
+++ b/apps/api_server/src/models/automation_catalog.ts
@@ -1,0 +1,29 @@
+import type {
+  AutomationActionType,
+  AutomationRuleSource,
+  AutomationTriggerKey,
+} from './automation_rule';
+
+export interface AutomationTriggerCatalogItem {
+  key: AutomationTriggerKey;
+  source: AutomationRuleSource;
+  label: string;
+  description: string;
+  signalTypes: string[];
+  configSchema: Record<string, unknown>;
+}
+
+export interface AutomationActionCatalogItem {
+  key: AutomationActionType;
+  label: string;
+  description: string;
+  configSchema: Record<string, unknown>;
+}
+
+export interface AutomationProviderCatalogItem {
+  source: AutomationRuleSource;
+  label: string;
+  description: string;
+  syncSupport: 'manual' | 'scheduled' | 'push_capable';
+  triggerKeys: AutomationTriggerKey[];
+}

--- a/apps/api_server/src/models/automation_rule.ts
+++ b/apps/api_server/src/models/automation_rule.ts
@@ -1,39 +1,69 @@
-export type AutomationTriggerType =
-  | 'project_step_due'
-  | 'task_due'
-  | 'plan_assembly';
-
 export type AutomationActionType =
+  | 'create_task'
+  | 'create_project_from_template'
   | 'auto_schedule'
   | 'send_notification'
   | 'tag_task';
 
+export type AutomationRuleSource =
+  | 'rhythm'
+  | 'planning_center'
+  | 'google_calendar'
+  | 'gmail';
+
+export type AutomationTriggerKey =
+  | 'rhythm.project_step_due'
+  | 'rhythm.task_due'
+  | 'rhythm.plan_assembly'
+  | 'planning_center.plan_upcoming'
+  | 'planning_center.plan_person_declined'
+  | 'planning_center.plan_person_unconfirmed'
+  | 'planning_center.needed_position_open'
+  | 'planning_center.special_service_candidate'
+  | 'google_calendar.event_matching_filter'
+  | 'google_calendar.all_day_event'
+  | 'gmail.message_matching_filter'
+  | 'gmail.unread_message_matching_filter';
+
 export interface AutomationRule {
   id: string;
   name: string;
-  triggerType: AutomationTriggerType;
+  source: AutomationRuleSource;
+  triggerKey: AutomationTriggerKey;
   triggerConfig: Record<string, unknown> | null;
   actionType: AutomationActionType;
   actionConfig: Record<string, unknown> | null;
   enabled: boolean;
+  ownerId: number | null;
+  sourceAccountId: string | null;
+  lastEvaluatedAt: string | null;
+  lastMatchedAt: string | null;
+  matchCountLastRun: number;
+  previewSample: Record<string, unknown> | null;
   createdAt: string;
   updatedAt: string;
 }
 
 export interface CreateAutomationRuleDto {
   name: string;
-  triggerType: AutomationTriggerType;
+  source: AutomationRuleSource;
+  triggerKey: AutomationTriggerKey;
   triggerConfig?: Record<string, unknown>;
   actionType: AutomationActionType;
   actionConfig?: Record<string, unknown>;
   enabled?: boolean;
+  ownerId?: number | null;
+  sourceAccountId?: string | null;
 }
 
 export interface UpdateAutomationRuleDto {
   name?: string;
-  triggerType?: AutomationTriggerType;
+  source?: AutomationRuleSource;
+  triggerKey?: AutomationTriggerKey;
   triggerConfig?: Record<string, unknown> | null;
   actionType?: AutomationActionType;
   actionConfig?: Record<string, unknown> | null;
   enabled?: boolean;
+  ownerId?: number | null;
+  sourceAccountId?: string | null;
 }

--- a/apps/api_server/src/models/automation_signal.ts
+++ b/apps/api_server/src/models/automation_signal.ts
@@ -1,0 +1,40 @@
+import type { AutomationRuleSource } from './automation_rule';
+
+export type AutomationSignalType =
+  | 'plan_upcoming'
+  | 'needed_position_open'
+  | 'team_member_declined'
+  | 'team_member_unconfirmed'
+  | 'special_service_candidate'
+  | 'calendar_event_seen'
+  | 'calendar_event_today'
+  | 'gmail_message_seen'
+  | 'gmail_unread_message_seen'
+  | 'gmail_message_from_sender';
+
+export interface AutomationSignal {
+  id: string;
+  provider: AutomationRuleSource;
+  signalType: AutomationSignalType;
+  externalId: string;
+  dedupeKey: string;
+  occurredAt: string | null;
+  syncedAt: string;
+  sourceAccountId: string | null;
+  sourceLabel: string | null;
+  payload: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateAutomationSignalDto {
+  provider: AutomationRuleSource;
+  signalType: AutomationSignalType;
+  externalId: string;
+  dedupeKey: string;
+  occurredAt?: string | null;
+  syncedAt: string;
+  sourceAccountId?: string | null;
+  sourceLabel?: string | null;
+  payload: Record<string, unknown>;
+}

--- a/apps/api_server/src/models/facility.ts
+++ b/apps/api_server/src/models/facility.ts
@@ -42,3 +42,12 @@ export interface CreateReservationDto {
   end_time: string;
   notes?: string | null;
 }
+
+export interface UpdateReservationDto {
+  title?: string;
+  reserved_by?: string;
+  reserved_by_user_id?: number | null;
+  start_time?: string;
+  end_time?: string;
+  notes?: string | null;
+}

--- a/apps/api_server/src/models/message.ts
+++ b/apps/api_server/src/models/message.ts
@@ -1,3 +1,9 @@
+export interface MessageThreadParticipant {
+  id: number;
+  name: string;
+  email: string;
+}
+
 export interface MessageThread {
   id: number;
   title: string;
@@ -7,6 +13,7 @@ export interface MessageThread {
   lastMessage?: string | null;
   unreadCount: number;
   isUnread: boolean;
+  participants: MessageThreadParticipant[];
 }
 
 export interface Message {
@@ -19,7 +26,6 @@ export interface Message {
 }
 
 export interface CreateThreadDto {
-  title?: string | null;
   createdBy: number;
   participantIds: number[];
 }

--- a/apps/api_server/src/models/user.ts
+++ b/apps/api_server/src/models/user.ts
@@ -3,6 +3,7 @@ export interface User {
   name: string;
   email: string;
   googleSub: string | null;
+  photoUrl: string | null;
   role: string;
   createdAt: string;
   updatedAt: string;
@@ -12,6 +13,7 @@ export interface CreateUserDto {
   name: string;
   email: string;
   googleSub?: string | null;
+  photoUrl?: string | null;
   role?: string;
 }
 
@@ -19,5 +21,6 @@ export interface UpdateUserDto {
   name?: string;
   email?: string;
   googleSub?: string | null;
+  photoUrl?: string | null;
   role?: string;
 }

--- a/apps/api_server/src/repositories/automation_rules_repository.ts
+++ b/apps/api_server/src/repositories/automation_rules_repository.ts
@@ -11,10 +11,18 @@ interface AutomationRuleRow {
   id: string;
   name: string;
   trigger_type: string;
+  source: string | null;
+  trigger_key: string | null;
   trigger_config: string | null;
   action_type: string;
   action_config: string | null;
   enabled: number;
+  owner_id: number | null;
+  source_account_id: string | null;
+  last_evaluated_at: string | null;
+  last_matched_at: string | null;
+  match_count_last_run: number;
+  preview_sample: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -23,30 +31,61 @@ function rowToRule(row: AutomationRuleRow): AutomationRule {
   return {
     id: row.id,
     name: row.name,
-    triggerType: row.trigger_type as AutomationRule['triggerType'],
+    source: (row.source ?? 'rhythm') as AutomationRule['source'],
+    triggerKey: (row.trigger_key ?? row.trigger_type) as AutomationRule['triggerKey'],
     triggerConfig: row.trigger_config ? JSON.parse(row.trigger_config) : null,
     actionType: row.action_type as AutomationRule['actionType'],
     actionConfig: row.action_config ? JSON.parse(row.action_config) : null,
     enabled: row.enabled === 1,
+    ownerId: row.owner_id,
+    sourceAccountId: row.source_account_id,
+    lastEvaluatedAt: row.last_evaluated_at,
+    lastMatchedAt: row.last_matched_at,
+    matchCountLastRun: row.match_count_last_run ?? 0,
+    previewSample: row.preview_sample ? JSON.parse(row.preview_sample) : null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
 }
 
 export class AutomationRulesRepository {
-  findAll(): AutomationRule[] {
-    const rows = getDb()
-      .prepare(
-        'SELECT * FROM automation_rules ORDER BY created_at ASC',
-      )
-      .all() as AutomationRuleRow[];
+  findAll(userId?: number): AutomationRule[] {
+    const rows = (userId != null
+      ? getDb()
+          .prepare(
+            `SELECT * FROM automation_rules
+             WHERE owner_id = ? OR owner_id IS NULL
+             ORDER BY created_at ASC`,
+          )
+          .all(userId)
+      : getDb()
+          .prepare('SELECT * FROM automation_rules ORDER BY created_at ASC')
+          .all()) as AutomationRuleRow[];
     return rows.map(rowToRule);
   }
 
-  findById(id: string): AutomationRule {
-    const row = getDb()
-      .prepare('SELECT * FROM automation_rules WHERE id = ?')
-      .get(id) as AutomationRuleRow | undefined;
+  findEnabledBySource(source: AutomationRule['source']): AutomationRule[] {
+    const rows = getDb()
+      .prepare(
+        `SELECT * FROM automation_rules
+         WHERE enabled = 1 AND source = ?
+         ORDER BY created_at ASC`,
+      )
+      .all(source) as AutomationRuleRow[];
+    return rows.map(rowToRule);
+  }
+
+  findById(id: string, userId?: number): AutomationRule {
+    const row = (userId != null
+      ? getDb()
+          .prepare(
+            `SELECT * FROM automation_rules
+             WHERE id = ? AND (owner_id = ? OR owner_id IS NULL)`,
+          )
+          .get(id, userId)
+      : getDb()
+          .prepare('SELECT * FROM automation_rules WHERE id = ?')
+          .get(id)) as AutomationRuleRow | undefined;
     if (!row) throw AppError.notFound('AutomationRule');
     return rowToRule(row);
   }
@@ -57,36 +96,46 @@ export class AutomationRulesRepository {
     getDb()
       .prepare(
         `INSERT INTO automation_rules
-         (id, name, trigger_type, trigger_config, action_type, action_config, enabled, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         (id, name, trigger_type, source, trigger_key, trigger_config, action_type, action_config, enabled, owner_id, source_account_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         id,
         dto.name,
-        dto.triggerType,
+        dto.triggerKey,
+        dto.source,
+        dto.triggerKey,
         dto.triggerConfig ? JSON.stringify(dto.triggerConfig) : null,
         dto.actionType,
         dto.actionConfig ? JSON.stringify(dto.actionConfig) : null,
         dto.enabled !== false ? 1 : 0,
+        dto.ownerId ?? null,
+        dto.sourceAccountId ?? null,
         now,
         now,
       );
-    return this.findById(id);
+    return this.findById(id, dto.ownerId ?? undefined);
   }
 
-  update(id: string, dto: UpdateAutomationRuleDto): AutomationRule {
-    const existing = this.findById(id);
+  update(
+    id: string,
+    dto: UpdateAutomationRuleDto,
+    userId?: number,
+  ): AutomationRule {
+    const existing = this.findById(id, userId);
     const now = new Date().toISOString();
     getDb()
       .prepare(
         `UPDATE automation_rules
-         SET name = ?, trigger_type = ?, trigger_config = ?,
-             action_type = ?, action_config = ?, enabled = ?, updated_at = ?
+         SET name = ?, trigger_type = ?, source = ?, trigger_key = ?, trigger_config = ?,
+             action_type = ?, action_config = ?, enabled = ?, owner_id = ?, source_account_id = ?, updated_at = ?
          WHERE id = ?`,
       )
       .run(
         dto.name ?? existing.name,
-        dto.triggerType ?? existing.triggerType,
+        dto.triggerKey ?? existing.triggerKey,
+        dto.source ?? existing.source,
+        dto.triggerKey ?? existing.triggerKey,
         'triggerConfig' in dto
           ? dto.triggerConfig
             ? JSON.stringify(dto.triggerConfig)
@@ -102,15 +151,50 @@ export class AutomationRulesRepository {
           : existing.actionConfig
             ? JSON.stringify(existing.actionConfig)
             : null,
-        dto.enabled !== undefined ? (dto.enabled ? 1 : 0) : (existing.enabled ? 1 : 0),
+        dto.enabled !== undefined
+          ? dto.enabled
+            ? 1
+            : 0
+          : existing.enabled
+            ? 1
+            : 0,
+        dto.ownerId !== undefined ? dto.ownerId : existing.ownerId,
+        dto.sourceAccountId !== undefined
+          ? dto.sourceAccountId
+          : existing.sourceAccountId,
         now,
         id,
       );
-    return this.findById(id);
+    return this.findById(id, userId);
   }
 
-  delete(id: string): void {
-    this.findById(id); // throws NOT_FOUND if missing
+  updateEvaluation(
+    id: string,
+    data: {
+      lastEvaluatedAt: string;
+      lastMatchedAt: string | null;
+      matchCountLastRun: number;
+      previewSample: Record<string, unknown> | null;
+    },
+  ): void {
+    getDb()
+      .prepare(
+        `UPDATE automation_rules
+         SET last_evaluated_at = ?, last_matched_at = ?, match_count_last_run = ?, preview_sample = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+      .run(
+        data.lastEvaluatedAt,
+        data.lastMatchedAt,
+        data.matchCountLastRun,
+        data.previewSample ? JSON.stringify(data.previewSample) : null,
+        new Date().toISOString(),
+        id,
+      );
+  }
+
+  delete(id: string, userId?: number): void {
+    this.findById(id, userId);
     getDb().prepare('DELETE FROM automation_rules WHERE id = ?').run(id);
   }
 }

--- a/apps/api_server/src/repositories/automation_signals_repository.ts
+++ b/apps/api_server/src/repositories/automation_signals_repository.ts
@@ -1,0 +1,119 @@
+import { v4 as uuidv4 } from 'uuid';
+import { getDb } from '../database/db';
+import type {
+  AutomationSignal,
+  CreateAutomationSignalDto,
+} from '../models/automation_signal';
+
+interface AutomationSignalRow {
+  id: string;
+  provider: string;
+  signal_type: string;
+  external_id: string;
+  dedupe_key: string;
+  occurred_at: string | null;
+  synced_at: string;
+  source_account_id: string | null;
+  source_label: string | null;
+  payload_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToSignal(row: AutomationSignalRow): AutomationSignal {
+  return {
+    id: row.id,
+    provider: row.provider as AutomationSignal['provider'],
+    signalType: row.signal_type as AutomationSignal['signalType'],
+    externalId: row.external_id,
+    dedupeKey: row.dedupe_key,
+    occurredAt: row.occurred_at,
+    syncedAt: row.synced_at,
+    sourceAccountId: row.source_account_id,
+    sourceLabel: row.source_label,
+    payload: JSON.parse(row.payload_json) as Record<string, unknown>,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export class AutomationSignalsRepository {
+  upsertMany(items: CreateAutomationSignalDto[]): AutomationSignal[] {
+    if (items.length === 0) return [];
+
+    const selectStmt = getDb().prepare(
+      'SELECT * FROM automation_signals WHERE dedupe_key = ? LIMIT 1',
+    );
+    const insertStmt = getDb().prepare(
+      `INSERT INTO automation_signals (
+        id, provider, signal_type, external_id, dedupe_key, occurred_at,
+        synced_at, source_account_id, source_label, payload_json, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const updateStmt = getDb().prepare(
+      `UPDATE automation_signals
+       SET provider = ?, signal_type = ?, external_id = ?, occurred_at = ?, synced_at = ?,
+           source_account_id = ?, source_label = ?, payload_json = ?, updated_at = ?
+       WHERE id = ?`,
+    );
+
+    getDb().transaction(() => {
+      for (const item of items) {
+        const now = new Date().toISOString();
+        const existing = selectStmt.get(item.dedupeKey) as
+          | AutomationSignalRow
+          | undefined;
+        if (existing) {
+          updateStmt.run(
+            item.provider,
+            item.signalType,
+            item.externalId,
+            item.occurredAt ?? null,
+            item.syncedAt,
+            item.sourceAccountId ?? null,
+            item.sourceLabel ?? null,
+            JSON.stringify(item.payload),
+            now,
+            existing.id,
+          );
+          continue;
+        }
+
+        insertStmt.run(
+          uuidv4(),
+          item.provider,
+          item.signalType,
+          item.externalId,
+          item.dedupeKey,
+          item.occurredAt ?? null,
+          item.syncedAt,
+          item.sourceAccountId ?? null,
+          item.sourceLabel ?? null,
+          JSON.stringify(item.payload),
+          now,
+          now,
+        );
+      }
+    })();
+
+    return items.map((item) => this.findByDedupeKey(item.dedupeKey)!);
+  }
+
+  findByDedupeKey(dedupeKey: string): AutomationSignal | null {
+    const row = getDb()
+      .prepare('SELECT * FROM automation_signals WHERE dedupe_key = ? LIMIT 1')
+      .get(dedupeKey) as AutomationSignalRow | undefined;
+    return row ? rowToSignal(row) : null;
+  }
+
+  listRecent(limit = 50): AutomationSignal[] {
+    const rows = getDb()
+      .prepare(
+        `SELECT * FROM automation_signals
+         ORDER BY synced_at DESC, updated_at DESC
+         LIMIT ?`,
+      )
+      .all(limit) as AutomationSignalRow[];
+    return rows.map(rowToSignal);
+  }
+}

--- a/apps/api_server/src/repositories/facilities_repository.ts
+++ b/apps/api_server/src/repositories/facilities_repository.ts
@@ -5,6 +5,7 @@ import type {
   CreateReservationDto,
   Facility,
   Reservation,
+  UpdateReservationDto,
   UpdateFacilityDto,
 } from '../models/facility';
 
@@ -57,6 +58,39 @@ function rowToReservation(row: ReservationRow): Reservation {
 }
 
 export class FacilitiesRepository {
+  private assertReservationWindowAvailable(
+    facilityId: number,
+    startTime: string,
+    endTime: string,
+    excludeReservationId?: number,
+  ): void {
+    const conflict = getDb()
+      .prepare(
+        `SELECT title, start_time, end_time
+         FROM reservations
+         WHERE facility_id = ?
+           AND (? IS NULL OR id != ?)
+           AND start_time < ?
+           AND end_time > ?
+         LIMIT 1`,
+      )
+      .get(
+        facilityId,
+        excludeReservationId ?? null,
+        excludeReservationId ?? null,
+        endTime,
+        startTime,
+      ) as
+      | { title: string; start_time: string; end_time: string }
+      | undefined;
+
+    if (conflict) {
+      throw AppError.conflict(
+        `Conflicts with "${conflict.title}" from ${conflict.start_time} to ${conflict.end_time}. Choose a different room or time.`,
+      );
+    }
+  }
+
   findAll(): Facility[] {
     const rows = getDb()
       .prepare('SELECT * FROM facilities ORDER BY name ASC')
@@ -123,6 +157,11 @@ export class FacilitiesRepository {
   createReservation(facilityId: number, data: CreateReservationDto): Reservation {
     // Ensure facility exists
     this.findById(facilityId);
+    this.assertReservationWindowAvailable(
+      facilityId,
+      data.start_time,
+      data.end_time,
+    );
     const result = getDb()
       .prepare(
         `INSERT INTO reservations (
@@ -143,5 +182,71 @@ export class FacilitiesRepository {
       .prepare('SELECT * FROM reservations WHERE id = ?')
       .get(result.lastInsertRowid as number) as ReservationRow;
     return rowToReservation(row);
+  }
+
+  findReservationById(id: number): Reservation {
+    const row = getDb()
+      .prepare('SELECT * FROM reservations WHERE id = ?')
+      .get(id) as ReservationRow | undefined;
+    if (!row) throw AppError.notFound('Reservation');
+    return rowToReservation(row);
+  }
+
+  updateReservation(
+    facilityId: number,
+    reservationId: number,
+    data: UpdateReservationDto,
+  ): Reservation {
+    this.findById(facilityId);
+    const existing = this.findReservationById(reservationId);
+    if (existing.facilityId !== facilityId) {
+      throw AppError.notFound('Reservation');
+    }
+
+    const nextStart = data.start_time ?? existing.startTime;
+    const nextEnd = data.end_time ?? existing.endTime;
+    this.assertReservationWindowAvailable(
+      facilityId,
+      nextStart,
+      nextEnd,
+      reservationId,
+    );
+
+    getDb()
+      .prepare(
+        `UPDATE reservations
+         SET title = ?, reserved_by = ?, reserved_by_user_id = ?, start_time = ?, end_time = ?, notes = ?
+         WHERE id = ?`,
+      )
+      .run(
+        data.title ?? existing.title,
+        data.reserved_by ?? existing.reservedBy,
+        data.reserved_by_user_id !== undefined
+            ? data.reserved_by_user_id
+            : existing.reservedByUserId,
+        data.start_time ?? existing.startTime,
+        data.end_time ?? existing.endTime,
+        data.notes !== undefined ? data.notes : existing.notes,
+        reservationId,
+      );
+
+    return this.findReservationById(reservationId);
+  }
+
+  deleteReservation(facilityId: number, reservationId: number): Reservation {
+    this.findById(facilityId);
+    const existing = this.findReservationById(reservationId);
+    if (existing.facilityId !== facilityId) {
+      throw AppError.notFound('Reservation');
+    }
+
+    const result = getDb()
+      .prepare('DELETE FROM reservations WHERE id = ?')
+      .run(reservationId);
+    if (result.changes === 0) {
+      throw AppError.notFound('Reservation');
+    }
+
+    return existing;
   }
 }

--- a/apps/api_server/src/repositories/messages_repository.ts
+++ b/apps/api_server/src/repositories/messages_repository.ts
@@ -5,6 +5,7 @@ import type {
   CreateThreadDto,
   Message,
   MessageThread,
+  MessageThreadParticipant,
 } from '../models/message';
 import { UsersRepository } from './users_repository';
 
@@ -41,6 +42,7 @@ function rowToThread(row: ThreadSummaryRow): MessageThread {
     lastMessage: row.last_message ?? null,
     unreadCount,
     isUnread: unreadCount > 0,
+    participants: [],
   };
 }
 
@@ -57,6 +59,42 @@ function rowToMessage(row: MessageRow): Message {
 
 export class MessagesRepository {
   private readonly usersRepo = new UsersRepository();
+
+  private getParticipantsForThread(threadId: number): MessageThreadParticipant[] {
+    const rows = getDb()
+      .prepare(
+        `SELECT u.id, u.name, u.email
+         FROM thread_participants tp
+         JOIN users u ON u.id = tp.user_id
+         WHERE tp.thread_id = ?
+         ORDER BY lower(u.name) ASC, u.id ASC`,
+      )
+      .all(threadId) as MessageThreadParticipant[];
+    return rows;
+  }
+
+  private withParticipants(thread: MessageThread): MessageThread {
+    return {
+      ...thread,
+      participants: this.getParticipantsForThread(thread.id),
+    };
+  }
+
+  private findExistingDirectThreadId(userIds: number[]): number | null {
+    if (userIds.length != 2) return null;
+    const normalized = [...userIds].sort((a, b) => a - b);
+    const row = getDb()
+      .prepare(
+        `SELECT tp.thread_id AS id
+         FROM thread_participants tp
+         GROUP BY tp.thread_id
+         HAVING COUNT(*) = 2
+            AND SUM(CASE WHEN tp.user_id IN (?, ?) THEN 1 ELSE 0 END) = 2
+         LIMIT 1`,
+      )
+      .get(normalized[0], normalized[1]) as { id: number } | undefined;
+    return row?.id ?? null;
+  }
 
   findAllThreadsForUser(userId: number): MessageThread[] {
     const rows = getDb()
@@ -84,7 +122,7 @@ export class MessagesRepository {
          ORDER BY t.updated_at DESC`,
       )
       .all(userId, userId, userId) as ThreadSummaryRow[];
-    return rows.map(rowToThread);
+    return rows.map((row) => this.withParticipants(rowToThread(row)));
   }
 
   findThreadByIdForUser(id: number, userId: number): MessageThread {
@@ -112,22 +150,26 @@ export class MessagesRepository {
       )
       .get(userId, userId, id, userId) as ThreadSummaryRow | undefined;
     if (!row) throw AppError.notFound('MessageThread');
-    return rowToThread(row);
+    return this.withParticipants(rowToThread(row));
   }
 
   createThread(data: CreateThreadDto): MessageThread {
     const participantIds = Array.from(
       new Set([data.createdBy, ...data.participantIds]),
     );
-    if (participantIds.length < 2) {
-      throw AppError.badRequest('A thread must include at least two participants');
+    if (participantIds.length !== 2) {
+      throw AppError.badRequest(
+        'Direct messages must include exactly one other participant',
+      );
+    }
+
+    const existingThreadId = this.findExistingDirectThreadId(participantIds);
+    if (existingThreadId != null) {
+      return this.findThreadByIdForUser(existingThreadId, data.createdBy);
     }
 
     const participantUsers = participantIds.map((id) => this.usersRepo.findById(id));
-    const title =
-      (data.title?.trim().length ?? 0) > 0
-        ? data.title!.trim()
-        : participantUsers.map((user) => user.name).join(', ');
+    const title = participantUsers.map((user) => user.name).join(', ');
 
     const now = new Date().toISOString();
     const result = getDb()
@@ -194,6 +236,14 @@ export class MessagesRepository {
       .prepare('SELECT * FROM messages WHERE id = ?')
       .get(result.lastInsertRowid as number) as MessageRow;
     return rowToMessage(row);
+  }
+
+  sendDirectMessage(senderUserId: number, recipientUserId: number, body: string): Message {
+    const thread = this.createThread({
+      createdBy: senderUserId,
+      participantIds: [recipientUserId],
+    });
+    return this.createMessage(thread.id, senderUserId, { body });
   }
 
   markThreadRead(threadId: number, userId: number): void {

--- a/apps/api_server/src/repositories/recurring_task_rules_repository.ts
+++ b/apps/api_server/src/repositories/recurring_task_rules_repository.ts
@@ -115,7 +115,8 @@ export class RecurringTaskRulesRepository {
     return this.findById(id, userId);
   }
 
-  delete(id: string): void {
+  delete(id: string, userId?: number): void {
+    this.findById(id, userId);
     const result = getDb().prepare('DELETE FROM recurring_task_rules WHERE id = ?').run(id);
     if (result.changes === 0) throw AppError.notFound('RecurringTaskRule');
   }

--- a/apps/api_server/src/repositories/tasks_repository.ts
+++ b/apps/api_server/src/repositories/tasks_repository.ts
@@ -229,7 +229,8 @@ export class TasksRepository {
     return this.findById(id, userId);
   }
 
-  delete(id: string): void {
+  delete(id: string, userId?: number): void {
+    this.findById(id, userId);
     const result = getDb().prepare('DELETE FROM tasks WHERE id = ?').run(id);
     if (result.changes === 0) throw AppError.notFound('Task');
   }

--- a/apps/api_server/src/repositories/users_repository.ts
+++ b/apps/api_server/src/repositories/users_repository.ts
@@ -7,6 +7,7 @@ interface UserRow {
   name: string;
   email: string;
   google_sub: string | null;
+  photo_url: string | null;
   role: string;
   created_at: string;
   updated_at: string;
@@ -18,6 +19,7 @@ function rowToUser(row: UserRow): User {
     name: row.name,
     email: row.email,
     googleSub: row.google_sub,
+    photoUrl: row.photo_url,
     role: row.role,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -25,6 +27,8 @@ function rowToUser(row: UserRow): User {
 }
 
 export class UsersRepository {
+  static readonly systemBotEmail = 'rhythm-bot@rhythm.local';
+
   findAll(): User[] {
     const rows = getDb()
       .prepare('SELECT * FROM users ORDER BY created_at ASC')
@@ -57,9 +61,15 @@ export class UsersRepository {
   create(data: CreateUserDto): User {
     const result = getDb()
       .prepare(
-        `INSERT INTO users (name, email, google_sub, role) VALUES (?, ?, ?, ?)`,
+        `INSERT INTO users (name, email, google_sub, photo_url, role) VALUES (?, ?, ?, ?, ?)`,
       )
-      .run(data.name, data.email, data.googleSub ?? null, data.role ?? 'member');
+      .run(
+        data.name,
+        data.email,
+        data.googleSub ?? null,
+        data.photoUrl ?? null,
+        data.role ?? 'member',
+      );
     return this.findById(result.lastInsertRowid as number);
   }
 
@@ -68,12 +78,13 @@ export class UsersRepository {
     const now = new Date().toISOString();
     getDb()
       .prepare(
-        `UPDATE users SET name = ?, email = ?, google_sub = ?, role = ?, updated_at = ? WHERE id = ?`,
+        `UPDATE users SET name = ?, email = ?, google_sub = ?, photo_url = ?, role = ?, updated_at = ? WHERE id = ?`,
       )
       .run(
         data.name ?? existing.name,
         data.email ?? existing.email,
         data.googleSub ?? existing.googleSub,
+        data.photoUrl !== undefined ? data.photoUrl : existing.photoUrl,
         data.role ?? existing.role,
         now,
         id,
@@ -85,6 +96,7 @@ export class UsersRepository {
     googleSub: string;
     email: string;
     name: string;
+    photoUrl?: string | null;
   }): User {
     const existingBySub = this.findByGoogleSub(data.googleSub);
     if (existingBySub) {
@@ -92,6 +104,7 @@ export class UsersRepository {
         name: data.name,
         email: data.email,
         googleSub: data.googleSub,
+        photoUrl: data.photoUrl ?? null,
       });
     }
 
@@ -101,6 +114,7 @@ export class UsersRepository {
         name: data.name,
         email: data.email,
         googleSub: data.googleSub,
+        photoUrl: data.photoUrl ?? null,
       });
     }
 
@@ -108,6 +122,27 @@ export class UsersRepository {
       name: data.name,
       email: data.email,
       googleSub: data.googleSub,
+      photoUrl: data.photoUrl ?? null,
+    });
+  }
+
+  findOrCreateSystemBot(): User {
+    const existing = this.findByEmail(UsersRepository.systemBotEmail);
+    if (existing != null) {
+      if (existing.name == 'Rhythm Bot' && existing.role == 'system') {
+        return existing;
+      }
+      return this.update(existing.id, {
+        name: 'Rhythm Bot',
+        role: 'system',
+      });
+    }
+
+    return this.create({
+      name: 'Rhythm Bot',
+      email: UsersRepository.systemBotEmail,
+      photoUrl: null,
+      role: 'system',
     });
   }
 }

--- a/apps/api_server/src/routes/automation_catalog_routes.ts
+++ b/apps/api_server/src/routes/automation_catalog_routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { AutomationCatalogController } from '../controllers/automation_catalog_controller';
-import { requireAuth } from '../middleware/require_auth';
+import { requireAuth } from '../middleware/auth_middleware';
 
 const controller = new AutomationCatalogController();
 export const automationCatalogRouter = Router();

--- a/apps/api_server/src/routes/automation_catalog_routes.ts
+++ b/apps/api_server/src/routes/automation_catalog_routes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { AutomationCatalogController } from '../controllers/automation_catalog_controller';
+import { requireAuth } from '../middleware/require_auth';
+
+const controller = new AutomationCatalogController();
+export const automationCatalogRouter = Router();
+
+automationCatalogRouter.use(requireAuth);
+automationCatalogRouter.get('/triggers', controller.getTriggers.bind(controller));
+automationCatalogRouter.get('/actions', controller.getActions.bind(controller));
+automationCatalogRouter.get('/providers', controller.getProviders.bind(controller));

--- a/apps/api_server/src/routes/automation_rules_routes.ts
+++ b/apps/api_server/src/routes/automation_rules_routes.ts
@@ -1,11 +1,14 @@
 import { Router } from 'express';
 import { AutomationRulesController } from '../controllers/automation_rules_controller';
+import { requireAuth } from '../middleware/auth_middleware';
 
 const controller = new AutomationRulesController();
 export const automationRulesRouter = Router();
 
+automationRulesRouter.use(requireAuth);
 automationRulesRouter.get('/', controller.getAll.bind(controller));
 automationRulesRouter.get('/:id', controller.getById.bind(controller));
+automationRulesRouter.get('/:id/preview', controller.getPreview.bind(controller));
 automationRulesRouter.post('/', controller.create.bind(controller));
 automationRulesRouter.patch('/:id', controller.update.bind(controller));
 automationRulesRouter.delete('/:id', controller.remove.bind(controller));

--- a/apps/api_server/src/routes/facilities_routes.ts
+++ b/apps/api_server/src/routes/facilities_routes.ts
@@ -12,3 +12,11 @@ facilitiesRouter.patch('/:id', controller.update.bind(controller));
 facilitiesRouter.delete('/:id', controller.remove.bind(controller));
 facilitiesRouter.get('/:id/reservations', controller.getReservations.bind(controller));
 facilitiesRouter.post('/:id/reservations', controller.createReservation.bind(controller));
+facilitiesRouter.patch(
+  '/:id/reservations/:reservationId',
+  controller.updateReservation.bind(controller),
+);
+facilitiesRouter.delete(
+  '/:id/reservations/:reservationId',
+  controller.deleteReservation.bind(controller),
+);

--- a/apps/api_server/src/server.ts
+++ b/apps/api_server/src/server.ts
@@ -5,22 +5,32 @@ import { config as loadDotenv } from 'dotenv';
 // CI writes OAuth secrets here before bundling into the .app.
 loadDotenv({ path: path.join(__dirname, '..', '.env') });
 
-import { createApp } from './app';
-import { initDb } from './database/db';
-import { startRecurrenceGenerationJob } from './jobs/recurrence_generation_job';
-import { startSyncOrchestratorJob } from './jobs/sync_orchestrator_job';
-import { logger } from './utils/logger';
+async function main() {
+  const [{ createApp }, { initDb }, { startRecurrenceGenerationJob }, { startSyncOrchestratorJob }, { logger }] =
+    await Promise.all([
+      import('./app'),
+      import('./database/db'),
+      import('./jobs/recurrence_generation_job'),
+      import('./jobs/sync_orchestrator_job'),
+      import('./utils/logger'),
+    ]);
 
-const port = Number(process.env.PORT ?? 4000);
+  const port = Number(process.env.PORT ?? 4000);
 
-initDb();
-logger.info('Database initialized');
+  initDb();
+  logger.info('Database initialized');
 
-startRecurrenceGenerationJob();
-startSyncOrchestratorJob();
+  startRecurrenceGenerationJob();
+  startSyncOrchestratorJob();
 
-const app = createApp();
+  const app = createApp();
 
-app.listen(port, () => {
-  logger.info(`Rhythm API listening on port ${port}`);
+  app.listen(port, () => {
+    logger.info(`Rhythm API listening on port ${port}`);
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
 });

--- a/apps/api_server/src/services/auth_service.ts
+++ b/apps/api_server/src/services/auth_service.ts
@@ -23,6 +23,7 @@ export class AuthService {
       googleSub: identity.sub,
       email: identity.email,
       name: identity.name,
+      photoUrl: identity.picture ?? null,
     });
     const session = this.sessionsRepo.create(user.id);
     return {

--- a/apps/api_server/src/services/automation_catalog_service.ts
+++ b/apps/api_server/src/services/automation_catalog_service.ts
@@ -3,6 +3,7 @@ import type {
   AutomationProviderCatalogItem,
   AutomationTriggerCatalogItem,
 } from '../models/automation_catalog';
+import type { IntegrationAccount } from '../models/integration_account';
 import type { AutomationActionType, AutomationTriggerKey } from '../models/automation_rule';
 
 const TRIGGERS: AutomationTriggerCatalogItem[] = [
@@ -167,12 +168,32 @@ export class AutomationCatalogService {
     return TRIGGERS;
   }
 
+  getTriggersForAccounts(accounts: IntegrationAccount[]): AutomationTriggerCatalogItem[] {
+    const enabledSources = new Set([
+      'rhythm',
+      ...accounts
+        .filter((account) => account.status === 'connected')
+        .map((account) => account.provider),
+    ]);
+    return TRIGGERS.filter((item) => enabledSources.has(item.source));
+  }
+
   getActions(): AutomationActionCatalogItem[] {
     return ACTIONS;
   }
 
   getProviders(): AutomationProviderCatalogItem[] {
     return PROVIDERS;
+  }
+
+  getProvidersForAccounts(accounts: IntegrationAccount[]): AutomationProviderCatalogItem[] {
+    const enabledSources = new Set([
+      'rhythm',
+      ...accounts
+        .filter((account) => account.status === 'connected')
+        .map((account) => account.provider),
+    ]);
+    return PROVIDERS.filter((item) => enabledSources.has(item.source));
   }
 
   findTrigger(key: string): AutomationTriggerCatalogItem | null {

--- a/apps/api_server/src/services/automation_catalog_service.ts
+++ b/apps/api_server/src/services/automation_catalog_service.ts
@@ -1,0 +1,189 @@
+import type {
+  AutomationActionCatalogItem,
+  AutomationProviderCatalogItem,
+  AutomationTriggerCatalogItem,
+} from '../models/automation_catalog';
+import type { AutomationActionType, AutomationTriggerKey } from '../models/automation_rule';
+
+const TRIGGERS: AutomationTriggerCatalogItem[] = [
+  {
+    key: 'rhythm.task_due',
+    source: 'rhythm',
+    label: 'Task is due',
+    description: 'Run when a Rhythm task approaches its due date.',
+    signalTypes: [],
+    configSchema: { fields: ['daysBeforeDue'] },
+  },
+  {
+    key: 'rhythm.project_step_due',
+    source: 'rhythm',
+    label: 'Project step is due',
+    description: 'Run when a Rhythm project step approaches its due date.',
+    signalTypes: [],
+    configSchema: { fields: ['daysBeforeDue'] },
+  },
+  {
+    key: 'rhythm.plan_assembly',
+    source: 'rhythm',
+    label: 'Weekly plan is assembled',
+    description: 'Run during weekly plan assembly.',
+    signalTypes: [],
+    configSchema: { fields: [] },
+  },
+  {
+    key: 'planning_center.plan_person_declined',
+    source: 'planning_center',
+    label: 'Volunteer declined',
+    description: 'Match Planning Center team members who declined a plan invitation.',
+    signalTypes: ['team_member_declined'],
+    configSchema: { fields: ['serviceType', 'teamId', 'positionName', 'leadDays'] },
+  },
+  {
+    key: 'planning_center.plan_person_unconfirmed',
+    source: 'planning_center',
+    label: 'Volunteer unconfirmed',
+    description: 'Match unconfirmed Planning Center team members close to a service date.',
+    signalTypes: ['team_member_unconfirmed'],
+    configSchema: { fields: ['serviceType', 'teamId', 'positionName', 'leadDays'] },
+  },
+  {
+    key: 'planning_center.needed_position_open',
+    source: 'planning_center',
+    label: 'Needed position open',
+    description: 'Match open needed positions from Planning Center plans.',
+    signalTypes: ['needed_position_open'],
+    configSchema: { fields: ['serviceType', 'teamId', 'positionName', 'leadDays'] },
+  },
+  {
+    key: 'planning_center.special_service_candidate',
+    source: 'planning_center',
+    label: 'Special service candidate',
+    description: 'Match non-Sunday plans that should create a project.',
+    signalTypes: ['special_service_candidate'],
+    configSchema: { fields: ['serviceType', 'leadDays'] },
+  },
+  {
+    key: 'google_calendar.event_matching_filter',
+    source: 'google_calendar',
+    label: 'Calendar event matches filter',
+    description: 'Match Google Calendar events by metadata filters.',
+    signalTypes: ['calendar_event_seen', 'calendar_event_today'],
+    configSchema: {
+      fields: ['textQuery', 'eventType', 'allDayOnly', 'dateWindowDays'],
+    },
+  },
+  {
+    key: 'google_calendar.all_day_event',
+    source: 'google_calendar',
+    label: 'All-day calendar event',
+    description: 'Match all-day Google Calendar events in a time window.',
+    signalTypes: ['calendar_event_today', 'calendar_event_seen'],
+    configSchema: { fields: ['textQuery', 'dateWindowDays'] },
+  },
+  {
+    key: 'gmail.message_matching_filter',
+    source: 'gmail',
+    label: 'Gmail message matches filter',
+    description: 'Match Gmail metadata by sender, subject, and recency.',
+    signalTypes: ['gmail_message_seen', 'gmail_message_from_sender'],
+    configSchema: { fields: ['sender', 'subjectContains', 'label', 'hoursSinceReceived'] },
+  },
+  {
+    key: 'gmail.unread_message_matching_filter',
+    source: 'gmail',
+    label: 'Unread Gmail message matches filter',
+    description: 'Match unread Gmail messages by sender and subject.',
+    signalTypes: ['gmail_unread_message_seen', 'gmail_message_from_sender'],
+    configSchema: { fields: ['sender', 'subjectContains', 'label', 'hoursSinceReceived'] },
+  },
+];
+
+const ACTIONS: AutomationActionCatalogItem[] = [
+  {
+    key: 'create_task',
+    label: 'Create task',
+    description: 'Create a follow-up task in Rhythm when the trigger matches.',
+    configSchema: { fields: ['titleTemplate', 'notesTemplate', 'dueDaysOffset'] },
+  },
+  {
+    key: 'create_project_from_template',
+    label: 'Create project from template',
+    description: 'Generate a project instance from an existing Rhythm template.',
+    configSchema: { fields: ['templateId', 'templateName', 'projectNameTemplate'] },
+  },
+  {
+    key: 'tag_task',
+    label: 'Tag task',
+    description: 'Create a follow-up task and include a tag marker in its notes.',
+    configSchema: { fields: ['tag', 'titleTemplate', 'notesTemplate'] },
+  },
+  {
+    key: 'send_notification',
+    label: 'Send notification',
+    description: 'Send a direct Rhythm message notification to the rule owner.',
+    configSchema: { fields: ['messageTemplate'] },
+  },
+  {
+    key: 'auto_schedule',
+    label: 'Auto-schedule task',
+    description: 'Create or update a task with a scheduled weekday.',
+    configSchema: { fields: ['titleTemplate', 'targetDay', 'dueDaysOffset'] },
+  },
+];
+
+const PROVIDERS: AutomationProviderCatalogItem[] = [
+  {
+    source: 'rhythm',
+    label: 'Rhythm',
+    description: 'Internal Rhythm planning triggers.',
+    syncSupport: 'scheduled',
+    triggerKeys: TRIGGERS.filter((item) => item.source === 'rhythm').map((item) => item.key),
+  },
+  {
+    source: 'planning_center',
+    label: 'Planning Center',
+    description: 'Sync-derived staffing and plan signals from Planning Center.',
+    syncSupport: 'push_capable',
+    triggerKeys: TRIGGERS.filter((item) => item.source === 'planning_center').map((item) => item.key),
+  },
+  {
+    source: 'google_calendar',
+    label: 'Google Calendar',
+    description: 'Metadata-driven calendar event triggers.',
+    syncSupport: 'push_capable',
+    triggerKeys: TRIGGERS.filter((item) => item.source === 'google_calendar').map((item) => item.key),
+  },
+  {
+    source: 'gmail',
+    label: 'Gmail',
+    description: 'Metadata-driven Gmail message triggers.',
+    syncSupport: 'push_capable',
+    triggerKeys: TRIGGERS.filter((item) => item.source === 'gmail').map((item) => item.key),
+  },
+];
+
+export class AutomationCatalogService {
+  getTriggers(): AutomationTriggerCatalogItem[] {
+    return TRIGGERS;
+  }
+
+  getActions(): AutomationActionCatalogItem[] {
+    return ACTIONS;
+  }
+
+  getProviders(): AutomationProviderCatalogItem[] {
+    return PROVIDERS;
+  }
+
+  findTrigger(key: string): AutomationTriggerCatalogItem | null {
+    return TRIGGERS.find((item) => item.key === key) ?? null;
+  }
+
+  isValidTriggerKey(key: string): key is AutomationTriggerKey {
+    return this.findTrigger(key) != null;
+  }
+
+  isValidActionType(key: string): key is AutomationActionType {
+    return ACTIONS.some((item) => item.key === key);
+  }
+}

--- a/apps/api_server/src/services/automation_engine_service.test.ts
+++ b/apps/api_server/src/services/automation_engine_service.test.ts
@@ -1,0 +1,431 @@
+import Database from 'better-sqlite3';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { AutomationCatalogController } from '../controllers/automation_catalog_controller';
+import { AutomationRulesController } from '../controllers/automation_rules_controller';
+import { setDb } from '../database/db';
+import { runMigrations } from '../database/migrations';
+import type { AutomationSignal } from '../models/automation_signal';
+import { AutomationRulesRepository } from '../repositories/automation_rules_repository';
+import { AutomationSignalsRepository } from '../repositories/automation_signals_repository';
+import { IntegrationAccountsRepository } from '../repositories/integration_accounts_repository';
+import { ProjectInstancesRepository } from '../repositories/project_instances_repository';
+import { ProjectTemplatesRepository } from '../repositories/project_templates_repository';
+import { TasksRepository } from '../repositories/tasks_repository';
+import { UsersRepository } from '../repositories/users_repository';
+
+import { AutomationEngineService } from './automation_engine_service';
+
+describe('Automation overhaul backend', () => {
+  beforeEach(() => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    setDb(db);
+  });
+
+  test('creates a follow-up task from a matching unread Gmail signal', () => {
+    const usersRepo = new UsersRepository();
+    const rulesRepo = new AutomationRulesRepository();
+    const tasksRepo = new TasksRepository();
+    const accountsRepo = new IntegrationAccountsRepository();
+    const engine = new AutomationEngineService();
+    const owner = usersRepo.create({
+      name: 'Alice',
+      email: 'alice@example.com',
+    });
+    const [gmailAccount] = accountsRepo.upsertGoogleAccount({
+      externalAccountId: 'google-user-1',
+      email: 'alice@example.com',
+      displayName: 'Alice',
+      accessToken: 'token',
+      refreshToken: null,
+      scope: 'gmail.metadata',
+      tokenType: 'Bearer',
+      expiresAt: null,
+    });
+
+    const rule = rulesRepo.create({
+      name: 'Unread finance follow-up',
+      source: 'gmail',
+      triggerKey: 'gmail.unread_message_matching_filter',
+      triggerConfig: {
+        sender: 'finance@',
+        subjectContains: 'invoice',
+        hoursSinceReceived: 24,
+      },
+      actionType: 'create_task',
+      actionConfig: {
+        titleTemplate: 'Follow up: {{subject}}',
+        notesTemplate: 'From {{sender}}',
+        dueDaysOffset: 1,
+      },
+      ownerId: owner.id,
+      sourceAccountId: gmailAccount.id,
+    });
+
+    const occurredAt = '2026-04-01T16:00:00.000Z';
+    const signal: AutomationSignal = {
+      id: 'sig-1',
+      provider: 'gmail',
+      signalType: 'gmail_unread_message_seen',
+      externalId: 'msg-1',
+      dedupeKey: 'gmail:unread:msg-1',
+      occurredAt,
+      syncedAt: '2026-04-01T17:00:00.000Z',
+      sourceAccountId: gmailAccount.id,
+      sourceLabel: 'alice@example.com',
+      payload: {
+        fromEmail: 'finance@example.com',
+        fromName: 'Finance',
+        subject: 'Invoice approval needed',
+        snippet: 'Please approve the April invoice.',
+        isUnread: true,
+        receivedAt: occurredAt,
+        threadId: 'thread-1',
+        labelIds: ['INBOX', 'UNREAD'],
+      },
+      createdAt: occurredAt,
+      updatedAt: occurredAt,
+    };
+
+    const result = engine.evaluateSignals('gmail', [signal]);
+
+    expect(result.matchedRules).toBe(1);
+    expect(result.executedActions).toBe(1);
+    expect(result.matchesByRuleId[rule.id]).toBe(1);
+
+    const tasks = tasksRepo.findAll(owner.id);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.title).toBe('Follow up: Invoice approval needed');
+    expect(tasks[0]?.notes).toBe('From finance@example.com');
+    expect(tasks[0]?.sourceType).toBe('automation_rule');
+    expect(tasks[0]?.sourceId).toBe(`${rule.id}:gmail-thread:thread-1`);
+    expect(tasks[0]?.dueDate).toBe('2026-04-02');
+
+    const updatedRule = rulesRepo.findById(rule.id, owner.id);
+    expect(updatedRule.matchCountLastRun).toBe(1);
+    expect(updatedRule.previewSample).toMatchObject({
+      fromEmail: 'finance@example.com',
+      subject: 'Invoice approval needed',
+    });
+    expect(updatedRule.lastEvaluatedAt).not.toBeNull();
+    expect(updatedRule.lastMatchedAt).not.toBeNull();
+  });
+
+  test('collapses matching Gmail messages in the same thread into one task', () => {
+    const usersRepo = new UsersRepository();
+    const rulesRepo = new AutomationRulesRepository();
+    const tasksRepo = new TasksRepository();
+    const accountsRepo = new IntegrationAccountsRepository();
+    const engine = new AutomationEngineService();
+    const owner = usersRepo.create({
+      name: 'Alice',
+      email: 'alice@example.com',
+    });
+    const [gmailAccount] = accountsRepo.upsertGoogleAccount({
+      externalAccountId: 'google-user-1',
+      email: 'alice@example.com',
+      displayName: 'Alice',
+      accessToken: 'token',
+      refreshToken: null,
+      scope: 'gmail.metadata',
+      tokenType: 'Bearer',
+      expiresAt: null,
+    });
+
+    const rule = rulesRepo.create({
+      name: 'Worship follow-up',
+      source: 'gmail',
+      triggerKey: 'gmail.unread_message_matching_filter',
+      triggerConfig: { sender: 'worship@visaliacrc.com' },
+      actionType: 'create_task',
+      actionConfig: {
+        titleTemplate: 'Respond to {{sender}}',
+      },
+      ownerId: owner.id,
+      sourceAccountId: gmailAccount.id,
+    });
+
+    const signals: AutomationSignal[] = [
+      {
+        id: 'sig-a',
+        provider: 'gmail',
+        signalType: 'gmail_unread_message_seen',
+        externalId: 'msg-a',
+        dedupeKey: 'gmail:unread:msg-a',
+        occurredAt: '2026-04-01T16:00:00.000Z',
+        syncedAt: '2026-04-01T17:00:00.000Z',
+        sourceAccountId: gmailAccount.id,
+        sourceLabel: 'alice@example.com',
+        payload: {
+          fromEmail: 'worship@visaliacrc.com',
+          subject: 'First message',
+          isUnread: true,
+          receivedAt: '2026-04-01T16:00:00.000Z',
+          threadId: 'thread-shared',
+          labelIds: ['INBOX', 'UNREAD'],
+        },
+        createdAt: '2026-04-01T17:00:00.000Z',
+        updatedAt: '2026-04-01T17:00:00.000Z',
+      },
+      {
+        id: 'sig-b',
+        provider: 'gmail',
+        signalType: 'gmail_unread_message_seen',
+        externalId: 'msg-b',
+        dedupeKey: 'gmail:unread:msg-b',
+        occurredAt: '2026-04-01T16:30:00.000Z',
+        syncedAt: '2026-04-01T17:00:00.000Z',
+        sourceAccountId: gmailAccount.id,
+        sourceLabel: 'alice@example.com',
+        payload: {
+          fromEmail: 'worship@visaliacrc.com',
+          subject: 'Second message',
+          isUnread: true,
+          receivedAt: '2026-04-01T16:30:00.000Z',
+          threadId: 'thread-shared',
+          labelIds: ['INBOX', 'UNREAD'],
+        },
+        createdAt: '2026-04-01T17:00:00.000Z',
+        updatedAt: '2026-04-01T17:00:00.000Z',
+      },
+    ];
+
+    const result = engine.evaluateSignals('gmail', signals);
+
+    expect(result.matchedRules).toBe(1);
+    expect(result.executedActions).toBe(2);
+
+    const tasks = tasksRepo.findAll(owner.id);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.sourceId).toBe(`${rule.id}:gmail-thread:thread-shared`);
+  });
+
+  test('creates a project from a Planning Center special service signal', () => {
+    const templatesRepo = new ProjectTemplatesRepository();
+    const instancesRepo = new ProjectInstancesRepository();
+    const rulesRepo = new AutomationRulesRepository();
+    const accountsRepo = new IntegrationAccountsRepository();
+    const engine = new AutomationEngineService();
+    const pcoAccount = accountsRepo.upsertPlanningCenterAccount({
+      externalAccountId: 'pco-user-1',
+      email: 'team@church.test',
+      displayName: 'Team',
+      accessToken: 'token',
+      refreshToken: null,
+      scope: 'services',
+      tokenType: 'Bearer',
+      expiresAt: null,
+    });
+
+    const template = templatesRepo.create({
+      name: 'Special Service',
+      anchorType: 'date',
+    });
+    templatesRepo.addStep(template.id, {
+      title: 'Confirm volunteers',
+      offsetDays: -7,
+      sortOrder: 0,
+    });
+
+    rulesRepo.create({
+      name: 'Special service project',
+      source: 'planning_center',
+      triggerKey: 'planning_center.special_service_candidate',
+      triggerConfig: { leadDays: 30 },
+      actionType: 'create_project_from_template',
+      actionConfig: {
+        templateName: 'Special Service',
+        projectNameTemplate: '{{title}} Project',
+      },
+      sourceAccountId: pcoAccount.id,
+    });
+
+    const signal: AutomationSignal = {
+      id: 'sig-2',
+      provider: 'planning_center',
+      signalType: 'special_service_candidate',
+      externalId: 'plan-42',
+      dedupeKey: 'planning_center:special:plan-42',
+      occurredAt: '2026-04-03T00:00:00.000Z',
+      syncedAt: '2026-04-01T17:00:00.000Z',
+      sourceAccountId: pcoAccount.id,
+      sourceLabel: 'Planning Center',
+      payload: {
+        title: 'Good Friday Service',
+        serviceTypeName: 'Worship',
+        planDate: '2026-04-03',
+        daysUntil: 2,
+      },
+      createdAt: '2026-04-01T17:00:00.000Z',
+      updatedAt: '2026-04-01T17:00:00.000Z',
+    };
+
+    const result = engine.evaluateSignals('planning_center', [signal]);
+
+    expect(result.matchedRules).toBe(1);
+    expect(result.executedActions).toBe(1);
+
+    const instances = instancesRepo.findByTemplateId(template.id);
+    expect(instances).toHaveLength(1);
+    expect(instances[0]?.name).toBe('Good Friday Service Project');
+    expect(instances[0]?.anchorDate).toBe('2026-04-03');
+    expect(instances[0]?.steps).toHaveLength(1);
+    expect(instances[0]?.steps[0]?.dueDate).toBe('2026-03-27');
+  });
+
+  test('dedupes automation signals by dedupe key and refreshes payload on re-sync', () => {
+    const repo = new AutomationSignalsRepository();
+
+    const first = repo.upsertMany([
+      {
+        provider: 'google_calendar',
+        signalType: 'calendar_event_seen',
+        externalId: 'event-1',
+        dedupeKey: 'google_calendar:seen:event-1',
+        occurredAt: '2026-04-05T16:00:00.000Z',
+        syncedAt: '2026-04-01T17:00:00.000Z',
+        sourceAccountId: 'calendar-account-1',
+        sourceLabel: 'team@example.com',
+        payload: {
+          title: 'Rehearsal',
+          location: 'Sanctuary',
+        },
+      },
+    ]);
+    const second = repo.upsertMany([
+      {
+        provider: 'google_calendar',
+        signalType: 'calendar_event_seen',
+        externalId: 'event-1',
+        dedupeKey: 'google_calendar:seen:event-1',
+        occurredAt: '2026-04-05T16:00:00.000Z',
+        syncedAt: '2026-04-01T18:00:00.000Z',
+        sourceAccountId: 'calendar-account-1',
+        sourceLabel: 'team@example.com',
+        payload: {
+          title: 'Band Rehearsal',
+          location: 'Main Room',
+        },
+      },
+    ]);
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(second[0]?.id).toBe(first[0]?.id);
+    expect(repo.listRecent()).toHaveLength(1);
+    expect(repo.findByDedupeKey('google_calendar:seen:event-1')).toMatchObject({
+      syncedAt: '2026-04-01T18:00:00.000Z',
+      payload: {
+        title: 'Band Rehearsal',
+        location: 'Main Room',
+      },
+    });
+  });
+
+  test('preview endpoint returns match metadata and catalog endpoints expose external providers', () => {
+    const usersRepo = new UsersRepository();
+    const rulesRepo = new AutomationRulesRepository();
+    const accountsRepo = new IntegrationAccountsRepository();
+    const previewController = new AutomationRulesController();
+    const catalogController = new AutomationCatalogController();
+    const owner = usersRepo.create({
+      name: 'Alice',
+      email: 'alice@example.com',
+    });
+    const [calendarAccount] = accountsRepo.upsertGoogleAccount({
+      externalAccountId: 'google-user-1',
+      email: 'alice@example.com',
+      displayName: 'Alice',
+      accessToken: 'token',
+      refreshToken: null,
+      scope: 'calendar.events.readonly',
+      tokenType: 'Bearer',
+      expiresAt: null,
+    });
+    const rule = rulesRepo.create({
+      name: 'Calendar rehearsal',
+      source: 'google_calendar',
+      triggerKey: 'google_calendar.event_matching_filter',
+      triggerConfig: { textQuery: 'rehearsal', dateWindowDays: 7 },
+      actionType: 'create_task',
+      actionConfig: { titleTemplate: 'Prep for {{title}}' },
+      ownerId: owner.id,
+      sourceAccountId: calendarAccount.id,
+    });
+    rulesRepo.updateEvaluation(rule.id, {
+      lastEvaluatedAt: '2026-04-01T18:00:00.000Z',
+      lastMatchedAt: '2026-04-01T18:00:00.000Z',
+      matchCountLastRun: 2,
+      previewSample: {
+        title: 'Band rehearsal',
+        startDate: '2026-04-02',
+      },
+    });
+
+    const previewRes = createMockResponse();
+    previewController.getPreview(
+      {
+        params: { id: rule.id },
+        auth: { user: owner },
+      } as never,
+      previewRes as never,
+      (err?: unknown) => {
+        if (err) throw err;
+      },
+    );
+
+    expect(previewRes.statusCode).toBe(200);
+    expect(previewRes.body).toMatchObject({
+      ruleId: rule.id,
+      matchCountLastRun: 2,
+      summary:
+        'When Calendar event matches filter from Google Calendar with match rehearsal, window 7 days then create task.',
+      previewSample: {
+        title: 'Band rehearsal',
+      },
+    });
+
+    const providersRes = createMockResponse();
+    catalogController.getProviders(
+      {} as never,
+      providersRes as never,
+      (err?: unknown) => {
+        if (err) throw err;
+      },
+    );
+
+    expect(providersRes.statusCode).toBe(200);
+    expect(providersRes.body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'rhythm' }),
+        expect.objectContaining({ source: 'google_calendar' }),
+        expect.objectContaining({ source: 'gmail' }),
+      ]),
+    );
+  });
+});
+
+function createMockResponse(): {
+  statusCode: number;
+  body: unknown;
+  status(code: number): unknown;
+  json(payload: unknown): unknown;
+  send(payload?: unknown): unknown;
+} {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    send(payload?: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+}

--- a/apps/api_server/src/services/automation_engine_service.ts
+++ b/apps/api_server/src/services/automation_engine_service.ts
@@ -1,0 +1,334 @@
+import { MessagesRepository } from '../repositories/messages_repository';
+import { AutomationRulesRepository } from '../repositories/automation_rules_repository';
+import { ProjectTemplatesRepository } from '../repositories/project_templates_repository';
+import { TasksRepository } from '../repositories/tasks_repository';
+import { UsersRepository } from '../repositories/users_repository';
+import type { AutomationSignal } from '../models/automation_signal';
+import type { AutomationRule } from '../models/automation_rule';
+import { ProjectGenerationService } from './project_generation_service';
+
+interface EvaluationResult {
+  matchedRules: number;
+  executedActions: number;
+  matchesByRuleId: Record<string, number>;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function interpolate(template: string | null, signal: AutomationSignal): string {
+  const fallback = template ?? '';
+  const tokens = {
+    provider: signal.provider,
+    signalType: signal.signalType,
+    title: asString(signal.payload.title) ?? '',
+    subject: asString(signal.payload.subject) ?? '',
+    sender: asString(signal.payload.fromEmail) ?? asString(signal.payload.fromName) ?? '',
+    serviceType: asString(signal.payload.serviceTypeName) ?? '',
+    position: asString(signal.payload.positionName) ?? '',
+    team: asString(signal.payload.teamName) ?? '',
+    date: asString(signal.payload.planDate) ?? asString(signal.payload.startDate) ?? '',
+    snippet: asString(signal.payload.snippet) ?? '',
+  };
+
+  return fallback.replace(/\{\{(\w+)\}\}/g, (_, key: string) => tokens[key as keyof typeof tokens] ?? '');
+}
+
+function computeDateOffset(baseDate: string | null, daysOffset: number): string | null {
+  if (!baseDate) return null;
+  const normalized = baseDate.includes('T') ? baseDate.slice(0, 10) : baseDate;
+  const date = new Date(`${normalized}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return null;
+  date.setUTCDate(date.getUTCDate() + daysOffset);
+  return date.toISOString().slice(0, 10);
+}
+
+function scheduleToTargetDay(dateString: string | null, targetDay: number): string | null {
+  if (!dateString) return null;
+  const normalized = dateString.includes('T') ? dateString.slice(0, 10) : dateString;
+  const date = new Date(`${normalized}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return null;
+  while (date.getUTCDay() !== targetDay) {
+    date.setUTCDate(date.getUTCDate() + 1);
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+export class AutomationEngineService {
+  private readonly rulesRepo = new AutomationRulesRepository();
+  private readonly tasksRepo = new TasksRepository();
+  private readonly messagesRepo = new MessagesRepository();
+  private readonly usersRepo = new UsersRepository();
+  private readonly templatesRepo = new ProjectTemplatesRepository();
+  private readonly projectGeneration = new ProjectGenerationService();
+
+  evaluateSignals(
+    source: AutomationRule['source'],
+    signals: AutomationSignal[],
+  ): EvaluationResult {
+    const rules = this.rulesRepo.findEnabledBySource(source);
+    const matchesByRuleId: Record<string, number> = {};
+    let matchedRules = 0;
+    let executedActions = 0;
+
+    for (const rule of rules) {
+      const matchingSignals = signals.filter((signal) => this.matchesRule(rule, signal));
+      const preview = matchingSignals[0]?.payload ?? null;
+      this.rulesRepo.updateEvaluation(rule.id, {
+        lastEvaluatedAt: new Date().toISOString(),
+        lastMatchedAt: matchingSignals[0] ? new Date().toISOString() : null,
+        matchCountLastRun: matchingSignals.length,
+        previewSample: preview,
+      });
+
+      if (matchingSignals.length === 0) continue;
+      matchedRules += 1;
+      matchesByRuleId[rule.id] = matchingSignals.length;
+
+      for (const signal of matchingSignals) {
+        if (this.executeAction(rule, signal)) {
+          executedActions += 1;
+        }
+      }
+    }
+
+    return { matchedRules, executedActions, matchesByRuleId };
+  }
+
+  private matchesRule(rule: AutomationRule, signal: AutomationSignal): boolean {
+    switch (rule.triggerKey) {
+      case 'planning_center.plan_person_declined':
+        return signal.signalType === 'team_member_declined' && this.matchesPlanningCenterFilters(rule, signal);
+      case 'planning_center.plan_person_unconfirmed':
+        return signal.signalType === 'team_member_unconfirmed' && this.matchesPlanningCenterFilters(rule, signal);
+      case 'planning_center.needed_position_open':
+        return signal.signalType === 'needed_position_open' && this.matchesPlanningCenterFilters(rule, signal);
+      case 'planning_center.special_service_candidate':
+        return signal.signalType === 'special_service_candidate' && this.matchesPlanningCenterFilters(rule, signal);
+      case 'google_calendar.event_matching_filter':
+        return (
+          (signal.signalType === 'calendar_event_seen' || signal.signalType === 'calendar_event_today') &&
+          this.matchesCalendarFilters(rule, signal)
+        );
+      case 'google_calendar.all_day_event':
+        return (
+          (signal.signalType === 'calendar_event_seen' || signal.signalType === 'calendar_event_today') &&
+          signal.payload.isAllDay === true &&
+          this.matchesCalendarFilters(rule, signal)
+        );
+      case 'gmail.message_matching_filter':
+        return (
+          (signal.signalType === 'gmail_message_seen' || signal.signalType === 'gmail_message_from_sender') &&
+          this.matchesGmailFilters(rule, signal, false)
+        );
+      case 'gmail.unread_message_matching_filter':
+        return (
+          (signal.signalType === 'gmail_unread_message_seen' || signal.signalType === 'gmail_message_from_sender') &&
+          this.matchesGmailFilters(rule, signal, true)
+        );
+      default:
+        return false;
+    }
+  }
+
+  private matchesPlanningCenterFilters(rule: AutomationRule, signal: AutomationSignal): boolean {
+    const config = rule.triggerConfig ?? {};
+    const leadDays = asNumber(config.leadDays);
+    const signalLeadDays = asNumber(signal.payload.daysUntil);
+    if (leadDays != null && signalLeadDays != null && signalLeadDays > leadDays) return false;
+    const serviceType = asString(config.serviceType);
+    if (serviceType != null && serviceType !== asString(signal.payload.serviceTypeName)) return false;
+    const teamId = asString(config.teamId);
+    if (teamId != null && teamId !== asString(signal.payload.teamId)) return false;
+    const positionName = asString(config.positionName)?.toLowerCase();
+    if (
+      positionName != null &&
+      positionName !== asString(signal.payload.positionName)?.toLowerCase()
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  private matchesCalendarFilters(rule: AutomationRule, signal: AutomationSignal): boolean {
+    const config = rule.triggerConfig ?? {};
+    const query = asString(config.textQuery)?.toLowerCase();
+    if (query != null) {
+      const haystack = [
+        asString(signal.payload.title),
+        asString(signal.payload.description),
+        asString(signal.payload.location),
+      ]
+        .filter((value): value is string => value != null)
+        .join(' ')
+        .toLowerCase();
+      if (!haystack.includes(query)) return false;
+    }
+
+    const eventType = asString(config.eventType);
+    if (eventType != null && eventType !== asString(signal.payload.eventType)) return false;
+
+    if (config.allDayOnly == true && signal.payload.isAllDay !== true) return false;
+
+    const dateWindowDays = asNumber(config.dateWindowDays);
+    if (dateWindowDays != null) {
+      const daysUntil = asNumber(signal.payload.daysUntilStart);
+      if (daysUntil != null && daysUntil > dateWindowDays) return false;
+    }
+
+    return true;
+  }
+
+  private matchesGmailFilters(
+    rule: AutomationRule,
+    signal: AutomationSignal,
+    unreadOnly: boolean,
+  ): boolean {
+    const config = rule.triggerConfig ?? {};
+    if (unreadOnly && signal.payload.isUnread !== true) return false;
+
+    const sender = asString(config.sender)?.toLowerCase();
+    if (sender != null) {
+      const fromEmail = asString(signal.payload.fromEmail)?.toLowerCase() ?? '';
+      const fromName = asString(signal.payload.fromName)?.toLowerCase() ?? '';
+      if (!fromEmail.includes(sender) && !fromName.includes(sender)) return false;
+    }
+
+    const subjectContains = asString(config.subjectContains)?.toLowerCase();
+    if (subjectContains != null) {
+      const subject = asString(signal.payload.subject)?.toLowerCase() ?? '';
+      if (!subject.includes(subjectContains)) return false;
+    }
+
+    const label = asString(config.label)?.toUpperCase();
+    if (label != null) {
+      const labels = Array.isArray(signal.payload.labelIds)
+        ? signal.payload.labelIds.map((item) => String(item).toUpperCase())
+        : [];
+      if (!labels.includes(label)) return false;
+    }
+
+    const hoursSinceReceived = asNumber(config.hoursSinceReceived);
+    if (hoursSinceReceived != null) {
+      const occurredAt = asString(signal.payload.receivedAt) ?? signal.occurredAt;
+      if (occurredAt != null) {
+        const ageHours = (Date.now() - new Date(occurredAt).getTime()) / (1000 * 60 * 60);
+        if (ageHours > hoursSinceReceived) return false;
+      }
+    }
+
+    return true;
+  }
+
+  private executeAction(rule: AutomationRule, signal: AutomationSignal): boolean {
+    switch (rule.actionType) {
+      case 'create_task':
+        this.createTaskFromSignal(rule, signal, false);
+        return true;
+      case 'tag_task':
+        this.createTaskFromSignal(rule, signal, true);
+        return true;
+      case 'auto_schedule':
+        this.createTaskFromSignal(rule, signal, false, true);
+        return true;
+      case 'send_notification':
+        return this.sendNotification(rule, signal);
+      case 'create_project_from_template':
+        return this.createProject(rule, signal);
+      default:
+        return false;
+    }
+  }
+
+  private createTaskFromSignal(
+    rule: AutomationRule,
+    signal: AutomationSignal,
+    includeTag: boolean,
+    autoSchedule = false,
+  ): void {
+    const config = rule.actionConfig ?? {};
+    const dueBase =
+      asString(signal.payload.planDate) ??
+      asString(signal.payload.startDate) ??
+      asString(signal.payload.receivedAt) ??
+      signal.occurredAt;
+    const dueDate = computeDateOffset(dueBase, asNumber(config.dueDaysOffset) ?? 0);
+    const title =
+      interpolate(asString(config.titleTemplate), signal) ||
+      asString(signal.payload.title) ||
+      asString(signal.payload.subject) ||
+      `${rule.name} follow-up`;
+    let notes =
+      interpolate(asString(config.notesTemplate), signal) ||
+      asString(signal.payload.notes) ||
+      asString(signal.payload.snippet) ||
+      null;
+    if (includeTag) {
+      const tag = asString(config.tag);
+      if (tag != null) {
+        notes = notes ? `[${tag}] ${notes}` : `[${tag}]`;
+      }
+    }
+    const scheduledDate = autoSchedule
+      ? scheduleToTargetDay(dueDate, asNumber(config.targetDay) ?? 1)
+      : null;
+
+    this.tasksRepo.upsertExternalTask({
+      title,
+      notes,
+      dueDate,
+      scheduledDate,
+      sourceType: 'automation_rule',
+      sourceId: `${rule.id}:${signal.dedupeKey}`,
+      ownerId: rule.ownerId ?? null,
+    });
+  }
+
+  private sendNotification(rule: AutomationRule, signal: AutomationSignal): boolean {
+    if (rule.ownerId == null) return false;
+    const bot = this.usersRepo.findOrCreateSystemBot();
+    const config = rule.actionConfig ?? {};
+    const message =
+      interpolate(asString(config.messageTemplate), signal) ||
+      `${rule.name} matched ${asString(signal.payload.title) ?? asString(signal.payload.subject) ?? signal.signalType}.`;
+    this.messagesRepo.sendDirectMessage(bot.id, rule.ownerId, message);
+    return true;
+  }
+
+  private createProject(rule: AutomationRule, signal: AutomationSignal): boolean {
+    const config = rule.actionConfig ?? {};
+    const templateId = asString(config.templateId);
+    const templateName = asString(config.templateName);
+    const template = templateId
+      ? this.templatesRepo.findById(templateId)
+      : templateName
+        ? this.templatesRepo.findByNameInsensitive(templateName)
+        : null;
+    if (template == null) return false;
+
+    const anchorDate =
+      asString(signal.payload.planDate) ??
+      asString(signal.payload.startDate) ??
+      computeDateOffset(signal.occurredAt, 0);
+    if (anchorDate == null) return false;
+
+    const projectName =
+      interpolate(asString(config.projectNameTemplate), signal) ||
+      asString(signal.payload.title) ||
+      rule.name;
+    this.projectGeneration.generate(template.id, anchorDate, projectName);
+    return true;
+  }
+}

--- a/apps/api_server/src/services/automation_engine_service.ts
+++ b/apps/api_server/src/services/automation_engine_service.ts
@@ -66,6 +66,16 @@ function scheduleToTargetDay(dateString: string | null, targetDay: number): stri
   return date.toISOString().slice(0, 10);
 }
 
+function taskSourceId(rule: AutomationRule, signal: AutomationSignal): string {
+  if (signal.provider === 'gmail') {
+    const threadId = asString(signal.payload.threadId);
+    if (threadId != null) {
+      return `${rule.id}:gmail-thread:${threadId}`;
+    }
+  }
+  return `${rule.id}:${signal.dedupeKey}`;
+}
+
 export class AutomationEngineService {
   private readonly rulesRepo = new AutomationRulesRepository();
   private readonly tasksRepo = new TasksRepository();
@@ -291,7 +301,7 @@ export class AutomationEngineService {
       dueDate,
       scheduledDate,
       sourceType: 'automation_rule',
-      sourceId: `${rule.id}:${signal.dedupeKey}`,
+      sourceId: taskSourceId(rule, signal),
       ownerId: rule.ownerId ?? null,
     });
   }

--- a/apps/api_server/src/services/google_identity_service.ts
+++ b/apps/api_server/src/services/google_identity_service.ts
@@ -6,6 +6,7 @@ interface GoogleTokenInfoResponse {
   email?: string;
   email_verified?: string;
   name?: string;
+  picture?: string;
   sub?: string;
 }
 
@@ -13,6 +14,7 @@ export interface GoogleIdentity {
   sub: string;
   email: string;
   name: string;
+  picture?: string | null;
 }
 
 export class GoogleIdentityService {
@@ -45,6 +47,7 @@ export class GoogleIdentityService {
       sub: body.sub,
       email: body.email,
       name: body.name?.trim() || body.email,
+      picture: body.picture?.trim() || null,
     };
   }
 }

--- a/apps/api_server/src/services/google_oauth_service.ts
+++ b/apps/api_server/src/services/google_oauth_service.ts
@@ -1,5 +1,6 @@
 import { AppError } from '../errors/app_error';
 import { env } from '../config/env';
+import type { IntegrationAccount } from '../models/integration_account';
 import { IntegrationAccountsRepository } from '../repositories/integration_accounts_repository';
 
 const GOOGLE_AUTH_BASE = 'https://accounts.google.com/o/oauth2/v2/auth';
@@ -68,6 +69,33 @@ export class GoogleOAuthService {
     });
   }
 
+  async refreshAccessToken(account: IntegrationAccount): Promise<IntegrationAccount> {
+    this.assertConfigured();
+    if (!account.refreshToken) {
+      throw AppError.badRequest(
+        'Google reconnect required: no refresh token is stored.',
+      );
+    }
+
+    const tokens = await this.refreshTokens(account.refreshToken);
+    const expiresAt = tokens.expires_in
+      ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+      : account.expiresAt;
+
+    this.accountsRepo.upsertGoogleAccount({
+      externalAccountId: account.externalAccountId,
+      email: account.email,
+      displayName: account.displayName,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token ?? account.refreshToken,
+      scope: tokens.scope ?? account.scope,
+      tokenType: tokens.token_type ?? account.tokenType,
+      expiresAt,
+    });
+
+    return this.accountsRepo.findByProvider(account.provider) ?? account;
+  }
+
   private assertConfigured(): void {
     if (!env.googleClientId || !env.googleClientSecret || !env.googleRedirectUri) {
       throw AppError.badRequest(
@@ -92,6 +120,26 @@ export class GoogleOAuthService {
     if (!response.ok) {
       const text = await response.text();
       throw AppError.badRequest(`Google token exchange failed: ${text}`);
+    }
+
+    return (await response.json()) as GoogleTokenResponse;
+  }
+
+  private async refreshTokens(refreshToken: string): Promise<GoogleTokenResponse> {
+    const response = await fetch(GOOGLE_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: env.googleClientId,
+        client_secret: env.googleClientSecret,
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token',
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw AppError.badRequest(`Google token refresh failed: ${text}`);
     }
 
     return (await response.json()) as GoogleTokenResponse;

--- a/apps/api_server/src/services/integrations_service.ts
+++ b/apps/api_server/src/services/integrations_service.ts
@@ -1,6 +1,7 @@
 import { GmailService } from '../integrations/gmail/gmail_service';
 import { GoogleCalendarService } from '../integrations/google_calendar/google_calendar_service';
 import { PlanningCenterService } from '../integrations/planning_center/planning_center_service';
+import type { IntegrationAccount } from '../models/integration_account';
 import type { CreateAutomationSignalDto } from '../models/automation_signal';
 import { AppError } from '../errors/app_error';
 import { AutomationRulesRepository } from '../repositories/automation_rules_repository';
@@ -11,6 +12,8 @@ import { IntegrationAccountsRepository } from '../repositories/integration_accou
 import { IntegrationPreferencesRepository } from '../repositories/integration_preferences_repository';
 import { ProjectTemplatesRepository } from '../repositories/project_templates_repository';
 import { AutomationEngineService } from './automation_engine_service';
+import { GoogleOAuthService } from './google_oauth_service';
+import { PlanningCenterOAuthService } from './planning_center_oauth_service';
 
 function daysUntil(dateString: string): number {
   const start = new Date();
@@ -35,9 +38,11 @@ export class IntegrationsService {
   private readonly gmail = new GmailService();
   private readonly planningCenter = new PlanningCenterService();
   private readonly automationEngine = new AutomationEngineService();
+  private readonly googleOAuth = new GoogleOAuthService();
+  private readonly planningCenterOAuth = new PlanningCenterOAuthService();
 
   async syncGoogleCalendar() {
-    const account = this.accountsRepo.findByProvider('google_calendar');
+    const account = await this.ensureFreshAccount('google_calendar');
     if (!account || !account.accessToken) {
       throw AppError.badRequest('Google Calendar is not connected');
     }
@@ -117,7 +122,7 @@ export class IntegrationsService {
   }
 
   async syncGmail() {
-    const account = this.accountsRepo.findByProvider('gmail');
+    const account = await this.ensureFreshAccount('gmail');
     if (!account || !account.accessToken) {
       throw AppError.badRequest('Gmail is not connected');
     }
@@ -210,7 +215,7 @@ export class IntegrationsService {
   }
 
   async syncPlanningCenter() {
-    const account = this.accountsRepo.findByProvider('planning_center');
+    const account = await this.ensureFreshAccount('planning_center');
     if (!account || !account.accessToken) {
       throw AppError.badRequest('Planning Center is not connected');
     }
@@ -313,6 +318,30 @@ export class IntegrationsService {
       );
       throw err;
     }
+  }
+
+  private async ensureFreshAccount(
+    provider: 'google_calendar' | 'gmail' | 'planning_center',
+  ): Promise<IntegrationAccount | null> {
+    const account = this.accountsRepo.findByProvider(provider);
+    if (!account) return null;
+    if (!this.shouldRefresh(account)) return account;
+
+    if (provider === 'planning_center') {
+      return this.planningCenterOAuth.refreshAccessToken(account);
+    }
+
+    const refreshed = await this.googleOAuth.refreshAccessToken(account);
+    if (provider === 'google_calendar') return refreshed;
+    return this.accountsRepo.findByProvider(provider) ?? refreshed;
+  }
+
+  private shouldRefresh(account: IntegrationAccount): boolean {
+    if (!account.refreshToken) return false;
+    if (!account.expiresAt) return true;
+    const expiresAtMs = Date.parse(account.expiresAt);
+    if (Number.isNaN(expiresAtMs)) return true;
+    return expiresAtMs <= Date.now() + 5 * 60 * 1000;
   }
 
   getPlanningCenterTaskPreferences() {

--- a/apps/api_server/src/services/integrations_service.ts
+++ b/apps/api_server/src/services/integrations_service.ts
@@ -1,28 +1,40 @@
 import { GmailService } from '../integrations/gmail/gmail_service';
 import { GoogleCalendarService } from '../integrations/google_calendar/google_calendar_service';
 import { PlanningCenterService } from '../integrations/planning_center/planning_center_service';
+import type { CreateAutomationSignalDto } from '../models/automation_signal';
 import { AppError } from '../errors/app_error';
+import { AutomationRulesRepository } from '../repositories/automation_rules_repository';
+import { AutomationSignalsRepository } from '../repositories/automation_signals_repository';
 import { CalendarShadowEventsRepository } from '../repositories/calendar_shadow_events_repository';
 import { GmailSignalsRepository } from '../repositories/gmail_signals_repository';
 import { IntegrationAccountsRepository } from '../repositories/integration_accounts_repository';
 import { IntegrationPreferencesRepository } from '../repositories/integration_preferences_repository';
-import { ProjectInstancesRepository } from '../repositories/project_instances_repository';
 import { ProjectTemplatesRepository } from '../repositories/project_templates_repository';
-import { TasksRepository } from '../repositories/tasks_repository';
-import { ProjectGenerationService } from './project_generation_service';
+import { AutomationEngineService } from './automation_engine_service';
+
+function daysUntil(dateString: string): number {
+  const start = new Date();
+  const startOfTodayUtc = Date.UTC(
+    start.getUTCFullYear(),
+    start.getUTCMonth(),
+    start.getUTCDate(),
+  );
+  const target = new Date(dateString).getTime();
+  return Math.floor((target - startOfTodayUtc) / (1000 * 60 * 60 * 24));
+}
 
 export class IntegrationsService {
   private readonly accountsRepo = new IntegrationAccountsRepository();
+  private readonly rulesRepo = new AutomationRulesRepository();
+  private readonly signalsRepo = new AutomationSignalsRepository();
   private readonly shadowEventsRepo = new CalendarShadowEventsRepository();
   private readonly gmailSignalsRepo = new GmailSignalsRepository();
-  private readonly tasksRepo = new TasksRepository();
   private readonly preferencesRepo = new IntegrationPreferencesRepository();
   private readonly templateRepo = new ProjectTemplatesRepository();
-  private readonly instanceRepo = new ProjectInstancesRepository();
   private readonly googleCalendar = new GoogleCalendarService();
   private readonly gmail = new GmailService();
   private readonly planningCenter = new PlanningCenterService();
-  private readonly projectGeneration = new ProjectGenerationService();
+  private readonly automationEngine = new AutomationEngineService();
 
   async syncGoogleCalendar() {
     const account = this.accountsRepo.findByProvider('google_calendar');
@@ -38,8 +50,63 @@ export class IntegrationsService {
           ...event,
         })),
       );
+      const syncedAt = new Date().toISOString();
+      const automationSignals: CreateAutomationSignalDto[] = [];
+      for (const event of events) {
+        const startDate = event.startAt.includes('T')
+          ? event.startAt.slice(0, 10)
+          : event.startAt;
+        const basePayload = {
+          title: event.title,
+          description: event.description,
+          location: event.location,
+          startDate,
+          startAt: event.startAt,
+          endAt: event.endAt,
+          isAllDay: event.isAllDay,
+          eventType: 'default',
+          sourceName: event.sourceName,
+          daysUntilStart: daysUntil(`${startDate}T00:00:00Z`),
+        };
+        automationSignals.push({
+          provider: 'google_calendar',
+          signalType: 'calendar_event_seen',
+          externalId: event.externalId,
+          dedupeKey: `google_calendar:seen:${event.externalId}`,
+          occurredAt: event.startAt,
+          syncedAt,
+          sourceAccountId: account.id,
+          sourceLabel: account.email ?? account.displayName ?? 'Google Calendar',
+          payload: basePayload,
+        });
+        if (basePayload.daysUntilStart <= 0) {
+          automationSignals.push({
+            provider: 'google_calendar',
+            signalType: 'calendar_event_today',
+            externalId: event.externalId,
+            dedupeKey: `google_calendar:today:${event.externalId}:${startDate}`,
+            occurredAt: event.startAt,
+            syncedAt,
+            sourceAccountId: account.id,
+            sourceLabel: account.email ?? account.displayName ?? 'Google Calendar',
+            payload: basePayload,
+          });
+        }
+      }
+      this.signalsRepo.upsertMany(automationSignals);
+      const evaluation = this.automationEngine.evaluateSignals(
+        'google_calendar',
+        this.signalsRepo.listRecent(automationSignals.length + 10).filter(
+          (item) => item.provider === 'google_calendar' && item.syncedAt === syncedAt,
+        ),
+      );
       this.accountsRepo.markSynced('google_calendar');
-      return { syncedCount: synced.length };
+      return {
+        syncedCount: synced.length,
+        generatedSignalCount: automationSignals.length,
+        matchedRuleCount: evaluation.matchedRules,
+        executedActionCount: evaluation.executedActions,
+      };
     } catch (err) {
       this.accountsRepo.markError(
         'google_calendar',
@@ -58,9 +125,75 @@ export class IntegrationsService {
     try {
       const signals = await this.gmail.listRecentInboxSignals(account);
       this.gmailSignalsRepo.upsertMany(signals);
+      const syncedAt = new Date().toISOString();
+      const automationSignals: CreateAutomationSignalDto[] = signals.flatMap((signal) => {
+        const payload = {
+          fromName: signal.fromName,
+          fromEmail: signal.fromEmail,
+          subject: signal.subject,
+          snippet: signal.snippet,
+          receivedAt: signal.receivedAt,
+          isUnread: signal.isUnread,
+          threadId: signal.threadId,
+          labelIds: signal.isUnread ? ['INBOX', 'UNREAD'] : ['INBOX'],
+        };
+        return [
+          {
+            provider: 'gmail' as const,
+            signalType: 'gmail_message_seen' as const,
+            externalId: signal.externalId,
+            dedupeKey: `gmail:seen:${signal.externalId}`,
+            occurredAt: signal.receivedAt,
+            syncedAt,
+            sourceAccountId: account.id,
+            sourceLabel: account.email ?? account.displayName ?? 'Gmail',
+            payload,
+          },
+          ...(signal.isUnread
+            ? [
+                {
+                  provider: 'gmail' as const,
+                  signalType: 'gmail_unread_message_seen' as const,
+                  externalId: signal.externalId,
+                  dedupeKey: `gmail:unread:${signal.externalId}`,
+                  occurredAt: signal.receivedAt,
+                  syncedAt,
+                  sourceAccountId: account.id,
+                  sourceLabel: account.email ?? account.displayName ?? 'Gmail',
+                  payload,
+                },
+              ]
+            : []),
+          ...(signal.fromEmail
+            ? [
+                {
+                  provider: 'gmail' as const,
+                  signalType: 'gmail_message_from_sender' as const,
+                  externalId: signal.externalId,
+                  dedupeKey: `gmail:sender:${signal.externalId}:${signal.fromEmail.toLowerCase()}`,
+                  occurredAt: signal.receivedAt,
+                  syncedAt,
+                  sourceAccountId: account.id,
+                  sourceLabel: account.email ?? account.displayName ?? 'Gmail',
+                  payload,
+                },
+              ]
+            : []),
+        ];
+      });
+      this.signalsRepo.upsertMany(automationSignals);
+      const evaluation = this.automationEngine.evaluateSignals(
+        'gmail',
+        this.signalsRepo.listRecent(automationSignals.length + 10).filter(
+          (item) => item.provider === 'gmail' && item.syncedAt === syncedAt,
+        ),
+      );
       this.accountsRepo.markSynced('gmail');
       return {
         syncedCount: signals.length,
+        generatedSignalCount: automationSignals.length,
+        matchedRuleCount: evaluation.matchedRules,
+        executedActionCount: evaluation.executedActions,
         signals: this.gmailSignalsRepo.listRecent(),
       };
     } catch (err) {
@@ -83,57 +216,95 @@ export class IntegrationsService {
     }
 
     try {
+      this.ensureDefaultRules();
       const preferences =
         this.preferencesRepo.getPlanningCenterTaskPreferences();
-      const signals = await this.planningCenter.collectAutomationSignals(
+      const collected = await this.planningCenter.collectAutomationSignals(
         account,
         preferences,
       );
-      const removedTaskCount =
-        this.tasksRepo.deleteAllBySourceType('planning_center_signal');
-
-      for (const task of signals.tasks) {
-        this.tasksRepo.upsertExternalTask({
-          title: task.title,
-          notes: task.notes,
-          dueDate: task.dueDate,
-          scheduledDate: task.scheduledDate,
-          sourceType: 'planning_center_signal',
-          sourceId: task.sourceId,
-        });
-      }
-
-      const template = this.templateRepo.findByNameInsensitive(
-        this.planningCenter.specialServiceTemplateName(),
+      const syncedAt = new Date().toISOString();
+      const automationSignals: CreateAutomationSignalDto[] = [
+        ...collected.upcomingPlans.map((plan) => ({
+          provider: 'planning_center' as const,
+          signalType: 'plan_upcoming' as const,
+          externalId: plan.planId,
+          dedupeKey: `planning_center:plan:${plan.planId}`,
+          occurredAt: `${plan.planDate}T00:00:00Z`,
+          syncedAt,
+          sourceAccountId: account.id,
+          sourceLabel: account.email ?? account.displayName ?? 'Planning Center',
+          payload: {
+            title: plan.title,
+            serviceTypeName: plan.serviceTypeName,
+            planDate: plan.planDate,
+            daysUntil: plan.daysUntil,
+          },
+        })),
+        ...collected.tasks.map((task) => ({
+          provider: 'planning_center' as const,
+          signalType: task.signalType,
+          externalId: task.sourceId,
+          dedupeKey: task.dedupeKey,
+          occurredAt: `${task.planDate}T00:00:00Z`,
+          syncedAt,
+          sourceAccountId: account.id,
+          sourceLabel: account.email ?? account.displayName ?? 'Planning Center',
+          payload: {
+            title: task.title,
+            notes: task.notes,
+            dueDate: task.dueDate,
+            scheduledDate: task.scheduledDate,
+            teamId: task.teamId,
+            teamName: task.teamName,
+            positionName: task.positionName,
+            serviceTypeName: task.serviceTypeName,
+            planId: task.planId,
+            planTitle: task.planTitle,
+            planDate: task.planDate,
+            daysUntil: task.daysUntil,
+          },
+        })),
+        ...collected.specialProjects.map((project) => ({
+          provider: 'planning_center' as const,
+          signalType: 'special_service_candidate' as const,
+          externalId: project.planId,
+          dedupeKey: `planning_center:special:${project.planId}`,
+          occurredAt: `${project.anchorDate}T00:00:00Z`,
+          syncedAt,
+          sourceAccountId: account.id,
+          sourceLabel: account.email ?? account.displayName ?? 'Planning Center',
+          payload: {
+            title: project.title,
+            name: project.name,
+            serviceTypeName: project.serviceTypeName,
+            planId: project.planId,
+            planDate: project.anchorDate,
+            daysUntil: project.daysUntil,
+          },
+        })),
+      ];
+      this.signalsRepo.upsertMany(automationSignals);
+      const evaluation = this.automationEngine.evaluateSignals(
+        'planning_center',
+        this.signalsRepo.listRecent(automationSignals.length + 10).filter(
+          (item) =>
+            item.provider === 'planning_center' && item.syncedAt === syncedAt,
+        ),
       );
-      let startedProjectCount = 0;
-      let eligibleSpecialServiceCount = signals.specialProjects.length;
-
-      if (template) {
-        for (const project of signals.specialProjects) {
-          const existing = this.instanceRepo.findByTemplateAndAnchor(
-            template.id,
-            project.anchorDate,
-            project.name,
-          );
-          if (existing) continue;
-          this.projectGeneration.generate(
-            template.id,
-            project.anchorDate,
-            project.name,
-          );
-          startedProjectCount += 1;
-        }
-      }
 
       this.accountsRepo.markSynced('planning_center');
       return {
-        planCount: signals.planCount,
-        taskSignalCount: signals.tasks.length,
-        removedTaskCount,
-        specialServiceEligibleCount: eligibleSpecialServiceCount,
-        specialServiceProjectTemplateFound: template != null,
-        startedProjectCount,
+        planCount: collected.planCount,
+        taskSignalCount: collected.tasks.length,
+        specialServiceEligibleCount: collected.specialProjects.length,
+        specialServiceProjectTemplateFound:
+          this.templateRepo.findByNameInsensitive(
+            this.planningCenter.specialServiceTemplateName(),
+          ) != null,
+        generatedSignalCount: automationSignals.length,
+        matchedRuleCount: evaluation.matchedRules,
+        executedActionCount: evaluation.executedActions,
       };
     } catch (err) {
       this.accountsRepo.markError(
@@ -161,5 +332,62 @@ export class IntegrationsService {
       throw AppError.badRequest('Planning Center is not connected');
     }
     return this.planningCenter.collectTaskOptions(account);
+  }
+
+  private ensureDefaultRules(): void {
+    const existing = this.rulesRepo.findAll();
+    const ensure = (name: string, payload: Parameters<AutomationRulesRepository['create']>[0]) => {
+      if (existing.some((rule) => rule.name === name && rule.ownerId == null)) return;
+      this.rulesRepo.create(payload);
+    };
+
+    ensure('PCO declined volunteer', {
+      name: 'PCO declined volunteer',
+      source: 'planning_center',
+      triggerKey: 'planning_center.plan_person_declined',
+      actionType: 'create_task',
+      triggerConfig: { leadDays: 21 },
+      actionConfig: {
+        titleTemplate: '{{title}}',
+        notesTemplate: '{{serviceType}} {{position}} {{date}}',
+      },
+      ownerId: null,
+    });
+    ensure('PCO open needed position', {
+      name: 'PCO open needed position',
+      source: 'planning_center',
+      triggerKey: 'planning_center.needed_position_open',
+      actionType: 'create_task',
+      triggerConfig: { leadDays: 21 },
+      actionConfig: {
+        titleTemplate: '{{title}}',
+        notesTemplate: '{{serviceType}} {{position}} {{date}}',
+      },
+      ownerId: null,
+    });
+    ensure('PCO unconfirmed volunteer', {
+      name: 'PCO unconfirmed volunteer',
+      source: 'planning_center',
+      triggerKey: 'planning_center.plan_person_unconfirmed',
+      actionType: 'create_task',
+      triggerConfig: { leadDays: 14 },
+      actionConfig: {
+        titleTemplate: '{{title}}',
+        notesTemplate: '{{serviceType}} {{position}} {{date}}',
+      },
+      ownerId: null,
+    });
+    ensure('PCO special service project', {
+      name: 'PCO special service project',
+      source: 'planning_center',
+      triggerKey: 'planning_center.special_service_candidate',
+      actionType: 'create_project_from_template',
+      triggerConfig: { leadDays: 30 },
+      actionConfig: {
+        templateName: this.planningCenter.specialServiceTemplateName(),
+        projectNameTemplate: '{{title}}',
+      },
+      ownerId: null,
+    });
   }
 }

--- a/apps/api_server/src/services/planning_center_oauth_service.ts
+++ b/apps/api_server/src/services/planning_center_oauth_service.ts
@@ -1,5 +1,6 @@
 import { AppError } from '../errors/app_error';
 import { env } from '../config/env';
+import type { IntegrationAccount } from '../models/integration_account';
 import { IntegrationAccountsRepository } from '../repositories/integration_accounts_repository';
 
 const PCO_AUTH_BASE = 'https://api.planningcenteronline.com/oauth/authorize';
@@ -57,6 +58,33 @@ export class PlanningCenterOAuthService {
     });
   }
 
+  async refreshAccessToken(account: IntegrationAccount): Promise<IntegrationAccount> {
+    this.assertConfigured();
+    if (!account.refreshToken) {
+      throw AppError.badRequest(
+        'Planning Center reconnect required: no refresh token is stored.',
+      );
+    }
+
+    const tokens = await this.refreshTokens(account.refreshToken);
+    const expiresAt = tokens.expires_in
+      ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+      : account.expiresAt;
+
+    this.accountsRepo.upsertPlanningCenterAccount({
+      externalAccountId: account.externalAccountId,
+      email: account.email,
+      displayName: account.displayName,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token ?? account.refreshToken,
+      scope: tokens.scope ?? account.scope,
+      tokenType: tokens.token_type ?? account.tokenType,
+      expiresAt,
+    });
+
+    return this.accountsRepo.findByProvider(account.provider) ?? account;
+  }
+
   private assertConfigured(): void {
     if (!env.pcoApplicationId || !env.pcoSecret || !env.pcoRedirectUri) {
       throw AppError.badRequest(
@@ -83,6 +111,28 @@ export class PlanningCenterOAuthService {
     if (!response.ok) {
       const text = await response.text();
       throw AppError.badRequest(`Planning Center token exchange failed: ${text}`);
+    }
+
+    return (await response.json()) as PlanningCenterTokenResponse;
+  }
+
+  private async refreshTokens(
+    refreshToken: string,
+  ): Promise<PlanningCenterTokenResponse> {
+    const response = await fetch(PCO_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: env.pcoApplicationId,
+        client_secret: env.pcoSecret,
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token',
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw AppError.badRequest(`Planning Center token refresh failed: ${text}`);
     }
 
     return (await response.json()) as PlanningCenterTokenResponse;

--- a/apps/api_server/src/services/sync_orchestrator_service.ts
+++ b/apps/api_server/src/services/sync_orchestrator_service.ts
@@ -38,7 +38,7 @@ export class SyncOrchestratorService {
       try {
         const result = await this.integrationsService.syncPlanningCenter();
         logger.info(
-          `SyncOrchestrator: Planning Center synced — ${result.taskSignalCount} task(s), ${result.startedProjectCount} project(s) started`,
+          `SyncOrchestrator: Planning Center synced — ${result.taskSignalCount} task signal(s), ${result.executedActionCount} action(s) executed`,
         );
       } catch (err) {
         logger.error(

--- a/apps/desktop_flutter/README.md
+++ b/apps/desktop_flutter/README.md
@@ -15,12 +15,20 @@ flutter run -d macos \
   --dart-define=GOOGLE_DESKTOP_CLIENT_ID=<desktop-google-client-id>
 ```
 
-For Google Sign-In, the desktop app now expects `GOOGLE_DESKTOP_CLIENT_ID` as a Dart define. The API separately trusts the web client ID for `POST /auth/google/login`.
+For Google Sign-In, the desktop app now expects `GOOGLE_DESKTOP_CLIENT_ID` as a Dart define. The packaged API must trust the same Firebase Apple client ID through `GOOGLE_AUTH_CLIENT_ID`.
 
 ## Beta Distribution
 - Use the `Desktop Release` GitHub Actions workflow to build downloadable tester artifacts.
 - The app now checks GitHub Releases for updates and can open the latest download from inside the sidebar.
 - Apple signing and notarization setup is documented in [docs/release/macos_distribution.md](/Users/ajhochhalter/Documents/Rhythm/docs/release/macos_distribution.md).
+
+### Packaged Beta Smoke Checklist
+- Install the DMG or ZIP artifact from the latest `Desktop Release` run.
+- Launch the packaged app and confirm the bundled API server starts without `flutter run`.
+- Sign in with Google and verify the app opens past the login gate.
+- Quit and relaunch the packaged app; confirm the session restores.
+- Open Messages, send/read a conversation across two users, and verify unread badges update.
+- Create a task and a facility reservation, then confirm user-scoped data still appears after restart.
 
 ## Notes
 - Avoid placing domain logic in controllers.

--- a/apps/desktop_flutter/lib/app/core/auth/auth_session_service.dart
+++ b/apps/desktop_flutter/lib/app/core/auth/auth_session_service.dart
@@ -58,6 +58,7 @@ class AuthSessionService extends ChangeNotifier {
       _sessionToken = storedToken;
       _currentUser = user;
       AuthSessionStore.setSessionToken(storedToken);
+      _errorMessage = null;
       _status = AuthStatus.authenticated;
     } catch (error) {
       await _clearLocalSession();
@@ -89,6 +90,7 @@ class AuthSessionService extends ChangeNotifier {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_sessionTokenKey, login.sessionToken);
 
+      _errorMessage = null;
       _status = AuthStatus.authenticated;
     } catch (error) {
       await _clearLocalSession();
@@ -104,7 +106,15 @@ class AuthSessionService extends ChangeNotifier {
     } catch (_) {
       // Local logout should still succeed if the server session is already gone.
     }
+    if (_googleInitialized) {
+      try {
+        await GoogleSignIn.instance.signOut();
+      } catch (_) {
+        // Local session reset still takes precedence.
+      }
+    }
     await _clearLocalSession();
+    _errorMessage = null;
     _status = AuthStatus.unauthenticated;
     notifyListeners();
   }

--- a/apps/desktop_flutter/lib/app/core/auth/auth_user.dart
+++ b/apps/desktop_flutter/lib/app/core/auth/auth_user.dart
@@ -4,12 +4,14 @@ class AuthUser {
     required this.name,
     required this.email,
     required this.role,
+    this.photoUrl,
   });
 
   final int id;
   final String name;
   final String email;
   final String role;
+  final String? photoUrl;
 
   factory AuthUser.fromJson(Map<String, dynamic> json) {
     return AuthUser(
@@ -17,6 +19,7 @@ class AuthUser {
       name: json['name'] as String,
       email: json['email'] as String,
       role: json['role'] as String? ?? 'member',
+      photoUrl: json['photoUrl'] as String?,
     );
   }
 }

--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -27,6 +27,11 @@ class AppShell extends StatefulWidget {
 class _AppShellState extends State<AppShell> with WindowListener {
   int _selectedIndex = 0;
 
+  void _onItemSelected(int index) {
+    if (_selectedIndex == index) return;
+    setState(() => _selectedIndex = index);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -50,6 +55,22 @@ class _AppShellState extends State<AppShell> with WindowListener {
   @override
   Widget build(BuildContext context) {
     final serverStatus = context.watch<ApiServerController>().status;
+    final authStatus = context.watch<AuthSessionService>().status;
+    final messagesController = context.read<MessagesController>();
+    final shouldPollMessages = serverStatus == ServerStatus.ready &&
+        authStatus == AuthStatus.authenticated &&
+        _selectedIndex == 5;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      messagesController.setScreenActive(shouldPollMessages);
+      if (authStatus == AuthStatus.unauthenticated) {
+        messagesController.reset();
+        if (_selectedIndex != 0) {
+          setState(() => _selectedIndex = 0);
+        }
+      }
+    });
 
     return switch (serverStatus) {
       ServerStatus.starting => const _ServerLoadingView(),
@@ -59,7 +80,7 @@ class _AppShellState extends State<AppShell> with WindowListener {
       ServerStatus.ready => _AuthGate(
           child: _AppContent(
             selectedIndex: _selectedIndex,
-            onItemSelected: (i) => setState(() => _selectedIndex = i),
+            onItemSelected: _onItemSelected,
           ),
         ),
     };

--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -50,6 +50,17 @@ class _AppShellState extends State<AppShell> with WindowListener {
   @override
   Widget build(BuildContext context) {
     final serverStatus = context.watch<ApiServerController>().status;
+    final authStatus = context.watch<AuthSessionService>().status;
+    final messagesController = context.read<MessagesController>();
+    final enableMessagePolling = serverStatus == ServerStatus.ready &&
+        authStatus == AuthStatus.authenticated;
+    final isMessagesScreenActive = enableMessagePolling && _selectedIndex == 5;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      messagesController.setPollingEnabled(enableMessagePolling);
+      messagesController.setScreenActive(isMessagesScreenActive);
+    });
 
     return switch (serverStatus) {
       ServerStatus.starting => const _ServerLoadingView(),

--- a/apps/desktop_flutter/lib/app/core/layout/navigation_sidebar.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/navigation_sidebar.dart
@@ -34,7 +34,7 @@ class NavigationSidebar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final unreadCount = context.watch<MessagesController>().unreadThreadCount;
+    final unreadCount = context.watch<MessagesController>().totalUnreadCount;
     return Container(
       width: 240,
       decoration: const BoxDecoration(
@@ -291,12 +291,49 @@ class _UserPanel extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            user.name,
-            style: const TextStyle(
-              color: Color(0xFF111827),
-              fontWeight: FontWeight.w600,
-            ),
+          Row(
+            children: [
+              CircleAvatar(
+                radius: 18,
+                backgroundColor: const Color(0x144F6AF5),
+                backgroundImage:
+                    user.photoUrl != null ? NetworkImage(user.photoUrl!) : null,
+                child: user.photoUrl == null
+                    ? Text(
+                        _initialsFor(user.name),
+                        style: const TextStyle(
+                          color: Color(0xFF4F6AF5),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      )
+                    : null,
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Signed In',
+                      style: TextStyle(
+                        color: Color(0xFF6B7280),
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      user.name,
+                      style: const TextStyle(
+                        color: Color(0xFF111827),
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ),
           const SizedBox(height: 4),
           Text(
@@ -306,12 +343,52 @@ class _UserPanel extends StatelessWidget {
           const SizedBox(height: 10),
           _SidebarButton(
             label: 'Sign out',
-            onTap: authSessionService.logout,
+            onTap: () => _confirmSignOut(context, authSessionService),
             outlined: true,
           ),
         ],
       ),
     );
+  }
+}
+
+String _initialsFor(String name) {
+  final parts = name
+      .trim()
+      .split(RegExp(r'\s+'))
+      .where((part) => part.isNotEmpty)
+      .take(2)
+      .toList();
+  if (parts.isEmpty) return '?';
+  return parts.map((part) => part[0].toUpperCase()).join();
+}
+
+Future<void> _confirmSignOut(
+  BuildContext context,
+  AuthSessionService authSessionService,
+) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Sign Out?'),
+      content: const Text(
+        'This will clear the current session and return to the login screen.',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Sign out'),
+        ),
+      ],
+    ),
+  );
+
+  if (confirmed == true) {
+    await authSessionService.logout();
   }
 }
 

--- a/apps/desktop_flutter/lib/features/facilities/controllers/facilities_controller.dart
+++ b/apps/desktop_flutter/lib/features/facilities/controllers/facilities_controller.dart
@@ -22,6 +22,27 @@ class FacilitiesController extends ChangeNotifier {
   FacilitiesStatus get status => _status;
   String? get errorMessage => _errorMessage;
 
+  Future<Facility> createFacility({
+    required String name,
+    String? description,
+    String? location,
+  }) async {
+    final facility = await _repository.createFacility({
+      'name': name,
+      if (description != null && description.isNotEmpty)
+        'description': description,
+      if (location != null && location.isNotEmpty) 'location': location,
+    });
+    _facilities = [..._facilities, facility]
+      ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    _reservationsByFacility = {
+      ..._reservationsByFacility,
+      facility.id: _reservationsByFacility[facility.id] ?? const [],
+    };
+    notifyListeners();
+    return facility;
+  }
+
   Future<void> loadFacilities() async {
     _status = FacilitiesStatus.loading;
     _errorMessage = null;
@@ -57,9 +78,9 @@ class FacilitiesController extends ChangeNotifier {
   }) async {
     final body = <String, dynamic>{
       'title': title,
-      'reservedBy': reservedBy,
-      if (startTime != null && startTime.isNotEmpty) 'startTime': startTime,
-      if (endTime != null && endTime.isNotEmpty) 'endTime': endTime,
+      'reserved_by': reservedBy,
+      if (startTime != null && startTime.isNotEmpty) 'start_time': startTime,
+      if (endTime != null && endTime.isNotEmpty) 'end_time': endTime,
       if (notes != null && notes.isNotEmpty) 'notes': notes,
     };
 
@@ -69,6 +90,60 @@ class FacilitiesController extends ChangeNotifier {
     final updated =
         List<Reservation>.from(_reservationsByFacility[facilityId] ?? [])
           ..add(reservation);
+    _reservationsByFacility = {
+      ..._reservationsByFacility,
+      facilityId: updated
+        ..sort((a, b) => (a.startTime ?? '').compareTo(b.startTime ?? '')),
+    };
+    notifyListeners();
+  }
+
+  Future<void> updateReservation(
+    int facilityId,
+    int reservationId, {
+    required String title,
+    required String reservedBy,
+    String? startTime,
+    String? endTime,
+    String? notes,
+  }) async {
+    final body = <String, dynamic>{
+      'title': title,
+      'reserved_by': reservedBy,
+      if (startTime != null && startTime.isNotEmpty) 'start_time': startTime,
+      if (endTime != null && endTime.isNotEmpty) 'end_time': endTime,
+      'notes': (notes != null && notes.isNotEmpty) ? notes : null,
+    };
+
+    final reservation = await _repository.updateReservation(
+      facilityId,
+      reservationId,
+      body,
+    );
+
+    final updated = List<Reservation>.from(
+      _reservationsByFacility[facilityId] ?? [],
+    );
+    final index = updated.indexWhere((item) => item.id == reservationId);
+    if (index >= 0) {
+      updated[index] = reservation;
+    } else {
+      updated.add(reservation);
+    }
+    updated.sort((a, b) => (a.startTime ?? '').compareTo(b.startTime ?? ''));
+    _reservationsByFacility = {
+      ..._reservationsByFacility,
+      facilityId: updated,
+    };
+    notifyListeners();
+  }
+
+  Future<void> deleteReservation(int facilityId, int reservationId) async {
+    await _repository.deleteReservation(facilityId, reservationId);
+
+    final updated = List<Reservation>.from(
+      _reservationsByFacility[facilityId] ?? [],
+    )..removeWhere((item) => item.id == reservationId);
     _reservationsByFacility = {
       ..._reservationsByFacility,
       facilityId: updated,

--- a/apps/desktop_flutter/lib/features/facilities/data/facilities_data_source.dart
+++ b/apps/desktop_flutter/lib/features/facilities/data/facilities_data_source.dart
@@ -26,6 +26,16 @@ class FacilitiesDataSource {
         .toList();
   }
 
+  Future<Facility> createFacility(Map<String, dynamic> body) async {
+    final response = await http.post(
+      Uri.parse('$_baseUrl/facilities'),
+      headers: AuthSessionStore.headers(json: true),
+      body: jsonEncode(body),
+    );
+    _assertOk(response);
+    return Facility.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
   Future<List<Reservation>> getReservations(int facilityId) async {
     final response = await http.get(
       Uri.parse('$_baseUrl/facilities/$facilityId/reservations'),
@@ -48,6 +58,29 @@ class FacilitiesDataSource {
     _assertOk(response);
     return Reservation.fromJson(
         jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  Future<Reservation> updateReservation(
+    int facilityId,
+    int reservationId,
+    Map<String, dynamic> body,
+  ) async {
+    final response = await http.patch(
+      Uri.parse('$_baseUrl/facilities/$facilityId/reservations/$reservationId'),
+      headers: AuthSessionStore.headers(json: true),
+      body: jsonEncode(body),
+    );
+    _assertOk(response);
+    return Reservation.fromJson(
+        jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  Future<void> deleteReservation(int facilityId, int reservationId) async {
+    final response = await http.delete(
+      Uri.parse('$_baseUrl/facilities/$facilityId/reservations/$reservationId'),
+      headers: AuthSessionStore.headers(),
+    );
+    _assertOk(response);
   }
 
   void _assertOk(http.Response response) {

--- a/apps/desktop_flutter/lib/features/facilities/repositories/facilities_repository.dart
+++ b/apps/desktop_flutter/lib/features/facilities/repositories/facilities_repository.dart
@@ -9,10 +9,23 @@ class FacilitiesRepository {
 
   Future<List<Facility>> getFacilities() => _dataSource.getFacilities();
 
+  Future<Facility> createFacility(Map<String, dynamic> body) =>
+      _dataSource.createFacility(body);
+
   Future<List<Reservation>> getReservations(int facilityId) =>
       _dataSource.getReservations(facilityId);
 
   Future<Reservation> createReservation(
           int facilityId, Map<String, dynamic> body) =>
       _dataSource.createReservation(facilityId, body);
+
+  Future<Reservation> updateReservation(
+    int facilityId,
+    int reservationId,
+    Map<String, dynamic> body,
+  ) =>
+      _dataSource.updateReservation(facilityId, reservationId, body);
+
+  Future<void> deleteReservation(int facilityId, int reservationId) =>
+      _dataSource.deleteReservation(facilityId, reservationId);
 }

--- a/apps/desktop_flutter/lib/features/facilities/views/facilities_view.dart
+++ b/apps/desktop_flutter/lib/features/facilities/views/facilities_view.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../app/core/auth/auth_session_service.dart';
 import '../../../app/core/widgets/error_banner.dart';
 import '../controllers/facilities_controller.dart';
 import '../models/facility.dart';
+import '../models/reservation.dart';
 
 class FacilitiesView extends StatefulWidget {
   const FacilitiesView({super.key});
@@ -122,7 +124,7 @@ class _FacilitiesGrid extends StatelessWidget {
               controller.reservationsByFacility[facility.id] ?? [];
           return _FacilityCard(
             facility: facility,
-            reservationCount: reservations.length,
+            reservations: reservations,
             controller: controller,
           );
         },
@@ -138,12 +140,12 @@ class _FacilitiesGrid extends StatelessWidget {
 class _FacilityCard extends StatelessWidget {
   const _FacilityCard({
     required this.facility,
-    required this.reservationCount,
+    required this.reservations,
     required this.controller,
   });
 
   final Facility facility;
-  final int reservationCount;
+  final List<Reservation> reservations;
   final FacilitiesController controller;
 
   @override
@@ -152,6 +154,7 @@ class _FacilityCard extends StatelessWidget {
     const cardBorder = Color(0xFFE5E7EB);
     const textPrimary = Color(0xFF111827);
     const textMuted = Color(0xFF9CA3AF);
+    final upcomingReservations = reservations.where(_isUpcoming).take(1).toList();
 
     return Card(
       elevation: 0,
@@ -208,12 +211,37 @@ class _FacilityCard extends StatelessWidget {
               ),
             ],
 
+            const SizedBox(height: 14),
+            if (upcomingReservations.isEmpty)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFF9FAFB),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: const Text(
+                  'No upcoming reservations',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 12, color: textMuted),
+                ),
+              )
+            else
+              _UpcomingReservationRow(
+                reservation: upcomingReservations.first,
+              ),
+
             const Spacer(),
 
             // Reservation count badge + Reserve button
             Row(
               children: [
-                _ReservationBadge(count: reservationCount),
+                _ReservationBadge(
+                  count: reservations.length,
+                  onTap: reservations.isEmpty
+                      ? null
+                      : () => _showReservationsDialog(context),
+                ),
                 const Spacer(),
                 OutlinedButton(
                   onPressed: () => _showReserveDialog(context),
@@ -246,6 +274,22 @@ class _FacilityCard extends StatelessWidget {
       ),
     );
   }
+
+  Future<void> _showReservationsDialog(BuildContext context) async {
+    await showDialog<void>(
+      context: context,
+      builder: (_) => _ReservationListDialog(
+        facility: facility,
+        controller: controller,
+      ),
+    );
+  }
+
+  bool _isUpcoming(Reservation reservation) {
+    final start = _parseReservationDateTime(reservation.startTime);
+    if (start == null) return false;
+    return !start.isBefore(DateTime.now());
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -253,9 +297,10 @@ class _FacilityCard extends StatelessWidget {
 // ---------------------------------------------------------------------------
 
 class _ReservationBadge extends StatelessWidget {
-  const _ReservationBadge({required this.count});
+  const _ReservationBadge({required this.count, this.onTap});
 
   final int count;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -278,20 +323,194 @@ class _ReservationBadge extends StatelessWidget {
       );
     }
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-      decoration: BoxDecoration(
-        color: cs.primary.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Text(
-        '$count ${count == 1 ? 'reservation' : 'reservations'}',
-        style: TextStyle(
-          fontSize: 11,
-          fontWeight: FontWeight.w500,
-          color: cs.primary,
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+        decoration: BoxDecoration(
+          color: cs.primary.withValues(alpha: 0.1),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          '$count ${count == 1 ? 'reservation' : 'reservations'}',
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w500,
+            color: cs.primary,
+          ),
         ),
       ),
+    );
+  }
+}
+
+class _UpcomingReservationRow extends StatelessWidget {
+  const _UpcomingReservationRow({required this.reservation});
+
+  final Reservation reservation;
+
+  @override
+  Widget build(BuildContext context) {
+    final start = _parseReservationDateTime(reservation.startTime);
+    final end = _parseReservationDateTime(reservation.endTime);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF9FAFB),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: const Color(0xFFE5E7EB)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 4,
+            height: 30,
+            decoration: BoxDecoration(
+              color: const Color(0xFF4F6AF5),
+              borderRadius: BorderRadius.circular(999),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  reservation.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF111827),
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  start != null
+                      ? '${_formatDateShort(start)} · ${_formatTimeOnly(start)}${end != null ? ' - ${_formatTimeOnly(end)}' : ''}'
+                      : reservation.reservedBy,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style:
+                      const TextStyle(fontSize: 10, color: Color(0xFF6B7280)),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReservationListDialog extends StatelessWidget {
+  const _ReservationListDialog({
+    required this.facility,
+    required this.controller,
+  });
+
+  final Facility facility;
+  final FacilitiesController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<FacilitiesController>(
+      builder: (context, liveController, _) {
+        final sorted = [
+          ...(liveController.reservationsByFacility[facility.id] ?? const [])
+        ]..sort((a, b) => (a.startTime ?? '').compareTo(b.startTime ?? ''));
+        return AlertDialog(
+          title: Text('${facility.name} Reservations'),
+          content: SizedBox(
+            width: 620,
+            child: sorted.isEmpty
+                ? const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 24),
+                    child: Text('No reservations yet.'),
+                  )
+                : ListView.separated(
+                    shrinkWrap: true,
+                    itemCount: sorted.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final reservation = sorted[index];
+                      final start =
+                          _parseReservationDateTime(reservation.startTime);
+                      final end =
+                          _parseReservationDateTime(reservation.endTime);
+                      return ListTile(
+                        contentPadding: const EdgeInsets.symmetric(vertical: 6),
+                        title: Text(reservation.title),
+                        subtitle: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('Reserved by ${reservation.reservedBy}'),
+                            if (start != null)
+                              Text(
+                                '${_formatDateShort(start)} · ${_formatTimeOnly(start)}${end != null ? ' - ${_formatTimeOnly(end)}' : ''}',
+                              ),
+                            if ((reservation.notes ?? '').isNotEmpty)
+                              Text(reservation.notes!),
+                          ],
+                        ),
+                        trailing: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            TextButton(
+                              onPressed: () async {
+                                await showDialog<void>(
+                                  context: context,
+                                  builder: (_) => _ReservationDialog(
+                                    controller: liveController,
+                                    facilities: liveController.facilities,
+                                    preselectedFacility: facility,
+                                    initialReservation: reservation,
+                                  ),
+                                );
+                              },
+                              child: const Text('Edit'),
+                            ),
+                            TextButton(
+                              onPressed: () async {
+                                final confirmed =
+                                    await _confirmDeleteReservation(
+                                  context,
+                                  reservation.title,
+                                );
+                                if (confirmed != true) return;
+                                await liveController.deleteReservation(
+                                  facility.id,
+                                  reservation.id,
+                                );
+                                if (context.mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text('Reservation deleted'),
+                                    ),
+                                  );
+                                }
+                              },
+                              child: const Text('Delete'),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Close'),
+            ),
+          ],
+        );
+      },
     );
   }
 }
@@ -305,96 +524,148 @@ class _ReservationDialog extends StatefulWidget {
     required this.controller,
     required this.facilities,
     this.preselectedFacility,
+    this.initialReservation,
   });
 
   final FacilitiesController controller;
   final List<Facility> facilities;
   final Facility? preselectedFacility;
+  final Reservation? initialReservation;
 
   @override
   State<_ReservationDialog> createState() => _ReservationDialogState();
 }
 
 class _ReservationDialogState extends State<_ReservationDialog> {
+  static const _addRoomValue = '__add_room__';
   final _formKey = GlobalKey<FormState>();
   final _titleController = TextEditingController();
   final _reservedByController = TextEditingController();
-  final _startTimeController = TextEditingController();
-  final _endTimeController = TextEditingController();
+  final _newRoomController = TextEditingController();
   final _notesController = TextEditingController();
 
   Facility? _selectedFacility;
+  DateTime? _startDate;
+  TimeOfDay? _startClock;
+  DateTime? _endDate;
+  TimeOfDay? _endClock;
   bool _saving = false;
+  bool _addingRoom = false;
 
   @override
   void initState() {
     super.initState();
+    final currentUser = AuthSessionService.instance.currentUser;
+    _reservedByController.text =
+        widget.initialReservation?.reservedBy ?? currentUser?.name ?? '';
+    _titleController.text = widget.initialReservation?.title ?? '';
+    _notesController.text = widget.initialReservation?.notes ?? '';
     _selectedFacility = widget.preselectedFacility ??
         (widget.facilities.isNotEmpty ? widget.facilities.first : null);
+    _startDate =
+        _parseReservationDateTime(widget.initialReservation?.startTime);
+    _endDate = _parseReservationDateTime(widget.initialReservation?.endTime);
+    _startClock = _startDate == null
+        ? null
+        : TimeOfDay(hour: _startDate!.hour, minute: _startDate!.minute);
+    _endClock = _endDate == null
+        ? null
+        : TimeOfDay(hour: _endDate!.hour, minute: _endDate!.minute);
   }
 
   @override
   void dispose() {
     _titleController.dispose();
     _reservedByController.dispose();
-    _startTimeController.dispose();
-    _endTimeController.dispose();
+    _newRoomController.dispose();
     _notesController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    final isTopLevel = widget.preselectedFacility == null;
-
     return AlertDialog(
-      title: const Text('Reserve Space'),
+      title: Text(
+        widget.initialReservation == null
+            ? 'Reserve Space'
+            : 'Edit Reservation',
+      ),
       content: SizedBox(
-        width: 440,
+        width: 520,
         child: Form(
           key: _formKey,
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // Facility selector (top-level button only)
-              if (isTopLevel && widget.facilities.isNotEmpty) ...[
-                DropdownButtonFormField<Facility>(
-                  value: _selectedFacility,
+              DropdownButtonFormField<String>(
+                value: _addingRoom
+                    ? _addRoomValue
+                    : _selectedFacility != null
+                        ? '${_selectedFacility!.id}'
+                        : null,
+                decoration: const InputDecoration(
+                  labelText: 'Facility Room *',
+                  border: OutlineInputBorder(),
+                ),
+                items: [
+                  ...widget.facilities.map(
+                    (f) => DropdownMenuItem<String>(
+                      value: '${f.id}',
+                      child: Text(f.name),
+                    ),
+                  ),
+                  const DropdownMenuItem<String>(
+                    value: _addRoomValue,
+                    child: Text('Add a Room'),
+                  ),
+                ],
+                onChanged: (value) {
+                  setState(() {
+                    _addingRoom = value == _addRoomValue;
+                    if (_addingRoom) {
+                      _selectedFacility = null;
+                    } else {
+                      _selectedFacility = widget.facilities.firstWhere(
+                        (facility) => '${facility.id}' == value,
+                      );
+                    }
+                  });
+                },
+                validator: (value) {
+                  if (_addingRoom) {
+                    return null;
+                  }
+                  return value == null ? 'Please select a room' : null;
+                },
+              ),
+              if (_addingRoom) ...[
+                const SizedBox(height: 16),
+                TextFormField(
+                  controller: _newRoomController,
                   decoration: const InputDecoration(
-                    labelText: 'Facility',
+                    labelText: 'New Room Name *',
                     border: OutlineInputBorder(),
                   ),
-                  items: widget.facilities
-                      .map(
-                        (f) => DropdownMenuItem(
-                          value: f,
-                          child: Text(f.name),
-                        ),
-                      )
-                      .toList(),
-                  onChanged: (v) => setState(() => _selectedFacility = v),
-                  validator: (v) =>
-                      v == null ? 'Please select a facility' : null,
+                  validator: (value) =>
+                      _addingRoom && (value == null || value.trim().isEmpty)
+                          ? 'Room name is required'
+                          : null,
                 ),
-                const SizedBox(height: 16),
               ],
-
-              // Title
+              const SizedBox(height: 16),
               TextFormField(
                 controller: _titleController,
-                autofocus: !isTopLevel,
+                autofocus: widget.preselectedFacility != null,
                 decoration: const InputDecoration(
-                  labelText: 'Title *',
+                  labelText: 'Event *',
                   border: OutlineInputBorder(),
                 ),
                 validator: (v) => (v == null || v.trim().isEmpty)
-                    ? 'Title is required'
+                    ? 'Event is required'
                     : null,
               ),
               const SizedBox(height: 16),
-
-              // Reserved By
               TextFormField(
                 controller: _reservedByController,
                 decoration: const InputDecoration(
@@ -406,36 +677,70 @@ class _ReservationDialogState extends State<_ReservationDialog> {
                     : null,
               ),
               const SizedBox(height: 16),
-
-              // Start / End time row
-              Row(
-                children: [
-                  Expanded(
-                    child: TextFormField(
-                      controller: _startTimeController,
-                      decoration: const InputDecoration(
-                        labelText: 'Start Time',
-                        hintText: 'e.g. 2026-04-01 09:00',
-                        border: OutlineInputBorder(),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: TextFormField(
-                      controller: _endTimeController,
-                      decoration: const InputDecoration(
-                        labelText: 'End Time',
-                        hintText: 'e.g. 2026-04-01 11:00',
-                        border: OutlineInputBorder(),
-                      ),
-                    ),
-                  ),
-                ],
+              _DateTimePickerRow(
+                label: 'Start Time *',
+                dateLabel:
+                    _startDate == null ? 'Pick date' : _formatDate(_startDate!),
+                timeLabel: _startClock == null
+                    ? 'Pick time'
+                    : _formatTime(_startClock!),
+                onPickDate: () async {
+                  final picked = await showDatePicker(
+                    context: context,
+                    initialDate: _startDate ?? DateTime.now(),
+                    firstDate: DateTime(2024),
+                    lastDate: DateTime(2035),
+                  );
+                  if (picked != null) {
+                    setState(() => _startDate = picked);
+                  }
+                },
+                onPickTime: () async {
+                  final picked = await showTimePicker(
+                    context: context,
+                    initialTime: _startClock ?? TimeOfDay.now(),
+                  );
+                  if (picked != null) {
+                    setState(() => _startClock = picked);
+                  }
+                },
               ),
               const SizedBox(height: 16),
-
-              // Notes
+              _DateTimePickerRow(
+                label: 'End Time *',
+                dateLabel:
+                    _endDate == null ? 'Pick date' : _formatDate(_endDate!),
+                timeLabel:
+                    _endClock == null ? 'Pick time' : _formatTime(_endClock!),
+                onPickDate: () async {
+                  final picked = await showDatePicker(
+                    context: context,
+                    initialDate: _endDate ?? _startDate ?? DateTime.now(),
+                    firstDate: DateTime(2024),
+                    lastDate: DateTime(2035),
+                  );
+                  if (picked != null) {
+                    setState(() => _endDate = picked);
+                  }
+                },
+                onPickTime: () async {
+                  final picked = await showTimePicker(
+                    context: context,
+                    initialTime: _endClock ?? _startClock ?? TimeOfDay.now(),
+                  );
+                  if (picked != null) {
+                    setState(() => _endClock = picked);
+                  }
+                },
+              ),
+              if (_dateTimeValidationMessage != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  _dateTimeValidationMessage!,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+              ],
+              const SizedBox(height: 16),
               TextFormField(
                 controller: _notesController,
                 decoration: const InputDecoration(
@@ -453,6 +758,46 @@ class _ReservationDialogState extends State<_ReservationDialog> {
           onPressed: _saving ? null : () => Navigator.pop(context),
           child: const Text('Cancel'),
         ),
+        if (widget.initialReservation != null)
+          TextButton(
+            onPressed: _saving
+                ? null
+                : () async {
+                    final navigator = Navigator.of(context);
+                    final messenger = ScaffoldMessenger.of(context);
+                    final confirmed = await _confirmDeleteReservation(
+                      context,
+                      widget.initialReservation!.title,
+                    );
+                    if (confirmed != true) return;
+                    setState(() => _saving = true);
+                    try {
+                      await widget.controller.deleteReservation(
+                        _selectedFacility!.id,
+                        widget.initialReservation!.id,
+                      );
+                      if (mounted) {
+                        navigator.pop();
+                        messenger.showSnackBar(
+                          const SnackBar(
+                            content: Text('Reservation deleted'),
+                          ),
+                        );
+                      }
+                    } catch (e) {
+                      if (mounted) {
+                        setState(() => _saving = false);
+                        messenger.showSnackBar(
+                          SnackBar(content: Text('Error: $e')),
+                        );
+                      }
+                    }
+                  },
+            style: TextButton.styleFrom(
+              foregroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('Delete'),
+          ),
         FilledButton(
           onPressed: _saving ? null : _submit,
           child: _saving
@@ -469,22 +814,53 @@ class _ReservationDialogState extends State<_ReservationDialog> {
 
   Future<void> _submit() async {
     if (!(_formKey.currentState?.validate() ?? false)) return;
-    if (_selectedFacility == null) return;
+    if (_dateTimeValidationMessage != null) {
+      setState(() {});
+      return;
+    }
 
     setState(() => _saving = true);
     try {
-      await widget.controller.createReservation(
-        _selectedFacility!.id,
-        title: _titleController.text.trim(),
-        reservedBy: _reservedByController.text.trim(),
-        startTime: _startTimeController.text.trim(),
-        endTime: _endTimeController.text.trim(),
-        notes: _notesController.text.trim(),
-      );
+      var facility = _selectedFacility;
+      if (_addingRoom) {
+        facility = await widget.controller.createFacility(
+          name: _newRoomController.text.trim(),
+        );
+      }
+      if (facility == null) {
+        throw Exception('Please choose a room.');
+      }
+
+      if (widget.initialReservation == null) {
+        await widget.controller.createReservation(
+          facility.id,
+          title: _titleController.text.trim(),
+          reservedBy: _reservedByController.text.trim(),
+          startTime: _composeTimestamp(_startDate!, _startClock!),
+          endTime: _composeTimestamp(_endDate!, _endClock!),
+          notes: _notesController.text.trim(),
+        );
+      } else {
+        await widget.controller.updateReservation(
+          facility.id,
+          widget.initialReservation!.id,
+          title: _titleController.text.trim(),
+          reservedBy: _reservedByController.text.trim(),
+          startTime: _composeTimestamp(_startDate!, _startClock!),
+          endTime: _composeTimestamp(_endDate!, _endClock!),
+          notes: _notesController.text.trim(),
+        );
+      }
       if (mounted) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Reservation created')),
+          SnackBar(
+            content: Text(
+              widget.initialReservation == null
+                  ? 'Reservation created'
+                  : 'Reservation updated',
+            ),
+          ),
         );
       }
     } catch (e) {
@@ -495,5 +871,198 @@ class _ReservationDialogState extends State<_ReservationDialog> {
         );
       }
     }
+  }
+
+  String? get _dateTimeValidationMessage {
+    if (_startDate == null || _startClock == null) {
+      return 'Start date and time are required.';
+    }
+    if (_endDate == null || _endClock == null) {
+      return 'End date and time are required.';
+    }
+
+    final start = DateTime(
+      _startDate!.year,
+      _startDate!.month,
+      _startDate!.day,
+      _startClock!.hour,
+      _startClock!.minute,
+    );
+    final end = DateTime(
+      _endDate!.year,
+      _endDate!.month,
+      _endDate!.day,
+      _endClock!.hour,
+      _endClock!.minute,
+    );
+    if (!end.isAfter(start)) {
+      return 'End time must be after start time.';
+    }
+
+    final facilityId = _selectedFacility?.id;
+    if (!_addingRoom && facilityId != null) {
+      final reservations =
+          widget.controller.reservationsByFacility[facilityId] ?? const [];
+      for (final reservation in reservations) {
+        if (widget.initialReservation?.id == reservation.id) continue;
+        final reservationStart = _parseReservationDateTime(reservation.startTime);
+        final reservationEnd = _parseReservationDateTime(reservation.endTime);
+        if (reservationStart == null || reservationEnd == null) continue;
+        final overlaps =
+            start.isBefore(reservationEnd) && end.isAfter(reservationStart);
+        if (overlaps) {
+          return 'Conflicts with "${reservation.title}". Choose a different room or time.';
+        }
+      }
+    }
+
+    return null;
+  }
+
+  String _composeTimestamp(DateTime date, TimeOfDay time) {
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    final hour = time.hour.toString().padLeft(2, '0');
+    final minute = time.minute.toString().padLeft(2, '0');
+    return '${date.year}-$month-$day $hour:$minute';
+  }
+
+  static String _formatDate(DateTime date) {
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return '${date.year}-$month-$day';
+  }
+
+  static String _formatTime(TimeOfDay time) {
+    final hour = time.hourOfPeriod == 0 ? 12 : time.hourOfPeriod;
+    final minute = time.minute.toString().padLeft(2, '0');
+    final period = time.period == DayPeriod.am ? 'AM' : 'PM';
+    return '$hour:$minute $period';
+  }
+}
+
+DateTime? _parseReservationDateTime(String? raw) {
+  if (raw == null || raw.isEmpty) return null;
+  final normalized = raw.contains('T') ? raw : raw.replaceFirst(' ', 'T');
+  return DateTime.tryParse(normalized);
+}
+
+String _formatDateShort(DateTime date) {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${months[date.month - 1]} ${date.day}';
+}
+
+String _formatTimeOnly(DateTime date) {
+  final hour = date.hour > 12
+      ? date.hour - 12
+      : date.hour == 0
+          ? 12
+          : date.hour;
+  final minute = date.minute.toString().padLeft(2, '0');
+  final period = date.hour >= 12 ? 'PM' : 'AM';
+  return '$hour:$minute $period';
+}
+
+Future<bool?> _confirmDeleteReservation(
+  BuildContext context,
+  String title,
+) {
+  return showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Delete Reservation?'),
+      content: Text('Delete "$title"? This cannot be undone.'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('Delete'),
+        ),
+      ],
+    ),
+  );
+}
+
+class _DateTimePickerRow extends StatelessWidget {
+  const _DateTimePickerRow({
+    required this.label,
+    required this.dateLabel,
+    required this.timeLabel,
+    required this.onPickDate,
+    required this.onPickTime,
+  });
+
+  final String label;
+  final String dateLabel;
+  final String timeLabel;
+  final VoidCallback onPickDate;
+  final VoidCallback onPickTime;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: const Color(0xFF374151),
+                fontWeight: FontWeight.w500,
+              ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: onPickDate,
+                icon: const Icon(Icons.calendar_month_outlined, size: 18),
+                label: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(dateLabel),
+                ),
+                style: OutlinedButton.styleFrom(
+                  alignment: Alignment.centerLeft,
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: onPickTime,
+                icon: const Icon(Icons.schedule_outlined, size: 18),
+                label: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(timeLabel),
+                ),
+                style: OutlinedButton.styleFrom(
+                  alignment: Alignment.centerLeft,
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
   }
 }

--- a/apps/desktop_flutter/lib/features/facilities/views/facilities_view.dart
+++ b/apps/desktop_flutter/lib/features/facilities/views/facilities_view.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../../../app/core/widgets/error_banner.dart';
 import '../controllers/facilities_controller.dart';
 import '../models/facility.dart';
+import '../models/reservation.dart';
 
 class FacilitiesView extends StatefulWidget {
   const FacilitiesView({super.key});
@@ -54,6 +55,41 @@ class _FacilitiesViewState extends State<FacilitiesView> {
       ),
     );
   }
+}
+
+DateTime? _parseReservationDateTime(String? raw) {
+  if (raw == null || raw.isEmpty) return null;
+  final normalized = raw.contains('T') ? raw : raw.replaceFirst(' ', 'T');
+  return DateTime.tryParse(normalized);
+}
+
+String _formatDateShort(DateTime date) {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${months[date.month - 1]} ${date.day}';
+}
+
+String _formatTimeOnly(DateTime date) {
+  final hour = date.hour > 12
+      ? date.hour - 12
+      : date.hour == 0
+          ? 12
+          : date.hour;
+  final minute = date.minute.toString().padLeft(2, '0');
+  final period = date.hour >= 12 ? 'PM' : 'AM';
+  return '$hour:$minute $period';
 }
 
 // ---------------------------------------------------------------------------
@@ -122,7 +158,7 @@ class _FacilitiesGrid extends StatelessWidget {
               controller.reservationsByFacility[facility.id] ?? [];
           return _FacilityCard(
             facility: facility,
-            reservationCount: reservations.length,
+            reservations: reservations,
             controller: controller,
           );
         },
@@ -138,12 +174,12 @@ class _FacilitiesGrid extends StatelessWidget {
 class _FacilityCard extends StatelessWidget {
   const _FacilityCard({
     required this.facility,
-    required this.reservationCount,
+    required this.reservations,
     required this.controller,
   });
 
   final Facility facility;
-  final int reservationCount;
+  final List<Reservation> reservations;
   final FacilitiesController controller;
 
   @override
@@ -152,6 +188,7 @@ class _FacilityCard extends StatelessWidget {
     const cardBorder = Color(0xFFE5E7EB);
     const textPrimary = Color(0xFF111827);
     const textMuted = Color(0xFF9CA3AF);
+    final previewReservation = _currentOrUpcomingReservation();
 
     return Card(
       elevation: 0,
@@ -208,12 +245,30 @@ class _FacilityCard extends StatelessWidget {
               ),
             ],
 
+            const SizedBox(height: 14),
+            if (previewReservation == null)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFF9FAFB),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: const Text(
+                  'No upcoming reservations',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(fontSize: 12, color: textMuted),
+                ),
+              )
+            else
+              _ReservationPreviewCard(reservation: previewReservation),
+
             const Spacer(),
 
             // Reservation count badge + Reserve button
             Row(
               children: [
-                _ReservationBadge(count: reservationCount),
+                _ReservationBadge(count: reservations.length),
                 const Spacer(),
                 OutlinedButton(
                   onPressed: () => _showReserveDialog(context),
@@ -234,6 +289,24 @@ class _FacilityCard extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Reservation? _currentOrUpcomingReservation() {
+    final candidates = reservations.where((reservation) {
+      final end = _parseReservationDateTime(reservation.endTime);
+      if (end == null) return false;
+      return !end.isBefore(DateTime.now());
+    }).toList()
+      ..sort((a, b) {
+        final aStart = _parseReservationDateTime(a.startTime);
+        final bStart = _parseReservationDateTime(b.startTime);
+        if (aStart == null && bStart == null) return 0;
+        if (aStart == null) return 1;
+        if (bStart == null) return -1;
+        return aStart.compareTo(bStart);
+      });
+
+    return candidates.isEmpty ? null : candidates.first;
   }
 
   Future<void> _showReserveDialog(BuildContext context) async {
@@ -291,6 +364,58 @@ class _ReservationBadge extends StatelessWidget {
           fontWeight: FontWeight.w500,
           color: cs.primary,
         ),
+      ),
+    );
+  }
+}
+
+class _ReservationPreviewCard extends StatelessWidget {
+  const _ReservationPreviewCard({required this.reservation});
+
+  final Reservation reservation;
+
+  @override
+  Widget build(BuildContext context) {
+    final start = _parseReservationDateTime(reservation.startTime);
+    final end = _parseReservationDateTime(reservation.endTime);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF9FAFB),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: const Color(0xFFE5E7EB)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            reservation.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: Color(0xFF111827),
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            reservation.reservedBy,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(fontSize: 11, color: Color(0xFF6B7280)),
+          ),
+          if (start != null) ...[
+            const SizedBox(height: 2),
+            Text(
+              '${_formatDateShort(start)} · ${_formatTimeOnly(start)}${end != null ? ' - ${_formatTimeOnly(end)}' : ''}',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 11, color: Color(0xFF6B7280)),
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/apps/desktop_flutter/lib/features/integrations/models/integration_account.dart
+++ b/apps/desktop_flutter/lib/features/integrations/models/integration_account.dart
@@ -6,8 +6,12 @@ class IntegrationAccount {
     required this.connected,
     this.email,
     this.displayName,
+    this.providerDisplayName,
+    this.accountLabel,
     this.lastSyncedAt,
     this.errorMessage,
+    this.availableTriggerFamilies = const [],
+    this.syncSupportMode,
   });
 
   factory IntegrationAccount.fromJson(Map<String, dynamic> json) {
@@ -19,8 +23,15 @@ class IntegrationAccount {
       connected: status == 'connected',
       email: json['email'] as String?,
       displayName: json['displayName'] as String?,
+      providerDisplayName: json['providerDisplayName'] as String?,
+      accountLabel: json['accountLabel'] as String?,
       lastSyncedAt: json['lastSyncedAt'] as String?,
       errorMessage: json['errorMessage'] as String?,
+      availableTriggerFamilies:
+          (json['availableTriggerFamilies'] as List<dynamic>? ?? const [])
+              .map((item) => item.toString())
+              .toList(),
+      syncSupportMode: json['syncSupportMode'] as String?,
     );
   }
 
@@ -30,6 +41,10 @@ class IntegrationAccount {
   final bool connected;
   final String? email;
   final String? displayName;
+  final String? providerDisplayName;
+  final String? accountLabel;
   final String? lastSyncedAt;
   final String? errorMessage;
+  final List<String> availableTriggerFamilies;
+  final String? syncSupportMode;
 }

--- a/apps/desktop_flutter/lib/features/messages/controllers/messages_controller.dart
+++ b/apps/desktop_flutter/lib/features/messages/controllers/messages_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../../../app/core/auth/auth_session_service.dart';
 import '../../../app/core/auth/auth_user.dart';
 import '../models/message.dart';
 import '../models/message_thread.dart';
@@ -9,10 +10,25 @@ import '../repositories/messages_repository.dart';
 
 enum MessagesStatus { idle, loading, error }
 
+class IncomingMessageNotice {
+  const IncomingMessageNotice({
+    required this.threadId,
+    required this.senderName,
+    required this.preview,
+  });
+
+  final int threadId;
+  final String senderName;
+  final String preview;
+}
+
 class MessagesController extends ChangeNotifier {
-  MessagesController(this._repository);
+  MessagesController(this._repository,
+      {Duration pollInterval = const Duration(seconds: 30)})
+      : _pollInterval = pollInterval;
 
   final MessagesRepository _repository;
+  final Duration _pollInterval;
 
   List<MessageThread> _threads = [];
   List<AuthUser> _users = [];
@@ -21,6 +37,9 @@ class MessagesController extends ChangeNotifier {
   MessagesStatus _status = MessagesStatus.idle;
   String? _errorMessage;
   Timer? _pollTimer;
+  bool _screenActive = false;
+  IncomingMessageNotice? _incomingNotice;
+  int _incomingNoticeVersion = 0;
 
   List<MessageThread> get threads => _threads;
   List<AuthUser> get users => _users;
@@ -28,7 +47,11 @@ class MessagesController extends ChangeNotifier {
   List<Message> get messages => _messages;
   MessagesStatus get status => _status;
   String? get errorMessage => _errorMessage;
-  int get unreadThreadCount => _threads.where((t) => t.isUnread).length;
+  int get totalUnreadCount =>
+      _threads.fold(0, (sum, thread) => sum + thread.unreadCount);
+  bool get isScreenActive => _screenActive;
+  IncomingMessageNotice? get incomingNotice => _incomingNotice;
+  int get incomingNoticeVersion => _incomingNoticeVersion;
 
   MessageThread? get selectedThread {
     if (_selectedThreadId == null) return null;
@@ -47,7 +70,9 @@ class MessagesController extends ChangeNotifier {
     }
 
     try {
+      final previousThreads = List<MessageThread>.from(_threads);
       _threads = await _repository.getThreads();
+      _maybeNotifyForUnreadThreadActivity(previousThreads, _threads);
       _status = MessagesStatus.idle;
     } catch (e) {
       _errorMessage = e.toString();
@@ -58,7 +83,11 @@ class MessagesController extends ChangeNotifier {
 
   Future<void> loadUsers() async {
     try {
-      _users = await _repository.getUsers();
+      final currentUserId = AuthSessionService.instance.currentUser?.id;
+      final users = await _repository.getUsers();
+      _users = currentUserId == null
+          ? users
+          : users.where((user) => user.id != currentUserId).toList();
       notifyListeners();
     } catch (e) {
       _errorMessage = e.toString();
@@ -68,13 +97,14 @@ class MessagesController extends ChangeNotifier {
   }
 
   Future<void> selectThread(int id) async {
+    _markThreadReadLocally(id);
     _selectedThreadId = id;
     _messages = [];
     notifyListeners();
 
     try {
-      _messages = await _repository.getMessages(id);
       await _repository.markRead(id);
+      _messages = await _repository.getMessages(id);
       await loadThreads(silent: true);
       _status = MessagesStatus.idle;
     } catch (e) {
@@ -84,12 +114,9 @@ class MessagesController extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> createThread(List<int> participantIds, {String? title}) async {
+  Future<void> createThread(List<int> participantIds) async {
     try {
-      final thread = await _repository.createThread(
-        participantIds,
-        title: title,
-      );
+      final thread = await _repository.createThread(participantIds);
       await loadThreads(silent: true);
       _status = MessagesStatus.idle;
       notifyListeners();
@@ -105,6 +132,7 @@ class MessagesController extends ChangeNotifier {
     try {
       final message = await _repository.sendMessage(threadId, content);
       _messages = [..._messages, message];
+      _touchThread(threadId, content);
       _status = MessagesStatus.idle;
       notifyListeners();
       await loadThreads(silent: true);
@@ -115,16 +143,151 @@ class MessagesController extends ChangeNotifier {
     }
   }
 
+  void setScreenActive(bool active) {
+    if (_screenActive == active) return;
+    _screenActive = active;
+    if (active) {
+      unawaited(loadThreads(silent: true));
+      startPolling();
+    } else {
+      stopPolling();
+    }
+  }
+
+  void reset() {
+    final isAlreadyReset = !_screenActive &&
+        _threads.isEmpty &&
+        _users.isEmpty &&
+        _selectedThreadId == null &&
+        _messages.isEmpty &&
+        _status == MessagesStatus.idle &&
+        _errorMessage == null;
+    if (isAlreadyReset) return;
+    stopPolling();
+    _screenActive = false;
+    _threads = [];
+    _users = [];
+    _selectedThreadId = null;
+    _messages = [];
+    _status = MessagesStatus.idle;
+    _errorMessage = null;
+    _incomingNotice = null;
+    _incomingNoticeVersion = 0;
+    notifyListeners();
+  }
+
+  void clearIncomingNotice() {
+    if (_incomingNotice == null) return;
+    _incomingNotice = null;
+    notifyListeners();
+  }
+
   void startPolling() {
     _pollTimer ??= Timer.periodic(
-      const Duration(seconds: 30),
-      (_) => loadThreads(silent: true),
+      _pollInterval,
+      (_) => unawaited(_poll()),
     );
   }
 
   void stopPolling() {
     _pollTimer?.cancel();
     _pollTimer = null;
+  }
+
+  void _markThreadReadLocally(int threadId) {
+    _threads = _threads
+        .map((thread) => thread.id == threadId
+            ? MessageThread(
+                id: thread.id,
+                title: thread.title,
+                lastMessage: thread.lastMessage,
+                updatedAt: thread.updatedAt,
+                unreadCount: 0,
+                participants: thread.participants,
+              )
+            : thread)
+        .toList();
+  }
+
+  void _touchThread(int threadId, String latestMessage) {
+    final matching = _threads.where((thread) => thread.id == threadId);
+    if (matching.isEmpty) return;
+    final thread = matching.first;
+    final updated = MessageThread(
+      id: thread.id,
+      title: thread.title,
+      lastMessage: latestMessage,
+      updatedAt: DateTime.now(),
+      unreadCount: 0,
+      participants: thread.participants,
+    );
+    _threads = [
+      updated,
+      ..._threads.where((thread) => thread.id != threadId),
+    ];
+  }
+
+  Future<void> _poll() async {
+    final previousMessages = List<Message>.from(_messages);
+    if (_selectedThreadId != null) {
+      try {
+        final threadId = _selectedThreadId!;
+        final nextMessages = await _repository.getMessages(threadId);
+        _maybeNotifyForIncomingMessages(previousMessages, nextMessages, threadId);
+        _messages = nextMessages;
+        await _repository.markRead(threadId);
+      } catch (_) {
+        // Fall back to thread-list refresh below.
+      }
+    }
+    await loadThreads(silent: true);
+  }
+
+  void _maybeNotifyForIncomingMessages(
+    List<Message> previousMessages,
+    List<Message> nextMessages,
+    int threadId,
+  ) {
+    final currentUserName = AuthSessionService.instance.currentUser?.name;
+    final previousIds = previousMessages.map((message) => message.id).toSet();
+    final incoming = nextMessages.where((message) {
+      if (previousIds.contains(message.id)) return false;
+      return currentUserName == null || message.senderName != currentUserName;
+    }).toList();
+    if (incoming.isEmpty) return;
+
+    final latest = incoming.last;
+    _incomingNotice = IncomingMessageNotice(
+      threadId: threadId,
+      senderName: latest.senderName,
+      preview: latest.content,
+    );
+    _incomingNoticeVersion += 1;
+  }
+
+  void _maybeNotifyForUnreadThreadActivity(
+    List<MessageThread> previousThreads,
+    List<MessageThread> nextThreads,
+  ) {
+    final previousById = {
+      for (final thread in previousThreads) thread.id: thread,
+    };
+
+    for (final thread in nextThreads) {
+      if (thread.id == _selectedThreadId) continue;
+      final previous = previousById[thread.id];
+      final unreadIncreased =
+          previous == null ? thread.unreadCount > 0 : thread.unreadCount > previous.unreadCount;
+      if (!unreadIncreased) continue;
+
+      _incomingNotice = IncomingMessageNotice(
+        threadId: thread.id,
+        senderName: thread.displayTitleFor(AuthSessionService.instance.currentUser?.id),
+        preview: thread.lastMessage ?? 'New message',
+      );
+      _incomingNoticeVersion += 1;
+      return;
+    }
   }
 
   @override

--- a/apps/desktop_flutter/lib/features/messages/controllers/messages_controller.dart
+++ b/apps/desktop_flutter/lib/features/messages/controllers/messages_controller.dart
@@ -212,7 +212,8 @@ class MessagesController extends ChangeNotifier {
       try {
         final threadId = _selectedThreadId!;
         final nextMessages = await _repository.getMessages(threadId);
-        _maybeNotifyForIncomingMessages(previousMessages, nextMessages, threadId);
+        _maybeNotifyForIncomingMessages(
+            previousMessages, nextMessages, threadId);
         _messages = nextMessages;
         await _repository.markRead(threadId);
       } catch (_) {

--- a/apps/desktop_flutter/lib/features/messages/controllers/messages_controller.dart
+++ b/apps/desktop_flutter/lib/features/messages/controllers/messages_controller.dart
@@ -47,6 +47,8 @@ class MessagesController extends ChangeNotifier {
   MessagesStatus get status => _status;
   String? get errorMessage => _errorMessage;
   int get unreadThreadCount => _threads.where((t) => t.isUnread).length;
+  int get totalUnreadCount =>
+      _threads.fold(0, (sum, thread) => sum + thread.unreadCount);
   IncomingMessageNotice? get incomingNotice => _incomingNotice;
 
   MessageThread? get selectedThread {

--- a/apps/desktop_flutter/lib/features/messages/controllers/messages_controller.dart
+++ b/apps/desktop_flutter/lib/features/messages/controllers/messages_controller.dart
@@ -9,10 +9,25 @@ import '../repositories/messages_repository.dart';
 
 enum MessagesStatus { idle, loading, error }
 
+class IncomingMessageNotice {
+  const IncomingMessageNotice({
+    required this.threadId,
+    required this.senderName,
+    required this.preview,
+  });
+
+  final int threadId;
+  final String senderName;
+  final String preview;
+}
+
 class MessagesController extends ChangeNotifier {
-  MessagesController(this._repository);
+  MessagesController(this._repository,
+      {Duration pollInterval = const Duration(seconds: 30)})
+      : _pollInterval = pollInterval;
 
   final MessagesRepository _repository;
+  final Duration _pollInterval;
 
   List<MessageThread> _threads = [];
   List<AuthUser> _users = [];
@@ -21,6 +36,9 @@ class MessagesController extends ChangeNotifier {
   MessagesStatus _status = MessagesStatus.idle;
   String? _errorMessage;
   Timer? _pollTimer;
+  bool _screenActive = false;
+  bool _pollingEnabled = false;
+  IncomingMessageNotice? _incomingNotice;
 
   List<MessageThread> get threads => _threads;
   List<AuthUser> get users => _users;
@@ -29,6 +47,7 @@ class MessagesController extends ChangeNotifier {
   MessagesStatus get status => _status;
   String? get errorMessage => _errorMessage;
   int get unreadThreadCount => _threads.where((t) => t.isUnread).length;
+  IncomingMessageNotice? get incomingNotice => _incomingNotice;
 
   MessageThread? get selectedThread {
     if (_selectedThreadId == null) return null;
@@ -47,7 +66,9 @@ class MessagesController extends ChangeNotifier {
     }
 
     try {
+      final previousThreads = List<MessageThread>.from(_threads);
       _threads = await _repository.getThreads();
+      _maybeNotifyForUnreadThreadActivity(previousThreads, _threads);
       _status = MessagesStatus.idle;
     } catch (e) {
       _errorMessage = e.toString();
@@ -68,13 +89,14 @@ class MessagesController extends ChangeNotifier {
   }
 
   Future<void> selectThread(int id) async {
+    _markThreadReadLocally(id);
     _selectedThreadId = id;
     _messages = [];
     notifyListeners();
 
     try {
-      _messages = await _repository.getMessages(id);
       await _repository.markRead(id);
+      _messages = await _repository.getMessages(id);
       await loadThreads(silent: true);
       _status = MessagesStatus.idle;
     } catch (e) {
@@ -105,6 +127,7 @@ class MessagesController extends ChangeNotifier {
     try {
       final message = await _repository.sendMessage(threadId, content);
       _messages = [..._messages, message];
+      _touchThread(threadId, content);
       _status = MessagesStatus.idle;
       notifyListeners();
       await loadThreads(silent: true);
@@ -115,16 +138,132 @@ class MessagesController extends ChangeNotifier {
     }
   }
 
+  void setScreenActive(bool active) {
+    if (_screenActive == active) return;
+    _screenActive = active;
+    if (active) {
+      unawaited(loadThreads(silent: true));
+    }
+  }
+
+  void setPollingEnabled(bool enabled) {
+    if (_pollingEnabled == enabled) return;
+    _pollingEnabled = enabled;
+    if (enabled) {
+      unawaited(loadThreads(silent: true));
+      startPolling();
+    } else {
+      stopPolling();
+    }
+  }
+
+  void clearIncomingNotice() {
+    if (_incomingNotice == null) return;
+    _incomingNotice = null;
+    notifyListeners();
+  }
+
   void startPolling() {
     _pollTimer ??= Timer.periodic(
-      const Duration(seconds: 30),
-      (_) => loadThreads(silent: true),
+      _pollInterval,
+      (_) => unawaited(_poll()),
     );
   }
 
   void stopPolling() {
     _pollTimer?.cancel();
     _pollTimer = null;
+  }
+
+  void _markThreadReadLocally(int threadId) {
+    _threads = _threads
+        .map((thread) => thread.id == threadId
+            ? MessageThread(
+                id: thread.id,
+                title: thread.title,
+                lastMessage: thread.lastMessage,
+                updatedAt: thread.updatedAt,
+                unreadCount: 0,
+              )
+            : thread)
+        .toList();
+  }
+
+  void _touchThread(int threadId, String latestMessage) {
+    final matching = _threads.where((thread) => thread.id == threadId);
+    if (matching.isEmpty) return;
+    final thread = matching.first;
+    final updated = MessageThread(
+      id: thread.id,
+      title: thread.title,
+      lastMessage: latestMessage,
+      updatedAt: DateTime.now(),
+      unreadCount: 0,
+    );
+    _threads = [
+      updated,
+      ..._threads.where((thread) => thread.id != threadId),
+    ];
+  }
+
+  Future<void> _poll() async {
+    final previousMessages = List<Message>.from(_messages);
+    if (_screenActive && _selectedThreadId != null) {
+      try {
+        final threadId = _selectedThreadId!;
+        final nextMessages = await _repository.getMessages(threadId);
+        _maybeNotifyForIncomingMessages(previousMessages, nextMessages, threadId);
+        _messages = nextMessages;
+        await _repository.markRead(threadId);
+      } catch (_) {
+        // Fall back to thread-list refresh below.
+      }
+    }
+    await loadThreads(silent: true);
+  }
+
+  void _maybeNotifyForIncomingMessages(
+    List<Message> previousMessages,
+    List<Message> nextMessages,
+    int threadId,
+  ) {
+    final previousIds = previousMessages.map((message) => message.id).toSet();
+    final incoming = nextMessages
+        .where((message) => !previousIds.contains(message.id))
+        .toList();
+    if (incoming.isEmpty) return;
+
+    final latest = incoming.last;
+    _incomingNotice = IncomingMessageNotice(
+      threadId: threadId,
+      senderName: latest.senderName,
+      preview: latest.content,
+    );
+  }
+
+  void _maybeNotifyForUnreadThreadActivity(
+    List<MessageThread> previousThreads,
+    List<MessageThread> nextThreads,
+  ) {
+    final previousById = {
+      for (final thread in previousThreads) thread.id: thread,
+    };
+
+    for (final thread in nextThreads) {
+      if (thread.id == _selectedThreadId) continue;
+      final previous = previousById[thread.id];
+      final unreadIncreased = previous == null
+          ? thread.unreadCount > 0
+          : thread.unreadCount > previous.unreadCount;
+      if (!unreadIncreased) continue;
+
+      _incomingNotice = IncomingMessageNotice(
+        threadId: thread.id,
+        senderName: thread.title,
+        preview: thread.lastMessage ?? 'New message',
+      );
+      return;
+    }
   }
 
   @override

--- a/apps/desktop_flutter/lib/features/messages/data/messages_data_source.dart
+++ b/apps/desktop_flutter/lib/features/messages/data/messages_data_source.dart
@@ -39,13 +39,11 @@ class MessagesDataSource {
         .toList();
   }
 
-  Future<MessageThread> createThread(List<int> participantIds,
-      {String? title}) async {
+  Future<MessageThread> createThread(List<int> participantIds) async {
     final response = await http.post(
       Uri.parse('$_baseUrl/message-threads'),
       headers: AuthSessionStore.headers(json: true),
       body: jsonEncode({
-        if (title != null && title.isNotEmpty) 'title': title,
         'participantIds': participantIds,
       }),
     );

--- a/apps/desktop_flutter/lib/features/messages/data/messages_data_source.dart
+++ b/apps/desktop_flutter/lib/features/messages/data/messages_data_source.dart
@@ -39,12 +39,14 @@ class MessagesDataSource {
         .toList();
   }
 
-  Future<MessageThread> createThread(List<int> participantIds) async {
+  Future<MessageThread> createThread(List<int> participantIds,
+      {String? title}) async {
     final response = await http.post(
       Uri.parse('$_baseUrl/message-threads'),
       headers: AuthSessionStore.headers(json: true),
       body: jsonEncode({
         'participantIds': participantIds,
+        if (title != null && title.trim().isNotEmpty) 'title': title.trim(),
       }),
     );
     _assertOk(response);

--- a/apps/desktop_flutter/lib/features/messages/models/message_thread.dart
+++ b/apps/desktop_flutter/lib/features/messages/models/message_thread.dart
@@ -1,3 +1,23 @@
+class MessageThreadParticipant {
+  const MessageThreadParticipant({
+    required this.id,
+    required this.name,
+    required this.email,
+  });
+
+  final int id;
+  final String name;
+  final String email;
+
+  factory MessageThreadParticipant.fromJson(Map<String, dynamic> json) {
+    return MessageThreadParticipant(
+      id: json['id'] as int,
+      name: json['name'] as String,
+      email: json['email'] as String,
+    );
+  }
+}
+
 class MessageThread {
   const MessageThread({
     required this.id,
@@ -5,6 +25,7 @@ class MessageThread {
     this.lastMessage,
     required this.updatedAt,
     required this.unreadCount,
+    this.participants = const [],
   });
 
   final int id;
@@ -12,6 +33,7 @@ class MessageThread {
   final String? lastMessage;
   final DateTime updatedAt;
   final int unreadCount;
+  final List<MessageThreadParticipant> participants;
 
   factory MessageThread.fromJson(Map<String, dynamic> json) {
     return MessageThread(
@@ -20,6 +42,10 @@ class MessageThread {
       lastMessage: json['lastMessage'] as String?,
       updatedAt: DateTime.parse(json['updatedAt'] as String),
       unreadCount: json['unreadCount'] as int? ?? 0,
+      participants: ((json['participants'] as List<dynamic>?) ?? const [])
+          .map((item) =>
+              MessageThreadParticipant.fromJson(item as Map<String, dynamic>))
+          .toList(),
     );
   }
 
@@ -29,4 +55,13 @@ class MessageThread {
   }
 
   bool get isUnread => unreadCount > 0;
+
+  String displayTitleFor(int? currentUserId) {
+    if (participants.isEmpty || currentUserId == null) {
+      return title;
+    }
+    final others = participants.where((p) => p.id != currentUserId).toList();
+    if (others.isEmpty) return title;
+    return others.map((p) => p.name).join(', ');
+  }
 }

--- a/apps/desktop_flutter/lib/features/messages/repositories/messages_repository.dart
+++ b/apps/desktop_flutter/lib/features/messages/repositories/messages_repository.dart
@@ -12,9 +12,8 @@ class MessagesRepository {
 
   Future<List<AuthUser>> getUsers() => _dataSource.getUsers();
 
-  Future<MessageThread> createThread(List<int> participantIds,
-          {String? title}) =>
-      _dataSource.createThread(participantIds, title: title);
+  Future<MessageThread> createThread(List<int> participantIds) =>
+      _dataSource.createThread(participantIds);
 
   Future<List<Message>> getMessages(int threadId) =>
       _dataSource.getMessages(threadId);

--- a/apps/desktop_flutter/lib/features/messages/repositories/messages_repository.dart
+++ b/apps/desktop_flutter/lib/features/messages/repositories/messages_repository.dart
@@ -12,8 +12,9 @@ class MessagesRepository {
 
   Future<List<AuthUser>> getUsers() => _dataSource.getUsers();
 
-  Future<MessageThread> createThread(List<int> participantIds) =>
-      _dataSource.createThread(participantIds);
+  Future<MessageThread> createThread(List<int> participantIds,
+          {String? title}) =>
+      _dataSource.createThread(participantIds, title: title);
 
   Future<List<Message>> getMessages(int threadId) =>
       _dataSource.getMessages(threadId);

--- a/apps/desktop_flutter/lib/features/messages/views/messages_view.dart
+++ b/apps/desktop_flutter/lib/features/messages/views/messages_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 
+import '../../../app/core/auth/auth_session_service.dart';
 import '../controllers/messages_controller.dart';
 import '../models/message.dart';
 import '../models/message_thread.dart';
@@ -31,11 +32,6 @@ class _MessagesViewState extends State<MessagesView> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final controller = context.read<MessagesController>();
-      controller.loadThreads();
-      controller.startPolling();
-    });
     _searchController.addListener(() {
       setState(() => _searchQuery = _searchController.text.toLowerCase());
     });
@@ -43,7 +39,6 @@ class _MessagesViewState extends State<MessagesView> {
 
   @override
   void dispose() {
-    context.read<MessagesController>().stopPolling();
     _searchController.dispose();
     super.dispose();
   }
@@ -82,8 +77,12 @@ class _ThreadListPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final controller = context.watch<MessagesController>();
+    final currentUserId = context.watch<AuthSessionService>().currentUser?.id;
     final filtered = controller.threads
-        .where((t) => t.title.toLowerCase().contains(searchQuery))
+        .where((t) => t
+            .displayTitleFor(currentUserId)
+            .toLowerCase()
+            .contains(searchQuery))
         .toList();
 
     return Container(
@@ -134,9 +133,8 @@ class _ThreadListPanel extends StatelessWidget {
     showDialog<void>(
       context: context,
       builder: (_) => _NewThreadDialog(
-        onCreated: (participantIds, title) => context
-            .read<MessagesController>()
-            .createThread(participantIds, title: title),
+        onCreated: (participantIds) =>
+            context.read<MessagesController>().createThread(participantIds),
       ),
     );
   }
@@ -226,6 +224,7 @@ class _ThreadRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final currentUserId = context.watch<AuthSessionService>().currentUser?.id;
     return InkWell(
       onTap: onTap,
       child: Container(
@@ -244,7 +243,7 @@ class _ThreadRow extends StatelessWidget {
                     children: [
                       Expanded(
                         child: Text(
-                          thread.title,
+                          thread.displayTitleFor(currentUserId),
                           style: TextStyle(
                             fontSize: 13,
                             fontWeight: thread.isUnread
@@ -369,20 +368,38 @@ class _MessagePanelState extends State<_MessagePanel> {
   @override
   Widget build(BuildContext context) {
     final controller = context.watch<MessagesController>();
+    final currentUserId = context.watch<AuthSessionService>().currentUser?.id;
 
     if (controller.selectedThreadId == null) {
-      return const Center(
-        child: Text(
-          'Select a conversation',
-          style: TextStyle(color: _kTextMuted, fontSize: 14),
-        ),
+      return Column(
+        children: [
+          if (controller.incomingNotice != null)
+            _IncomingMessageBanner(notice: controller.incomingNotice!),
+          const Expanded(
+            child: Center(
+              child: Text(
+                'Select a conversation',
+                style: TextStyle(color: _kTextMuted, fontSize: 14),
+              ),
+            ),
+          ),
+        ],
       );
     }
 
-    final thread = controller.selectedThread;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scrollController.hasClients) return;
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+    });
 
     return Column(
       children: [
+        if (controller.incomingNotice != null)
+          _IncomingMessageBanner(notice: controller.incomingNotice!),
         // Header
         Container(
           height: 56,
@@ -393,7 +410,7 @@ class _MessagePanelState extends State<_MessagePanel> {
           child: Align(
             alignment: Alignment.centerLeft,
             child: Text(
-              thread?.title ?? '',
+              controller.selectedThread?.displayTitleFor(currentUserId) ?? '',
               style: const TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w600,
@@ -425,6 +442,62 @@ class _MessagePanelState extends State<_MessagePanel> {
           onSend: () => _sendMessage(context),
         ),
       ],
+    );
+  }
+}
+
+class _IncomingMessageBanner extends StatelessWidget {
+  const _IncomingMessageBanner({required this.notice});
+
+  final IncomingMessageNotice notice;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0xFFF8FAFF),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: const BoxDecoration(
+          border: Border(bottom: BorderSide(color: Color(0xFFD6E4FF))),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.notifications_active_outlined,
+                size: 18, color: _kPrimary),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    notice.senderName,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: _kTextPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    notice.preview,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      color: _kTextSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            TextButton(
+              onPressed: () => context.read<MessagesController>().clearIncomingNotice(),
+              child: const Text('Dismiss'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -578,30 +651,21 @@ class _ReplyArea extends StatelessWidget {
 class _NewThreadDialog extends StatefulWidget {
   const _NewThreadDialog({required this.onCreated});
 
-  final Future<void> Function(List<int> participantIds, String? title)
-      onCreated;
+  final Future<void> Function(List<int> participantIds) onCreated;
 
   @override
   State<_NewThreadDialog> createState() => _NewThreadDialogState();
 }
 
 class _NewThreadDialogState extends State<_NewThreadDialog> {
-  final _titleController = TextEditingController();
-  final Set<int> _selectedUserIds = <int>{};
+  int? _selectedUserId;
 
   @override
-  void dispose() {
-    _titleController.dispose();
-    super.dispose();
-  }
+  void dispose() => super.dispose();
 
   Future<void> _submit() async {
-    if (_selectedUserIds.isEmpty) return;
-    final title = _titleController.text.trim();
-    await widget.onCreated(
-      _selectedUserIds.toList()..sort(),
-      title.isEmpty ? null : title,
-    );
+    if (_selectedUserId == null) return;
+    await widget.onCreated([_selectedUserId!]);
     if (!mounted) return;
     Navigator.of(context).pop();
   }
@@ -616,26 +680,16 @@ class _NewThreadDialogState extends State<_NewThreadDialog> {
         style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
       ),
       content: SizedBox(
-        width: 420,
+        width: 360,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            TextField(
-              controller: _titleController,
-              autofocus: true,
-              style: const TextStyle(fontSize: 14),
-              decoration: InputDecoration(
-                labelText: 'Optional title',
-                hintText: 'Defaults to participant names',
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                focusedBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: const BorderSide(color: _kPrimary),
-                ),
+            const Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'Choose one teammate to start a direct conversation.',
+                style: TextStyle(fontSize: 13, color: _kTextSecondary),
               ),
-              onSubmitted: (_) => _submit(),
             ),
             const SizedBox(height: 12),
             if (users.isEmpty)
@@ -653,20 +707,15 @@ class _NewThreadDialogState extends State<_NewThreadDialog> {
                   itemCount: users.length,
                   itemBuilder: (context, index) {
                     final user = users[index];
-                    final isSelected = _selectedUserIds.contains(user.id);
-                    return CheckboxListTile(
-                      value: isSelected,
-                      activeColor: _kPrimary,
+                    return RadioListTile<int>(
+                      value: user.id,
                       title: Text(user.name),
                       subtitle: Text(user.email),
-                      controlAffinity: ListTileControlAffinity.leading,
+                      groupValue: _selectedUserId,
+                      activeColor: _kPrimary,
                       onChanged: (value) {
                         setState(() {
-                          if (value == true) {
-                            _selectedUserIds.add(user.id);
-                          } else {
-                            _selectedUserIds.remove(user.id);
-                          }
+                          _selectedUserId = value;
                         });
                       },
                     );
@@ -682,7 +731,7 @@ class _NewThreadDialogState extends State<_NewThreadDialog> {
           child: const Text('Cancel', style: TextStyle(color: _kTextSecondary)),
         ),
         FilledButton(
-          onPressed: _selectedUserIds.isEmpty ? null : _submit,
+          onPressed: _selectedUserId == null ? null : _submit,
           style: FilledButton.styleFrom(backgroundColor: _kPrimary),
           child: const Text('Create', style: TextStyle(color: Colors.white)),
         ),

--- a/apps/desktop_flutter/lib/features/messages/views/messages_view.dart
+++ b/apps/desktop_flutter/lib/features/messages/views/messages_view.dart
@@ -371,18 +371,35 @@ class _MessagePanelState extends State<_MessagePanel> {
     final controller = context.watch<MessagesController>();
 
     if (controller.selectedThreadId == null) {
-      return const Center(
-        child: Text(
-          'Select a conversation',
-          style: TextStyle(color: _kTextMuted, fontSize: 14),
-        ),
+      return Column(
+        children: [
+          if (controller.incomingNotice != null)
+            _IncomingMessageBanner(notice: controller.incomingNotice!),
+          const Expanded(
+            child: Center(
+              child: Text(
+                'Select a conversation',
+                style: TextStyle(color: _kTextMuted, fontSize: 14),
+              ),
+            ),
+          ),
+        ],
       );
     }
 
-    final thread = controller.selectedThread;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_scrollController.hasClients) return;
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      );
+    });
 
     return Column(
       children: [
+        if (controller.incomingNotice != null)
+          _IncomingMessageBanner(notice: controller.incomingNotice!),
         // Header
         Container(
           height: 56,
@@ -393,7 +410,7 @@ class _MessagePanelState extends State<_MessagePanel> {
           child: Align(
             alignment: Alignment.centerLeft,
             child: Text(
-              thread?.title ?? '',
+              controller.selectedThread?.title ?? '',
               style: const TextStyle(
                 fontSize: 16,
                 fontWeight: FontWeight.w600,
@@ -425,6 +442,62 @@ class _MessagePanelState extends State<_MessagePanel> {
           onSend: () => _sendMessage(context),
         ),
       ],
+    );
+  }
+}
+
+class _IncomingMessageBanner extends StatelessWidget {
+  const _IncomingMessageBanner({required this.notice});
+
+  final IncomingMessageNotice notice;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: const Color(0xFFF8FAFF),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: const BoxDecoration(
+          border: Border(bottom: BorderSide(color: Color(0xFFD6E4FF))),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.notifications_active_outlined,
+                size: 18, color: _kPrimary),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    notice.senderName,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      color: _kTextPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    notice.preview,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      color: _kTextSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            TextButton(
+              onPressed: () => context.read<MessagesController>().clearIncomingNotice(),
+              child: const Text('Dismiss'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/apps/desktop_flutter/lib/features/messages/views/messages_view.dart
+++ b/apps/desktop_flutter/lib/features/messages/views/messages_view.dart
@@ -492,7 +492,8 @@ class _IncomingMessageBanner extends StatelessWidget {
               ),
             ),
             TextButton(
-              onPressed: () => context.read<MessagesController>().clearIncomingNotice(),
+              onPressed: () =>
+                  context.read<MessagesController>().clearIncomingNotice(),
               child: const Text('Dismiss'),
             ),
           ],

--- a/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
+++ b/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../app/core/auth/auth_session_service.dart';
 import '../../../app/core/services/server_config_service.dart';
 
 class SettingsView extends StatefulWidget {
@@ -42,6 +43,9 @@ class _SettingsViewState extends State<SettingsView> {
 
   @override
   Widget build(BuildContext context) {
+    final auth = context.watch<AuthSessionService>();
+    final user = auth.currentUser;
+
     return Scaffold(
       backgroundColor: const Color(0xFFFFFFFF),
       appBar: AppBar(
@@ -57,8 +61,104 @@ class _SettingsViewState extends State<SettingsView> {
       body: ListView(
         padding: const EdgeInsets.all(24),
         children: [
+          if (user != null) ...[
+            const Text(
+              'ACCOUNT',
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: Color(0xFF6B7280),
+                letterSpacing: 0.8,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Container(
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: const Color(0xFFFFFFFF),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: const Color(0xFFE5E7EB)),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Signed in user',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w600,
+                      color: Color(0xFF111827),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      CircleAvatar(
+                        radius: 22,
+                        backgroundColor: const Color(0x144F6AF5),
+                        backgroundImage: user.photoUrl != null
+                            ? NetworkImage(user.photoUrl!)
+                            : null,
+                        child: user.photoUrl == null
+                            ? Text(
+                                _settingsInitialsFor(user.name),
+                                style: const TextStyle(
+                                  color: Color(0xFF4F6AF5),
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              )
+                            : null,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              user.name,
+                              style: const TextStyle(
+                                color: Color(0xFF111827),
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              user.email,
+                              style: const TextStyle(
+                                fontSize: 13,
+                                color: Color(0xFF6B7280),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    'Role: ${user.role}',
+                    style: const TextStyle(
+                      fontSize: 13,
+                      color: Color(0xFF6B7280),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  OutlinedButton(
+                    onPressed: () async {
+                      final navigator = Navigator.of(context);
+                      await auth.logout();
+                      if (mounted) {
+                        navigator.pop();
+                      }
+                    },
+                    child: const Text('Sign out'),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+          ],
           const Text(
-            'Server',
+            'SERVER',
             style: TextStyle(
               fontSize: 12,
               fontWeight: FontWeight.w600,
@@ -122,4 +222,15 @@ class _SettingsViewState extends State<SettingsView> {
       ),
     );
   }
+}
+
+String _settingsInitialsFor(String name) {
+  final parts = name
+      .trim()
+      .split(RegExp(r'\s+'))
+      .where((part) => part.isNotEmpty)
+      .take(2)
+      .toList();
+  if (parts.isEmpty) return '?';
+  return parts.map((part) => part[0].toUpperCase()).join();
 }

--- a/apps/desktop_flutter/lib/features/tasks/controllers/automation_rules_controller.dart
+++ b/apps/desktop_flutter/lib/features/tasks/controllers/automation_rules_controller.dart
@@ -38,6 +38,7 @@ class AutomationRulesController extends ChangeNotifier {
   Future<void> load() async {
     _status = AutomationRulesStatus.loading;
     _errorMessage = null;
+    _selectedPreview = null;
     notifyListeners();
     try {
       final results = await Future.wait<dynamic>([
@@ -93,6 +94,7 @@ class AutomationRulesController extends ChangeNotifier {
         sourceAccountId: sourceAccountId,
       );
       _rules = [..._rules, rule];
+      _selectedPreview = null;
       notifyListeners();
     } catch (e) {
       _errorMessage = e.toString();
@@ -123,6 +125,10 @@ class AutomationRulesController extends ChangeNotifier {
         sourceAccountId: sourceAccountId,
       );
       _rules = _rules.map((r) => r.id == id ? updated : r).toList();
+      if (_selectedPreview?.ruleId == id) {
+        await loadPreview(id);
+        return;
+      }
       notifyListeners();
     } catch (e) {
       _errorMessage = e.toString();
@@ -136,6 +142,10 @@ class AutomationRulesController extends ChangeNotifier {
     try {
       final updated = await _repository.update(id, enabled: !rule.enabled);
       _rules = _rules.map((r) => r.id == id ? updated : r).toList();
+      if (_selectedPreview?.ruleId == id) {
+        await loadPreview(id);
+        return;
+      }
       notifyListeners();
     } catch (e) {
       _errorMessage = e.toString();
@@ -148,6 +158,9 @@ class AutomationRulesController extends ChangeNotifier {
     try {
       await _repository.delete(id);
       _rules = _rules.where((r) => r.id != id).toList();
+      if (_selectedPreview?.ruleId == id) {
+        _selectedPreview = null;
+      }
       notifyListeners();
     } catch (e) {
       _errorMessage = e.toString();

--- a/apps/desktop_flutter/lib/features/tasks/controllers/automation_rules_controller.dart
+++ b/apps/desktop_flutter/lib/features/tasks/controllers/automation_rules_controller.dart
@@ -1,4 +1,9 @@
 import 'package:flutter/foundation.dart';
+
+import '../../integrations/models/integration_account.dart';
+import '../../integrations/models/planning_center_task_options.dart';
+import '../data/automation_rules_data_source.dart';
+import '../models/automation_catalog.dart';
 import '../models/automation_rule.dart';
 import '../repositories/automation_rules_repository.dart';
 
@@ -10,10 +15,23 @@ class AutomationRulesController extends ChangeNotifier {
   final AutomationRulesRepository _repository;
 
   List<AutomationRule> _rules = [];
+  List<AutomationTriggerCatalogItem> _triggers = [];
+  List<AutomationActionCatalogItem> _actions = [];
+  List<AutomationProviderCatalogItem> _providers = [];
+  List<IntegrationAccount> _accounts = [];
+  PlanningCenterTaskOptions? _planningCenterTaskOptions;
+  AutomationRulePreview? _selectedPreview;
   AutomationRulesStatus _status = AutomationRulesStatus.idle;
   String? _errorMessage;
 
   List<AutomationRule> get rules => _rules;
+  List<AutomationTriggerCatalogItem> get triggers => _triggers;
+  List<AutomationActionCatalogItem> get actions => _actions;
+  List<AutomationProviderCatalogItem> get providers => _providers;
+  List<IntegrationAccount> get accounts => _accounts;
+  PlanningCenterTaskOptions? get planningCenterTaskOptions =>
+      _planningCenterTaskOptions;
+  AutomationRulePreview? get selectedPreview => _selectedPreview;
   AutomationRulesStatus get status => _status;
   String? get errorMessage => _errorMessage;
 
@@ -22,7 +40,20 @@ class AutomationRulesController extends ChangeNotifier {
     _errorMessage = null;
     notifyListeners();
     try {
-      _rules = await _repository.getAll();
+      final results = await Future.wait<dynamic>([
+        _repository.getAll(),
+        _repository.getTriggers(),
+        _repository.getActions(),
+        _repository.getProviders(),
+        _repository.getAccounts(),
+        _repository.getPlanningCenterTaskOptions(),
+      ]);
+      _rules = results[0] as List<AutomationRule>;
+      _triggers = results[1] as List<AutomationTriggerCatalogItem>;
+      _actions = results[2] as List<AutomationActionCatalogItem>;
+      _providers = results[3] as List<AutomationProviderCatalogItem>;
+      _accounts = results[4] as List<IntegrationAccount>;
+      _planningCenterTaskOptions = results[5] as PlanningCenterTaskOptions?;
       _status = AutomationRulesStatus.idle;
     } catch (e) {
       _errorMessage = e.toString();
@@ -31,20 +62,35 @@ class AutomationRulesController extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> loadPreview(String ruleId) async {
+    try {
+      _selectedPreview = await _repository.getPreview(ruleId);
+      notifyListeners();
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = AutomationRulesStatus.error;
+      notifyListeners();
+    }
+  }
+
   Future<void> createRule({
     required String name,
-    required String triggerType,
+    required String source,
+    required String triggerKey,
     required String actionType,
     Map<String, dynamic>? triggerConfig,
     Map<String, dynamic>? actionConfig,
+    String? sourceAccountId,
   }) async {
     try {
       final rule = await _repository.create(
         name: name,
-        triggerType: triggerType,
+        source: source,
+        triggerKey: triggerKey,
         actionType: actionType,
         triggerConfig: triggerConfig,
         actionConfig: actionConfig,
+        sourceAccountId: sourceAccountId,
       );
       _rules = [..._rules, rule];
       notifyListeners();
@@ -58,19 +104,23 @@ class AutomationRulesController extends ChangeNotifier {
   Future<void> updateRule(
     String id, {
     String? name,
-    String? triggerType,
+    String? source,
+    String? triggerKey,
     String? actionType,
     Map<String, dynamic>? triggerConfig,
     Map<String, dynamic>? actionConfig,
+    String? sourceAccountId,
   }) async {
     try {
       final updated = await _repository.update(
         id,
         name: name,
-        triggerType: triggerType,
+        source: source,
+        triggerKey: triggerKey,
         actionType: actionType,
         triggerConfig: triggerConfig,
         actionConfig: actionConfig,
+        sourceAccountId: sourceAccountId,
       );
       _rules = _rules.map((r) => r.id == id ? updated : r).toList();
       notifyListeners();

--- a/apps/desktop_flutter/lib/features/tasks/data/automation_rules_data_source.dart
+++ b/apps/desktop_flutter/lib/features/tasks/data/automation_rules_data_source.dart
@@ -1,8 +1,43 @@
 import 'dart:convert';
+
 import 'package:http/http.dart' as http;
+
+import '../../../app/core/auth/auth_session_store.dart';
 import '../../../app/core/constants/app_constants.dart';
 import '../../../app/core/errors/app_error.dart';
+import '../../integrations/models/integration_account.dart';
+import '../../integrations/models/planning_center_task_options.dart';
+import '../models/automation_catalog.dart';
 import '../models/automation_rule.dart';
+
+class AutomationRulePreview {
+  const AutomationRulePreview({
+    required this.ruleId,
+    required this.summary,
+    this.previewSample,
+    this.lastMatchedAt,
+    this.lastEvaluatedAt,
+    this.matchCountLastRun = 0,
+  });
+
+  factory AutomationRulePreview.fromJson(Map<String, dynamic> json) {
+    return AutomationRulePreview(
+      ruleId: json['ruleId'] as String,
+      summary: json['summary'] as String? ?? '',
+      previewSample: json['previewSample'] as Map<String, dynamic>?,
+      lastMatchedAt: json['lastMatchedAt'] as String?,
+      lastEvaluatedAt: json['lastEvaluatedAt'] as String?,
+      matchCountLastRun: (json['matchCountLastRun'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  final String ruleId;
+  final String summary;
+  final Map<String, dynamic>? previewSample;
+  final String? lastMatchedAt;
+  final String? lastEvaluatedAt;
+  final int matchCountLastRun;
+}
 
 class AutomationRulesDataSource {
   AutomationRulesDataSource({String? baseUrl})
@@ -11,7 +46,10 @@ class AutomationRulesDataSource {
   final String _baseUrl;
 
   Future<List<AutomationRule>> fetchAll() async {
-    final response = await http.get(Uri.parse('$_baseUrl/automation-rules'));
+    final response = await http.get(
+      Uri.parse('$_baseUrl/automation-rules'),
+      headers: AuthSessionStore.headers(),
+    );
     _assertOk(response);
     final list = jsonDecode(response.body) as List<dynamic>;
     return list
@@ -19,23 +57,100 @@ class AutomationRulesDataSource {
         .toList();
   }
 
+  Future<List<AutomationTriggerCatalogItem>> fetchTriggers() async {
+    final response = await http.get(
+      Uri.parse('$_baseUrl/automation-catalog/triggers'),
+      headers: AuthSessionStore.headers(),
+    );
+    _assertOk(response);
+    final list = jsonDecode(response.body) as List<dynamic>;
+    return list
+        .map((item) => AutomationTriggerCatalogItem.fromJson(
+            item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<AutomationActionCatalogItem>> fetchActions() async {
+    final response = await http.get(
+      Uri.parse('$_baseUrl/automation-catalog/actions'),
+      headers: AuthSessionStore.headers(),
+    );
+    _assertOk(response);
+    final list = jsonDecode(response.body) as List<dynamic>;
+    return list
+        .map((item) => AutomationActionCatalogItem.fromJson(
+            item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<AutomationProviderCatalogItem>> fetchProviders() async {
+    final response = await http.get(
+      Uri.parse('$_baseUrl/automation-catalog/providers'),
+      headers: AuthSessionStore.headers(),
+    );
+    _assertOk(response);
+    final list = jsonDecode(response.body) as List<dynamic>;
+    return list
+        .map((item) => AutomationProviderCatalogItem.fromJson(
+            item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<IntegrationAccount>> fetchAccounts() async {
+    final response = await http.get(
+      Uri.parse('$_baseUrl/integrations/accounts'),
+      headers: AuthSessionStore.headers(),
+    );
+    _assertOk(response);
+    final list = jsonDecode(response.body) as List<dynamic>;
+    return list
+        .map((item) => IntegrationAccount.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<PlanningCenterTaskOptions?> fetchPlanningCenterTaskOptions() async {
+    final response = await http.get(
+      Uri.parse('$_baseUrl/integrations/planning-center/task-options'),
+      headers: AuthSessionStore.headers(),
+    );
+    if (response.statusCode >= 400) return null;
+    return PlanningCenterTaskOptions.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+  }
+
+  Future<AutomationRulePreview> fetchPreview(String id) async {
+    final response = await http.get(
+      Uri.parse('$_baseUrl/automation-rules/$id/preview'),
+      headers: AuthSessionStore.headers(),
+    );
+    _assertOk(response);
+    return AutomationRulePreview.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+  }
+
   Future<AutomationRule> create({
     required String name,
-    required String triggerType,
+    required String source,
+    required String triggerKey,
     required String actionType,
     Map<String, dynamic>? triggerConfig,
     Map<String, dynamic>? actionConfig,
+    String? sourceAccountId,
     bool enabled = true,
   }) async {
     final response = await http.post(
       Uri.parse('$_baseUrl/automation-rules'),
-      headers: {'Content-Type': 'application/json'},
+      headers: AuthSessionStore.headers(json: true),
       body: jsonEncode({
         'name': name,
-        'triggerType': triggerType,
+        'source': source,
+        'triggerKey': triggerKey,
         'actionType': actionType,
         if (triggerConfig != null) 'triggerConfig': triggerConfig,
         if (actionConfig != null) 'actionConfig': actionConfig,
+        if (sourceAccountId != null) 'sourceAccountId': sourceAccountId,
         'enabled': enabled,
       }),
     );
@@ -47,21 +162,25 @@ class AutomationRulesDataSource {
   Future<AutomationRule> update(
     String id, {
     String? name,
-    String? triggerType,
+    String? source,
+    String? triggerKey,
     String? actionType,
     Map<String, dynamic>? triggerConfig,
     Map<String, dynamic>? actionConfig,
+    String? sourceAccountId,
     bool? enabled,
   }) async {
     final response = await http.patch(
       Uri.parse('$_baseUrl/automation-rules/$id'),
-      headers: {'Content-Type': 'application/json'},
+      headers: AuthSessionStore.headers(json: true),
       body: jsonEncode({
         if (name != null) 'name': name,
-        if (triggerType != null) 'triggerType': triggerType,
+        if (source != null) 'source': source,
+        if (triggerKey != null) 'triggerKey': triggerKey,
         if (actionType != null) 'actionType': actionType,
         if (triggerConfig != null) 'triggerConfig': triggerConfig,
         if (actionConfig != null) 'actionConfig': actionConfig,
+        if (sourceAccountId != null) 'sourceAccountId': sourceAccountId,
         if (enabled != null) 'enabled': enabled,
       }),
     );
@@ -71,8 +190,10 @@ class AutomationRulesDataSource {
   }
 
   Future<void> delete(String id) async {
-    final response =
-        await http.delete(Uri.parse('$_baseUrl/automation-rules/$id'));
+    final response = await http.delete(
+      Uri.parse('$_baseUrl/automation-rules/$id'),
+      headers: AuthSessionStore.headers(),
+    );
     _assertOk(response);
   }
 

--- a/apps/desktop_flutter/lib/features/tasks/data/automation_rules_data_source.dart
+++ b/apps/desktop_flutter/lib/features/tasks/data/automation_rules_data_source.dart
@@ -65,8 +65,8 @@ class AutomationRulesDataSource {
     _assertOk(response);
     final list = jsonDecode(response.body) as List<dynamic>;
     return list
-        .map((item) => AutomationTriggerCatalogItem.fromJson(
-            item as Map<String, dynamic>))
+        .map((item) =>
+            AutomationTriggerCatalogItem.fromJson(item as Map<String, dynamic>))
         .toList();
   }
 
@@ -78,8 +78,8 @@ class AutomationRulesDataSource {
     _assertOk(response);
     final list = jsonDecode(response.body) as List<dynamic>;
     return list
-        .map((item) => AutomationActionCatalogItem.fromJson(
-            item as Map<String, dynamic>))
+        .map((item) =>
+            AutomationActionCatalogItem.fromJson(item as Map<String, dynamic>))
         .toList();
   }
 
@@ -104,7 +104,8 @@ class AutomationRulesDataSource {
     _assertOk(response);
     final list = jsonDecode(response.body) as List<dynamic>;
     return list
-        .map((item) => IntegrationAccount.fromJson(item as Map<String, dynamic>))
+        .map(
+            (item) => IntegrationAccount.fromJson(item as Map<String, dynamic>))
         .toList();
   }
 

--- a/apps/desktop_flutter/lib/features/tasks/models/automation_catalog.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/automation_catalog.dart
@@ -1,0 +1,81 @@
+class AutomationTriggerCatalogItem {
+  const AutomationTriggerCatalogItem({
+    required this.key,
+    required this.source,
+    required this.label,
+    required this.description,
+    required this.signalTypes,
+    required this.configSchema,
+  });
+
+  factory AutomationTriggerCatalogItem.fromJson(Map<String, dynamic> json) {
+    return AutomationTriggerCatalogItem(
+      key: json['key'] as String,
+      source: json['source'] as String,
+      label: json['label'] as String,
+      description: json['description'] as String? ?? '',
+      signalTypes: (json['signalTypes'] as List<dynamic>? ?? const [])
+          .map((item) => item.toString())
+          .toList(),
+      configSchema: json['configSchema'] as Map<String, dynamic>? ?? const {},
+    );
+  }
+
+  final String key;
+  final String source;
+  final String label;
+  final String description;
+  final List<String> signalTypes;
+  final Map<String, dynamic> configSchema;
+}
+
+class AutomationActionCatalogItem {
+  const AutomationActionCatalogItem({
+    required this.key,
+    required this.label,
+    required this.description,
+    required this.configSchema,
+  });
+
+  factory AutomationActionCatalogItem.fromJson(Map<String, dynamic> json) {
+    return AutomationActionCatalogItem(
+      key: json['key'] as String,
+      label: json['label'] as String,
+      description: json['description'] as String? ?? '',
+      configSchema: json['configSchema'] as Map<String, dynamic>? ?? const {},
+    );
+  }
+
+  final String key;
+  final String label;
+  final String description;
+  final Map<String, dynamic> configSchema;
+}
+
+class AutomationProviderCatalogItem {
+  const AutomationProviderCatalogItem({
+    required this.source,
+    required this.label,
+    required this.description,
+    required this.syncSupport,
+    required this.triggerKeys,
+  });
+
+  factory AutomationProviderCatalogItem.fromJson(Map<String, dynamic> json) {
+    return AutomationProviderCatalogItem(
+      source: json['source'] as String,
+      label: json['label'] as String,
+      description: json['description'] as String? ?? '',
+      syncSupport: json['syncSupport'] as String? ?? 'manual',
+      triggerKeys: (json['triggerKeys'] as List<dynamic>? ?? const [])
+          .map((item) => item.toString())
+          .toList(),
+    );
+  }
+
+  final String source;
+  final String label;
+  final String description;
+  final String syncSupport;
+  final List<String> triggerKeys;
+}

--- a/apps/desktop_flutter/lib/features/tasks/models/automation_rule.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/automation_rule.dart
@@ -2,22 +2,34 @@ class AutomationRule {
   const AutomationRule({
     required this.id,
     required this.name,
-    required this.triggerType,
+    required this.source,
+    required this.triggerKey,
     this.triggerConfig,
     required this.actionType,
     this.actionConfig,
     required this.enabled,
+    this.sourceAccountId,
+    this.lastEvaluatedAt,
+    this.lastMatchedAt,
+    this.matchCountLastRun = 0,
+    this.previewSample,
     required this.createdAt,
     required this.updatedAt,
   });
 
   final String id;
   final String name;
-  final String triggerType;
+  final String source;
+  final String triggerKey;
   final Map<String, dynamic>? triggerConfig;
   final String actionType;
   final Map<String, dynamic>? actionConfig;
   final bool enabled;
+  final String? sourceAccountId;
+  final String? lastEvaluatedAt;
+  final String? lastMatchedAt;
+  final int matchCountLastRun;
+  final Map<String, dynamic>? previewSample;
   final String createdAt;
   final String updatedAt;
 
@@ -25,11 +37,17 @@ class AutomationRule {
     return AutomationRule(
       id: json['id'] as String,
       name: json['name'] as String,
-      triggerType: json['triggerType'] as String,
+      source: json['source'] as String? ?? 'rhythm',
+      triggerKey: json['triggerKey'] as String,
       triggerConfig: json['triggerConfig'] as Map<String, dynamic>?,
       actionType: json['actionType'] as String,
       actionConfig: json['actionConfig'] as Map<String, dynamic>?,
       enabled: json['enabled'] as bool? ?? true,
+      sourceAccountId: json['sourceAccountId'] as String?,
+      lastEvaluatedAt: json['lastEvaluatedAt'] as String?,
+      lastMatchedAt: json['lastMatchedAt'] as String?,
+      matchCountLastRun: (json['matchCountLastRun'] as num?)?.toInt() ?? 0,
+      previewSample: json['previewSample'] as Map<String, dynamic>?,
       createdAt: json['createdAt'] as String,
       updatedAt: json['updatedAt'] as String,
     );
@@ -38,38 +56,18 @@ class AutomationRule {
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': name,
-        'triggerType': triggerType,
+        'source': source,
+        'triggerKey': triggerKey,
         if (triggerConfig != null) 'triggerConfig': triggerConfig,
         'actionType': actionType,
         if (actionConfig != null) 'actionConfig': actionConfig,
         'enabled': enabled,
+        if (sourceAccountId != null) 'sourceAccountId': sourceAccountId,
+        if (lastEvaluatedAt != null) 'lastEvaluatedAt': lastEvaluatedAt,
+        if (lastMatchedAt != null) 'lastMatchedAt': lastMatchedAt,
+        'matchCountLastRun': matchCountLastRun,
+        if (previewSample != null) 'previewSample': previewSample,
         'createdAt': createdAt,
         'updatedAt': updatedAt,
-      };
-
-  static const triggerTypes = [
-    'project_step_due',
-    'task_due',
-    'plan_assembly',
-  ];
-
-  static const actionTypes = [
-    'auto_schedule',
-    'send_notification',
-    'tag_task',
-  ];
-
-  static String triggerLabel(String type) => switch (type) {
-        'project_step_due' => 'Project step is due',
-        'task_due' => 'Task is due',
-        'plan_assembly' => 'Plan is assembled',
-        _ => type,
-      };
-
-  static String actionLabel(String type) => switch (type) {
-        'auto_schedule' => 'Auto-schedule to day',
-        'send_notification' => 'Send notification',
-        'tag_task' => 'Tag task',
-        _ => type,
       };
 }

--- a/apps/desktop_flutter/lib/features/tasks/models/automation_rule.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/automation_rule.dart
@@ -33,12 +33,20 @@ class AutomationRule {
   final String createdAt;
   final String updatedAt;
 
+  String get triggerType => switch (triggerKey) {
+        'rhythm.project_step_due' => 'project_step_due',
+        'rhythm.task_due' => 'task_due',
+        'rhythm.plan_assembly' => 'plan_assembly',
+        _ => triggerKey,
+      };
+
   factory AutomationRule.fromJson(Map<String, dynamic> json) {
     return AutomationRule(
       id: json['id'] as String,
       name: json['name'] as String,
       source: json['source'] as String? ?? 'rhythm',
-      triggerKey: json['triggerKey'] as String,
+      triggerKey: (json['triggerKey'] as String?) ??
+          _legacyTriggerKey(json['triggerType'] as String?),
       triggerConfig: json['triggerConfig'] as Map<String, dynamic>?,
       actionType: json['actionType'] as String,
       actionConfig: json['actionConfig'] as Map<String, dynamic>?,
@@ -69,5 +77,41 @@ class AutomationRule {
         if (previewSample != null) 'previewSample': previewSample,
         'createdAt': createdAt,
         'updatedAt': updatedAt,
+      };
+
+  static String _legacyTriggerKey(String? triggerType) => switch (triggerType) {
+        'project_step_due' => 'rhythm.project_step_due',
+        'task_due' => 'rhythm.task_due',
+        'plan_assembly' => 'rhythm.plan_assembly',
+        _ => triggerType ?? 'rhythm.task_due',
+      };
+
+  static String triggerLabel(String type) => switch (type) {
+        'project_step_due' => 'Project step is due',
+        'rhythm.project_step_due' => 'Project step is due',
+        'task_due' => 'Task is due',
+        'rhythm.task_due' => 'Task is due',
+        'plan_assembly' => 'Plan is assembled',
+        'rhythm.plan_assembly' => 'Plan is assembled',
+        'planning_center.plan_person_declined' => 'Volunteer declined',
+        'planning_center.plan_person_unconfirmed' => 'Volunteer unconfirmed',
+        'planning_center.needed_position_open' => 'Needed position open',
+        'planning_center.special_service_candidate' =>
+          'Special service candidate',
+        'google_calendar.event_matching_filter' => 'Calendar event matches filter',
+        'google_calendar.all_day_event' => 'All-day calendar event',
+        'gmail.message_matching_filter' => 'Gmail message matches filter',
+        'gmail.unread_message_matching_filter' =>
+          'Unread Gmail message matches filter',
+        _ => type,
+      };
+
+  static String actionLabel(String type) => switch (type) {
+        'create_task' => 'Create task',
+        'create_project_from_template' => 'Create project from template',
+        'auto_schedule' => 'Auto-schedule to day',
+        'send_notification' => 'Send notification',
+        'tag_task' => 'Tag task',
+        _ => type,
       };
 }

--- a/apps/desktop_flutter/lib/features/tasks/models/automation_rule.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/automation_rule.dart
@@ -98,7 +98,8 @@ class AutomationRule {
         'planning_center.needed_position_open' => 'Needed position open',
         'planning_center.special_service_candidate' =>
           'Special service candidate',
-        'google_calendar.event_matching_filter' => 'Calendar event matches filter',
+        'google_calendar.event_matching_filter' =>
+          'Calendar event matches filter',
         'google_calendar.all_day_event' => 'All-day calendar event',
         'gmail.message_matching_filter' => 'Gmail message matches filter',
         'gmail.unread_message_matching_filter' =>

--- a/apps/desktop_flutter/lib/features/tasks/repositories/automation_rules_repository.dart
+++ b/apps/desktop_flutter/lib/features/tasks/repositories/automation_rules_repository.dart
@@ -1,4 +1,7 @@
+import '../../integrations/models/integration_account.dart';
+import '../../integrations/models/planning_center_task_options.dart';
 import '../data/automation_rules_data_source.dart';
+import '../models/automation_catalog.dart';
 import '../models/automation_rule.dart';
 
 class AutomationRulesRepository {
@@ -7,40 +10,59 @@ class AutomationRulesRepository {
   final AutomationRulesDataSource _dataSource;
 
   Future<List<AutomationRule>> getAll() => _dataSource.fetchAll();
+  Future<List<AutomationTriggerCatalogItem>> getTriggers() =>
+      _dataSource.fetchTriggers();
+  Future<List<AutomationActionCatalogItem>> getActions() =>
+      _dataSource.fetchActions();
+  Future<List<AutomationProviderCatalogItem>> getProviders() =>
+      _dataSource.fetchProviders();
+  Future<List<IntegrationAccount>> getAccounts() => _dataSource.fetchAccounts();
+  Future<PlanningCenterTaskOptions?> getPlanningCenterTaskOptions() =>
+      _dataSource.fetchPlanningCenterTaskOptions();
+  Future<AutomationRulePreview> getPreview(String id) =>
+      _dataSource.fetchPreview(id);
 
   Future<AutomationRule> create({
     required String name,
-    required String triggerType,
+    required String source,
+    required String triggerKey,
     required String actionType,
     Map<String, dynamic>? triggerConfig,
     Map<String, dynamic>? actionConfig,
+    String? sourceAccountId,
     bool enabled = true,
   }) =>
       _dataSource.create(
         name: name,
-        triggerType: triggerType,
+        source: source,
+        triggerKey: triggerKey,
         actionType: actionType,
         triggerConfig: triggerConfig,
         actionConfig: actionConfig,
+        sourceAccountId: sourceAccountId,
         enabled: enabled,
       );
 
   Future<AutomationRule> update(
     String id, {
     String? name,
-    String? triggerType,
+    String? source,
+    String? triggerKey,
     String? actionType,
     Map<String, dynamic>? triggerConfig,
     Map<String, dynamic>? actionConfig,
+    String? sourceAccountId,
     bool? enabled,
   }) =>
       _dataSource.update(
         id,
         name: name,
-        triggerType: triggerType,
+        source: source,
+        triggerKey: triggerKey,
         actionType: actionType,
         triggerConfig: triggerConfig,
         actionConfig: actionConfig,
+        sourceAccountId: sourceAccountId,
         enabled: enabled,
       );
 

--- a/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
@@ -5,6 +5,7 @@ import '../../../app/core/widgets/error_banner.dart';
 import '../../integrations/models/integration_account.dart';
 import '../../integrations/models/planning_center_task_options.dart';
 import '../controllers/automation_rules_controller.dart';
+import '../data/automation_rules_data_source.dart';
 import '../models/automation_catalog.dart';
 import '../models/automation_rule.dart';
 
@@ -16,6 +17,13 @@ class AutomationRulesView extends StatefulWidget {
 }
 
 class _AutomationRulesViewState extends State<AutomationRulesView> {
+  static const List<String> _sourceOrder = [
+    'rhythm',
+    'planning_center',
+    'google_calendar',
+    'gmail',
+  ];
+
   @override
   void initState() {
     super.initState();
@@ -32,6 +40,14 @@ class _AutomationRulesViewState extends State<AutomationRulesView> {
         for (final rule in controller.rules) {
           grouped.putIfAbsent(rule.source, () => []).add(rule);
         }
+        final orderedEntries = grouped.entries.toList()
+          ..sort((a, b) {
+            final left = _sourceOrder.indexOf(a.key);
+            final right = _sourceOrder.indexOf(b.key);
+            final leftIndex = left == -1 ? _sourceOrder.length : left;
+            final rightIndex = right == -1 ? _sourceOrder.length : right;
+            return leftIndex.compareTo(rightIndex);
+          });
 
         return Scaffold(
           backgroundColor: const Color(0xFFF6F8FB),
@@ -40,8 +56,9 @@ class _AutomationRulesViewState extends State<AutomationRulesView> {
             children: [
               _OverviewHeader(
                 ruleCount: controller.rules.length,
-                providerCount:
-                    controller.accounts.where((account) => account.connected).length,
+                providerCount: controller.accounts
+                    .where((account) => account.connected)
+                    .length,
                 enabledCount:
                     controller.rules.where((rule) => rule.enabled).length,
                 latestSync: _latestSync(controller.accounts),
@@ -63,7 +80,7 @@ class _AutomationRulesViewState extends State<AutomationRulesView> {
                           )
                         : ListView(
                             padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
-                            children: grouped.entries
+                            children: orderedEntries
                                 .map(
                                   (entry) => _RuleGroup(
                                     source: entry.key,
@@ -124,6 +141,22 @@ class _AutomationRulesViewState extends State<AutomationRulesView> {
       triggerConfig: result.triggerConfig,
       actionConfig: result.actionConfig,
       sourceAccountId: result.sourceAccountId,
+    );
+  }
+
+  Future<void> _openPreview(
+    BuildContext context,
+    AutomationRulesController controller,
+    AutomationRule rule,
+  ) async {
+    await controller.loadPreview(rule.id);
+    if (!context.mounted) return;
+    await showDialog<void>(
+      context: context,
+      builder: (context) => _AutomationPreviewDialog(
+        rule: rule,
+        preview: controller.selectedPreview,
+      ),
     );
   }
 }
@@ -190,7 +223,9 @@ class _OverviewHeader extends StatelessWidget {
               _StatCard(label: 'Connected providers', value: '$providerCount'),
               _StatCard(
                 label: 'Latest sync',
-                value: latestSync == null ? 'Never' : latestSync!.replaceFirst('T', ' '),
+                value: latestSync == null
+                    ? 'Never'
+                    : latestSync!.replaceFirst('T', ' '),
               ),
             ],
           ),
@@ -313,6 +348,9 @@ class _RuleGroup extends StatelessWidget {
                 onEdit: () => context
                     .findAncestorStateOfType<_AutomationRulesViewState>()
                     ?._openBuilder(context, controller, existing: rule),
+                onInspect: () => context
+                    .findAncestorStateOfType<_AutomationRulesViewState>()
+                    ?._openPreview(context, controller, rule),
                 onDelete: () => controller.deleteRule(rule.id),
                 onToggle: () => controller.toggleEnabled(rule.id),
               ),
@@ -331,6 +369,7 @@ class _RuleCard extends StatelessWidget {
     required this.trigger,
     required this.action,
     required this.onEdit,
+    required this.onInspect,
     required this.onDelete,
     required this.onToggle,
   });
@@ -340,6 +379,7 @@ class _RuleCard extends StatelessWidget {
   final AutomationTriggerCatalogItem? trigger;
   final AutomationActionCatalogItem? action;
   final VoidCallback onEdit;
+  final VoidCallback onInspect;
   final VoidCallback onDelete;
   final VoidCallback onToggle;
 
@@ -355,69 +395,83 @@ class _RuleCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(12),
         side: const BorderSide(color: Color(0xFFE5E7EB)),
       ),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Switch(value: rule.enabled, onChanged: (_) => onToggle()),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(rule.name,
-                      style: const TextStyle(
-                          fontSize: 15, fontWeight: FontWeight.w700)),
-                  const SizedBox(height: 6),
-                  Text(
-                    '${trigger?.label ?? rule.triggerKey} -> ${action?.label ?? rule.actionType}',
-                    style: const TextStyle(color: Color(0xFF2563EB)),
-                  ),
-                  const SizedBox(height: 8),
-                  Wrap(
-                    spacing: 10,
-                    runSpacing: 8,
-                    children: [
-                      _MetaChip(
-                        icon: Icons.account_circle_outlined,
-                        label: accountLabel,
-                      ),
-                      _MetaChip(
-                        icon: Icons.sync,
-                        label: account?.connected == true
-                            ? 'Connected'
-                            : rule.source == 'rhythm'
-                                ? 'Internal'
-                                : 'Disconnected',
-                      ),
-                      _MetaChip(
-                        icon: Icons.bolt_outlined,
-                        label: rule.lastMatchedAt == null
-                            ? 'No recent matches'
-                            : '${rule.matchCountLastRun} match(es)',
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onInspect,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Switch(value: rule.enabled, onChanged: (_) => onToggle()),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(rule.name,
+                        style: const TextStyle(
+                            fontSize: 15, fontWeight: FontWeight.w700)),
+                    const SizedBox(height: 6),
+                    Text(
+                      '${trigger?.label ?? rule.triggerKey} -> ${action?.label ?? rule.actionType}',
+                      style: const TextStyle(color: Color(0xFF2563EB)),
+                    ),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 10,
+                      runSpacing: 8,
+                      children: [
+                        _MetaChip(
+                          icon: Icons.account_circle_outlined,
+                          label: accountLabel,
+                        ),
+                        _MetaChip(
+                          icon: Icons.sync,
+                          label: account?.connected == true
+                              ? 'Connected'
+                              : rule.source == 'rhythm'
+                                  ? 'Internal'
+                                  : 'Disconnected',
+                        ),
+                        _MetaChip(
+                          icon: Icons.bolt_outlined,
+                          label: rule.lastMatchedAt == null
+                              ? 'No recent matches'
+                              : '${rule.matchCountLastRun} match(es)',
+                        ),
+                        _MetaChip(
+                          icon: Icons.schedule_outlined,
+                          label: rule.lastEvaluatedAt == null
+                              ? 'Not evaluated yet'
+                              : 'Evaluated ${_formatStamp(rule.lastEvaluatedAt!)}',
+                        ),
+                      ],
+                    ),
+                    if (rule.previewSample != null) ...[
+                      const SizedBox(height: 10),
+                      Text(
+                        _previewLabel(rule.previewSample!),
+                        style: const TextStyle(color: Colors.black54),
                       ),
                     ],
-                  ),
-                  if (rule.previewSample != null) ...[
-                    const SizedBox(height: 10),
-                    Text(
-                      _previewLabel(rule.previewSample!),
-                      style: const TextStyle(color: Colors.black54),
-                    ),
                   ],
-                ],
+                ),
               ),
-            ),
-            IconButton(
-              onPressed: onEdit,
-              icon: const Icon(Icons.edit_outlined),
-            ),
-            IconButton(
-              onPressed: onDelete,
-              icon: const Icon(Icons.delete_outline),
-            ),
-          ],
+              IconButton(
+                onPressed: onInspect,
+                icon: const Icon(Icons.visibility_outlined),
+              ),
+              IconButton(
+                onPressed: onEdit,
+                icon: const Icon(Icons.edit_outlined),
+              ),
+              IconButton(
+                onPressed: onDelete,
+                icon: const Icon(Icons.delete_outline),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -430,6 +484,89 @@ class _RuleCard extends StatelessWidget {
       preview['serviceTypeName'],
       preview['positionName'],
     ].whereType<Object>().join(' · ');
+  }
+}
+
+class _AutomationPreviewDialog extends StatelessWidget {
+  const _AutomationPreviewDialog({
+    required this.rule,
+    required this.preview,
+  });
+
+  final AutomationRule rule;
+  final AutomationRulePreview? preview;
+
+  @override
+  Widget build(BuildContext context) {
+    final summary = preview?.summary ??
+        'No preview summary is available yet for this automation.';
+    final sample = preview?.previewSample ?? rule.previewSample;
+    return AlertDialog(
+      title: Text(rule.name),
+      content: SizedBox(
+        width: 520,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(summary),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                _MetaChip(
+                  icon: Icons.bolt_outlined,
+                  label: preview?.matchCountLastRun == null
+                      ? 'No recent run'
+                      : '${preview!.matchCountLastRun} match(es) last run',
+                ),
+                _MetaChip(
+                  icon: Icons.schedule_outlined,
+                  label: preview?.lastEvaluatedAt == null
+                      ? 'Never evaluated'
+                      : 'Evaluated ${_formatStamp(preview!.lastEvaluatedAt!)}',
+                ),
+                _MetaChip(
+                  icon: Icons.history_toggle_off,
+                  label: preview?.lastMatchedAt == null
+                      ? 'No recent match'
+                      : 'Matched ${_formatStamp(preview!.lastMatchedAt!)}',
+                ),
+              ],
+            ),
+            if (sample != null) ...[
+              const SizedBox(height: 16),
+              const Text(
+                'Latest sample',
+                style: TextStyle(fontWeight: FontWeight.w700),
+              ),
+              const SizedBox(height: 8),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFF8FAFC),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  sample.entries
+                      .where((entry) => entry.value != null)
+                      .map((entry) => '${entry.key}: ${entry.value}')
+                      .join('\n'),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Close'),
+        ),
+      ],
+    );
   }
 }
 
@@ -516,6 +653,7 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
   int? _hoursSinceReceived;
   int? _targetDay;
   bool _allDayOnly = false;
+  String? _validationError;
 
   @override
   void initState() {
@@ -546,12 +684,15 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
     _tagController = TextEditingController(
       text: existing?.actionConfig?['tag']?.toString() ?? '',
     );
-    _selectedSource = existing?.source ?? widget.controller.providers.firstOrNull?.source;
+    _selectedSource =
+        existing?.source ?? widget.controller.providers.firstOrNull?.source;
     _selectedTriggerKey = existing?.triggerKey;
-    _selectedActionType = existing?.actionType ?? widget.controller.actions.firstOrNull?.key;
+    _selectedActionType =
+        existing?.actionType ?? widget.controller.actions.firstOrNull?.key;
     _selectedAccountId = existing?.sourceAccountId;
     _selectedTeamId = existing?.triggerConfig?['teamId']?.toString();
-    _selectedPositionName = existing?.triggerConfig?['positionName']?.toString();
+    _selectedPositionName =
+        existing?.triggerConfig?['positionName']?.toString();
     _selectedEventType = existing?.triggerConfig?['eventType']?.toString();
     _selectedLabel = existing?.triggerConfig?['label']?.toString();
     _leadDays = (existing?.triggerConfig?['leadDays'] as num?)?.toInt();
@@ -561,6 +702,10 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
         (existing?.triggerConfig?['hoursSinceReceived'] as num?)?.toInt();
     _targetDay = (existing?.actionConfig?['targetDay'] as num?)?.toInt();
     _allDayOnly = existing?.triggerConfig?['allDayOnly'] == true;
+    _syncAccountSelectionWithSource();
+    if (existing == null && _nameController.text.trim().isEmpty) {
+      _nameController.text = _suggestedName();
+    }
   }
 
   @override
@@ -584,10 +729,12 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
         .toList();
     _selectedTriggerKey ??= triggers.firstOrNull?.key;
     _selectedActionType ??= widget.controller.actions.firstOrNull?.key;
-    final trigger = triggers.where((item) => item.key == _selectedTriggerKey).firstOrNull;
+    final trigger =
+        triggers.where((item) => item.key == _selectedTriggerKey).firstOrNull;
 
     return AlertDialog(
-      title: Text(widget.existing == null ? 'New automation' : 'Edit automation'),
+      title:
+          Text(widget.existing == null ? 'New automation' : 'Edit automation'),
       content: SizedBox(
         width: 620,
         child: SingleChildScrollView(
@@ -605,9 +752,9 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
               const SizedBox(height: 12),
               DropdownButtonFormField<String>(
                 value: _selectedSource,
-                decoration:
-                    const InputDecoration(labelText: 'Source', border: OutlineInputBorder()),
-                items: widget.controller.providers
+                decoration: const InputDecoration(
+                    labelText: 'Source', border: OutlineInputBorder()),
+                items: _availableProviders()
                     .map((item) => DropdownMenuItem(
                           value: item.source,
                           child: Text(item.label),
@@ -619,6 +766,8 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
                       .where((item) => item.source == value)
                       .firstOrNull
                       ?.key;
+                  _syncAccountSelectionWithSource();
+                  _populateSuggestedNameIfEmpty();
                 }),
               ),
               const SizedBox(height: 12),
@@ -642,8 +791,16 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
                                 item.provider),
                           )),
                 ],
-                onChanged: (value) => setState(() => _selectedAccountId = value),
+                onChanged: (value) =>
+                    setState(() => _selectedAccountId = value),
               ),
+              if (_selectedSource != null && _validationError != null) ...[
+                const SizedBox(height: 10),
+                Text(
+                  _validationError!,
+                  style: const TextStyle(color: Colors.redAccent),
+                ),
+              ],
               const SizedBox(height: 18),
               _stepTitle('2. Trigger'),
               DropdownButtonFormField<String>(
@@ -658,7 +815,10 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
                           child: Text(item.label),
                         ))
                     .toList(),
-                onChanged: (value) => setState(() => _selectedTriggerKey = value),
+                onChanged: (value) => setState(() {
+                  _selectedTriggerKey = value;
+                  _populateSuggestedNameIfEmpty();
+                }),
               ),
               if (trigger != null) ...[
                 const SizedBox(height: 8),
@@ -681,7 +841,10 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
                           child: Text(item.label),
                         ))
                     .toList(),
-                onChanged: (value) => setState(() => _selectedActionType = value),
+                onChanged: (value) => setState(() {
+                  _selectedActionType = value;
+                  _populateSuggestedNameIfEmpty();
+                }),
               ),
               const SizedBox(height: 12),
               ..._buildActionFields(),
@@ -707,11 +870,15 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
         ),
         FilledButton(
           onPressed: () {
-            final name = _nameController.text.trim();
-            if (name.isEmpty ||
-                _selectedSource == null ||
+            final name = _nameController.text.trim().isEmpty
+                ? _suggestedName()
+                : _nameController.text.trim();
+            final validationError = _validateDraft();
+            setState(() => _validationError = validationError);
+            if (_selectedSource == null ||
                 _selectedTriggerKey == null ||
-                _selectedActionType == null) {
+                _selectedActionType == null ||
+                validationError != null) {
               return;
             }
             Navigator.pop(
@@ -810,7 +977,8 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
             border: OutlineInputBorder(),
           ),
           items: const [
-            DropdownMenuItem<String>(value: null, child: Text('Any event type')),
+            DropdownMenuItem<String>(
+                value: null, child: Text('Any event type')),
             DropdownMenuItem<String>(value: 'default', child: Text('Default')),
             DropdownMenuItem<String>(
                 value: 'focusTime', child: Text('Focus time')),
@@ -875,6 +1043,20 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
       ];
     }
     return const [];
+  }
+
+  void _populateSuggestedNameIfEmpty() {
+    if (widget.existing != null) return;
+    if (_nameController.text.trim().isNotEmpty) return;
+    _nameController.text = _suggestedName();
+  }
+
+  String _suggestedName() {
+    return widget.controller.triggers
+            .where((item) => item.key == _selectedTriggerKey)
+            .firstOrNull
+            ?.label ??
+        _labelForSource(_selectedSource);
   }
 
   List<Widget> _buildActionFields() {
@@ -952,7 +1134,9 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
     final config = <String, dynamic>{};
     if (_leadDays != null) config['leadDays'] = _leadDays;
     if (_selectedTeamId != null) config['teamId'] = _selectedTeamId;
-    if (_selectedPositionName != null) config['positionName'] = _selectedPositionName;
+    if (_selectedPositionName != null) {
+      config['positionName'] = _selectedPositionName;
+    }
     if (_textQueryController.text.trim().isNotEmpty) {
       config['textQuery'] = _textQueryController.text.trim();
     }
@@ -1000,7 +1184,80 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
             .firstOrNull
             ?.label ??
         (_selectedActionType ?? 'Action');
-    return 'When $triggerLabel from ${_labelForSource(_selectedSource)} then $actionLabel.';
+    final accountLabel = _selectedAccountId == null
+        ? (_selectedSource == 'rhythm' ? 'Rhythm' : 'default connected account')
+        : widget.controller.accounts
+                .where((item) => item.id == _selectedAccountId)
+                .firstOrNull
+                ?.accountLabel ??
+            'selected account';
+    final filters = _buildTriggerConfig();
+    final filterSummary = filters == null || filters.isEmpty
+        ? 'with no extra filters'
+        : 'with ${filters.entries.map((entry) => '${entry.key}: ${entry.value}').join(', ')}';
+    return 'When $triggerLabel from ${_labelForSource(_selectedSource)} on $accountLabel, $filterSummary, then $actionLabel.';
+  }
+
+  List<AutomationProviderCatalogItem> _availableProviders() {
+    final connectedSources = widget.controller.accounts
+        .where((account) => account.connected)
+        .map((account) => account.provider)
+        .toSet();
+    final providers = widget.controller.providers.where((provider) {
+      if (provider.source == 'rhythm') return true;
+      if (provider.source == widget.existing?.source) return true;
+      return connectedSources.contains(provider.source);
+    }).toList();
+    final existingSource = widget.existing?.source;
+    if (existingSource != null &&
+        providers.every((provider) => provider.source != existingSource)) {
+      providers.add(
+        AutomationProviderCatalogItem(
+          source: existingSource,
+          label: _labelForSource(existingSource),
+          description: 'Previously configured provider',
+          syncSupport: 'manual',
+          triggerKeys: const [],
+        ),
+      );
+    }
+    return providers;
+  }
+
+  void _syncAccountSelectionWithSource() {
+    if (_selectedSource == null || _selectedSource == 'rhythm') {
+      _selectedAccountId = null;
+      return;
+    }
+    final accounts = widget.controller.accounts
+        .where((account) =>
+            account.provider == _selectedSource && account.connected)
+        .toList();
+    if (accounts.any((account) => account.id == _selectedAccountId)) return;
+    _selectedAccountId = accounts.firstOrNull?.id;
+  }
+
+  String? _validateDraft() {
+    if (_selectedSource != null && _selectedSource != 'rhythm') {
+      final hasConnectedAccount = widget.controller.accounts.any(
+        (account) =>
+            account.provider == _selectedSource &&
+            account.connected &&
+            account.id == _selectedAccountId,
+      );
+      if (!hasConnectedAccount) {
+        return 'Connect ${_labelForSource(_selectedSource)} before creating this automation.';
+      }
+    }
+    if (_selectedActionType == 'create_project_from_template' &&
+        _templateNameController.text.trim().isEmpty) {
+      return 'Project automations need a template name.';
+    }
+    if (_selectedActionType == 'send_notification' &&
+        _messageTemplateController.text.trim().isEmpty) {
+      return 'Notification automations need a message template.';
+    }
+    return null;
   }
 
   List<String> _positionsForTeam(
@@ -1008,7 +1265,10 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
     String? teamId,
   ) {
     if (teamId == null) {
-      return options.positionsByTeamId.values.expand((item) => item).toSet().toList()
+      return options.positionsByTeamId.values
+          .expand((item) => item)
+          .toSet()
+          .toList()
         ..sort();
     }
     return options.positionsByTeamId[teamId] ?? const [];
@@ -1034,7 +1294,8 @@ class _IntegerDropdown extends StatelessWidget {
   Widget build(BuildContext context) {
     return DropdownButtonFormField<int>(
       value: value,
-      decoration: InputDecoration(labelText: label, border: const OutlineInputBorder()),
+      decoration:
+          InputDecoration(labelText: label, border: const OutlineInputBorder()),
       items: options
           .map((item) => DropdownMenuItem(
                 value: item,
@@ -1052,3 +1313,14 @@ String _labelForSource(String? source) => switch (source) {
       'gmail' => 'Gmail',
       _ => 'Rhythm',
     };
+
+String _formatStamp(String value) {
+  final parsed = DateTime.tryParse(value);
+  if (parsed == null) return value;
+  final local = parsed.toLocal();
+  final month = local.month.toString().padLeft(2, '0');
+  final day = local.day.toString().padLeft(2, '0');
+  final hour = local.hour.toString().padLeft(2, '0');
+  final minute = local.minute.toString().padLeft(2, '0');
+  return '$month/$day ${local.year} $hour:$minute';
+}

--- a/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-import '../controllers/automation_rules_controller.dart';
-import '../models/automation_rule.dart';
+
 import '../../../app/core/widgets/error_banner.dart';
+import '../../integrations/models/integration_account.dart';
+import '../../integrations/models/planning_center_task_options.dart';
+import '../controllers/automation_rules_controller.dart';
+import '../models/automation_catalog.dart';
+import '../models/automation_rule.dart';
 
 class AutomationRulesView extends StatefulWidget {
   const AutomationRulesView({super.key});
@@ -25,12 +28,25 @@ class _AutomationRulesViewState extends State<AutomationRulesView> {
   Widget build(BuildContext context) {
     return Consumer<AutomationRulesController>(
       builder: (context, controller, _) {
+        final grouped = <String, List<AutomationRule>>{};
+        for (final rule in controller.rules) {
+          grouped.putIfAbsent(rule.source, () => []).add(rule);
+        }
+
         return Scaffold(
-          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+          backgroundColor: const Color(0xFFF6F8FB),
           body: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              _Header(onAdd: () => _showCreateDialog(context, controller)),
+              _OverviewHeader(
+                ruleCount: controller.rules.length,
+                providerCount:
+                    controller.accounts.where((account) => account.connected).length,
+                enabledCount:
+                    controller.rules.where((rule) => rule.enabled).length,
+                latestSync: _latestSync(controller.accounts),
+                onCreate: () => _openBuilder(context, controller),
+              ),
               if (controller.status == AutomationRulesStatus.error &&
                   controller.errorMessage != null)
                 ErrorBanner(
@@ -43,19 +59,19 @@ class _AutomationRulesViewState extends State<AutomationRulesView> {
                     ? const Center(child: CircularProgressIndicator())
                     : controller.rules.isEmpty
                         ? _EmptyState(
-                            onAdd: () => _showCreateDialog(context, controller))
-                        : ListView.builder(
-                            padding: const EdgeInsets.all(24),
-                            itemCount: controller.rules.length,
-                            itemBuilder: (context, i) => _RuleCard(
-                              rule: controller.rules[i],
-                              onToggle: () => controller
-                                  .toggleEnabled(controller.rules[i].id),
-                              onDelete: () =>
-                                  controller.deleteRule(controller.rules[i].id),
-                              onEdit: () => _showEditDialog(
-                                  context, controller, controller.rules[i]),
-                            ),
+                            onCreate: () => _openBuilder(context, controller),
+                          )
+                        : ListView(
+                            padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
+                            children: grouped.entries
+                                .map(
+                                  (entry) => _RuleGroup(
+                                    source: entry.key,
+                                    rules: entry.value,
+                                    controller: controller,
+                                  ),
+                                )
+                                .toList(),
                           ),
               ),
             ],
@@ -65,419 +81,118 @@ class _AutomationRulesViewState extends State<AutomationRulesView> {
     );
   }
 
-  Future<void> _showCreateDialog(
-      BuildContext context, AutomationRulesController controller) async {
-    final nameCtrl = TextEditingController();
-    String selectedTrigger = AutomationRule.triggerTypes.first;
-    String selectedAction = AutomationRule.actionTypes.first;
-    final triggerConfigCtrls = <String, TextEditingController>{};
-    final actionConfigCtrls = <String, TextEditingController>{};
-    int? daysBeforeDue;
-    int? targetDay;
+  String? _latestSync(List<IntegrationAccount> accounts) {
+    final values = accounts
+        .map((account) => account.lastSyncedAt)
+        .whereType<String>()
+        .toList()
+      ..sort();
+    return values.isEmpty ? null : values.last;
+  }
 
-    await showDialog<void>(
+  Future<void> _openBuilder(
+    BuildContext context,
+    AutomationRulesController controller, {
+    AutomationRule? existing,
+  }) async {
+    final result = await showDialog<_AutomationDraft>(
       context: context,
-      builder: (dialogContext) => StatefulBuilder(
-        builder: (ctx, setDialogState) => AlertDialog(
-          title: const Text('New Automation Rule'),
-          content: SizedBox(
-            width: 420,
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  TextField(
-                    controller: nameCtrl,
-                    decoration: const InputDecoration(
-                      labelText: 'Rule name',
-                      border: OutlineInputBorder(),
-                    ),
-                    autofocus: true,
-                  ),
-                  const SizedBox(height: 16),
-                  const Text('When\u2026',
-                      style: TextStyle(fontWeight: FontWeight.w600)),
-                  const SizedBox(height: 8),
-                  DropdownButtonFormField<String>(
-                    value: selectedTrigger,
-                    decoration:
-                        const InputDecoration(border: OutlineInputBorder()),
-                    items: AutomationRule.triggerTypes
-                        .map((t) => DropdownMenuItem(
-                              value: t,
-                              child: Text(AutomationRule.triggerLabel(t)),
-                            ))
-                        .toList(),
-                    onChanged: (v) => setDialogState(() {
-                      selectedTrigger = v ?? selectedTrigger;
-                      daysBeforeDue = null;
-                      triggerConfigCtrls.forEach((_, c) => c.dispose());
-                      triggerConfigCtrls.clear();
-                    }),
-                  ),
-                  ..._buildTriggerConfigFields(
-                    selectedTrigger,
-                    triggerConfigCtrls,
-                    daysBeforeDue,
-                    (v) => setDialogState(() => daysBeforeDue = v),
-                    setDialogState,
-                  ),
-                  const SizedBox(height: 16),
-                  const Text('Then\u2026',
-                      style: TextStyle(fontWeight: FontWeight.w600)),
-                  const SizedBox(height: 8),
-                  DropdownButtonFormField<String>(
-                    value: selectedAction,
-                    decoration:
-                        const InputDecoration(border: OutlineInputBorder()),
-                    items: AutomationRule.actionTypes
-                        .map((a) => DropdownMenuItem(
-                              value: a,
-                              child: Text(AutomationRule.actionLabel(a)),
-                            ))
-                        .toList(),
-                    onChanged: (v) => setDialogState(() {
-                      selectedAction = v ?? selectedAction;
-                      targetDay = null;
-                      actionConfigCtrls.forEach((_, c) => c.dispose());
-                      actionConfigCtrls.clear();
-                    }),
-                  ),
-                  ..._buildActionConfigFields(
-                    selectedAction,
-                    actionConfigCtrls,
-                    targetDay,
-                    (v) => setDialogState(() => targetDay = v),
-                    setDialogState,
-                  ),
-                ],
-              ),
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(dialogContext),
-              child: const Text('Cancel'),
-            ),
-            FilledButton(
-              onPressed: () async {
-                final name = nameCtrl.text.trim();
-                if (name.isEmpty) return;
-                final triggerConfig = _buildTriggerConfig(
-                    selectedTrigger, triggerConfigCtrls, daysBeforeDue);
-                final actionConfig = _buildActionConfig(
-                    selectedAction, actionConfigCtrls, targetDay);
-                Navigator.pop(dialogContext);
-                await controller.createRule(
-                  name: name,
-                  triggerType: selectedTrigger,
-                  actionType: selectedAction,
-                  triggerConfig: triggerConfig.isEmpty ? null : triggerConfig,
-                  actionConfig: actionConfig.isEmpty ? null : actionConfig,
-                );
-              },
-              child: const Text('Create'),
-            ),
-          ],
-        ),
+      builder: (context) => _AutomationBuilderDialog(
+        controller: controller,
+        existing: existing,
       ),
     );
-
-    nameCtrl.dispose();
-    triggerConfigCtrls.forEach((_, c) => c.dispose());
-    actionConfigCtrls.forEach((_, c) => c.dispose());
-  }
-
-  Future<void> _showEditDialog(BuildContext context,
-      AutomationRulesController controller, AutomationRule rule) async {
-    final nameCtrl = TextEditingController(text: rule.name);
-    String selectedTrigger = rule.triggerType;
-    String selectedAction = rule.actionType;
-    final triggerConfigCtrls = <String, TextEditingController>{};
-    final actionConfigCtrls = <String, TextEditingController>{};
-
-    // Pre-populate config values from the existing rule
-    int? daysBeforeDue =
-        (rule.triggerConfig?['daysBeforeDue'] as num?)?.toInt();
-    int? targetDay = (rule.actionConfig?['targetDay'] as num?)?.toInt();
-
-    // Pre-populate text controllers for action config
-    if (rule.actionConfig?['message'] != null) {
-      actionConfigCtrls['message'] =
-          TextEditingController(text: rule.actionConfig!['message'] as String);
+    if (result == null) return;
+    if (existing == null) {
+      await controller.createRule(
+        name: result.name,
+        source: result.source,
+        triggerKey: result.triggerKey,
+        actionType: result.actionType,
+        triggerConfig: result.triggerConfig,
+        actionConfig: result.actionConfig,
+        sourceAccountId: result.sourceAccountId,
+      );
+      return;
     }
-    if (rule.actionConfig?['tag'] != null) {
-      actionConfigCtrls['tag'] =
-          TextEditingController(text: rule.actionConfig!['tag'] as String);
-    }
-
-    await showDialog<void>(
-      context: context,
-      builder: (dialogContext) => StatefulBuilder(
-        builder: (ctx, setDialogState) => AlertDialog(
-          title: const Text('Edit Automation Rule'),
-          content: SizedBox(
-            width: 420,
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  TextField(
-                    controller: nameCtrl,
-                    decoration: const InputDecoration(
-                      labelText: 'Rule name',
-                      border: OutlineInputBorder(),
-                    ),
-                    autofocus: true,
-                  ),
-                  const SizedBox(height: 16),
-                  const Text('When\u2026',
-                      style: TextStyle(fontWeight: FontWeight.w600)),
-                  const SizedBox(height: 8),
-                  DropdownButtonFormField<String>(
-                    value: selectedTrigger,
-                    decoration:
-                        const InputDecoration(border: OutlineInputBorder()),
-                    items: AutomationRule.triggerTypes
-                        .map((t) => DropdownMenuItem(
-                              value: t,
-                              child: Text(AutomationRule.triggerLabel(t)),
-                            ))
-                        .toList(),
-                    onChanged: (v) => setDialogState(() {
-                      selectedTrigger = v ?? selectedTrigger;
-                      daysBeforeDue = null;
-                      triggerConfigCtrls.forEach((_, c) => c.dispose());
-                      triggerConfigCtrls.clear();
-                    }),
-                  ),
-                  ..._buildTriggerConfigFields(
-                    selectedTrigger,
-                    triggerConfigCtrls,
-                    daysBeforeDue,
-                    (v) => setDialogState(() => daysBeforeDue = v),
-                    setDialogState,
-                  ),
-                  const SizedBox(height: 16),
-                  const Text('Then\u2026',
-                      style: TextStyle(fontWeight: FontWeight.w600)),
-                  const SizedBox(height: 8),
-                  DropdownButtonFormField<String>(
-                    value: selectedAction,
-                    decoration:
-                        const InputDecoration(border: OutlineInputBorder()),
-                    items: AutomationRule.actionTypes
-                        .map((a) => DropdownMenuItem(
-                              value: a,
-                              child: Text(AutomationRule.actionLabel(a)),
-                            ))
-                        .toList(),
-                    onChanged: (v) => setDialogState(() {
-                      selectedAction = v ?? selectedAction;
-                      targetDay = null;
-                      actionConfigCtrls.forEach((_, c) => c.dispose());
-                      actionConfigCtrls.clear();
-                    }),
-                  ),
-                  ..._buildActionConfigFields(
-                    selectedAction,
-                    actionConfigCtrls,
-                    targetDay,
-                    (v) => setDialogState(() => targetDay = v),
-                    setDialogState,
-                  ),
-                ],
-              ),
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(dialogContext),
-              child: const Text('Cancel'),
-            ),
-            FilledButton(
-              onPressed: () async {
-                final name = nameCtrl.text.trim();
-                if (name.isEmpty) return;
-                final triggerConfig = _buildTriggerConfig(
-                    selectedTrigger, triggerConfigCtrls, daysBeforeDue);
-                final actionConfig = _buildActionConfig(
-                    selectedAction, actionConfigCtrls, targetDay);
-                Navigator.pop(dialogContext);
-                await controller.updateRule(
-                  rule.id,
-                  name: name,
-                  triggerType: selectedTrigger,
-                  actionType: selectedAction,
-                  triggerConfig: triggerConfig.isEmpty ? null : triggerConfig,
-                  actionConfig: actionConfig.isEmpty ? null : actionConfig,
-                );
-              },
-              child: const Text('Save'),
-            ),
-          ],
-        ),
-      ),
+    await controller.updateRule(
+      existing.id,
+      name: result.name,
+      source: result.source,
+      triggerKey: result.triggerKey,
+      actionType: result.actionType,
+      triggerConfig: result.triggerConfig,
+      actionConfig: result.actionConfig,
+      sourceAccountId: result.sourceAccountId,
     );
-
-    nameCtrl.dispose();
-    triggerConfigCtrls.forEach((_, c) => c.dispose());
-    actionConfigCtrls.forEach((_, c) => c.dispose());
-  }
-
-  /// Returns config fields widgets for the chosen trigger type.
-  List<Widget> _buildTriggerConfigFields(
-    String triggerType,
-    Map<String, TextEditingController> ctrls,
-    int? daysBeforeDue,
-    ValueChanged<int?> onDaysChanged,
-    StateSetter setDialogState,
-  ) {
-    switch (triggerType) {
-      case 'task_due':
-      case 'project_step_due':
-        return [
-          const SizedBox(height: 12),
-          _IntegerField(
-            label: 'Days before due date',
-            value: daysBeforeDue,
-            onChanged: onDaysChanged,
-          ),
-        ];
-      default:
-        return [];
-    }
-  }
-
-  /// Returns config fields widgets for the chosen action type.
-  List<Widget> _buildActionConfigFields(
-    String actionType,
-    Map<String, TextEditingController> ctrls,
-    int? targetDay,
-    ValueChanged<int?> onDayChanged,
-    StateSetter setDialogState,
-  ) {
-    switch (actionType) {
-      case 'auto_schedule':
-        return [
-          const SizedBox(height: 12),
-          DropdownButtonFormField<int>(
-            value: targetDay,
-            decoration: const InputDecoration(
-              labelText: 'Schedule to day',
-              border: OutlineInputBorder(),
-            ),
-            items: const [
-              DropdownMenuItem(value: 0, child: Text('Sunday')),
-              DropdownMenuItem(value: 1, child: Text('Monday')),
-              DropdownMenuItem(value: 2, child: Text('Tuesday')),
-              DropdownMenuItem(value: 3, child: Text('Wednesday')),
-              DropdownMenuItem(value: 4, child: Text('Thursday')),
-              DropdownMenuItem(value: 5, child: Text('Friday')),
-              DropdownMenuItem(value: 6, child: Text('Saturday')),
-            ],
-            onChanged: (v) => setDialogState(() => onDayChanged(v)),
-          ),
-        ];
-      case 'send_notification':
-        ctrls.putIfAbsent('message', () => TextEditingController());
-        return [
-          const SizedBox(height: 12),
-          TextField(
-            controller: ctrls['message'],
-            decoration: const InputDecoration(
-              labelText: 'Notification message (optional)',
-              border: OutlineInputBorder(),
-            ),
-          ),
-        ];
-      case 'tag_task':
-        ctrls.putIfAbsent('tag', () => TextEditingController());
-        return [
-          const SizedBox(height: 12),
-          TextField(
-            controller: ctrls['tag'],
-            decoration: const InputDecoration(
-              labelText: 'Tag name',
-              border: OutlineInputBorder(),
-            ),
-          ),
-        ];
-      default:
-        return [];
-    }
-  }
-
-  Map<String, dynamic> _buildTriggerConfig(
-    String triggerType,
-    Map<String, TextEditingController> ctrls,
-    int? daysBeforeDue,
-  ) {
-    switch (triggerType) {
-      case 'task_due':
-      case 'project_step_due':
-        return {'daysBeforeDue': daysBeforeDue ?? 0};
-      default:
-        return {};
-    }
-  }
-
-  Map<String, dynamic> _buildActionConfig(
-    String actionType,
-    Map<String, TextEditingController> ctrls,
-    int? targetDay,
-  ) {
-    switch (actionType) {
-      case 'auto_schedule':
-        if (targetDay != null) return {'targetDay': targetDay};
-        return {};
-      case 'send_notification':
-        final msg = ctrls['message']?.text.trim() ?? '';
-        if (msg.isNotEmpty) return {'message': msg};
-        return {};
-      case 'tag_task':
-        final tag = ctrls['tag']?.text.trim() ?? '';
-        if (tag.isNotEmpty) return {'tag': tag};
-        return {};
-      default:
-        return {};
-    }
   }
 }
 
-class _Header extends StatelessWidget {
-  const _Header({required this.onAdd});
-  final VoidCallback onAdd;
+class _OverviewHeader extends StatelessWidget {
+  const _OverviewHeader({
+    required this.ruleCount,
+    required this.providerCount,
+    required this.enabledCount,
+    required this.latestSync,
+    required this.onCreate,
+  });
+
+  final int ruleCount;
+  final int providerCount;
+  final int enabledCount;
+  final String? latestSync;
+  final VoidCallback onCreate;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+      padding: const EdgeInsets.fromLTRB(24, 24, 24, 16),
       decoration: const BoxDecoration(
         color: Colors.white,
         border: Border(bottom: BorderSide(color: Color(0xFFE5E7EB))),
       ),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Automations',
-                    style:
-                        TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-                SizedBox(height: 2),
-                Text('Rules that apply during weekly plan assembly',
-                    style: TextStyle(color: Colors.black54, fontSize: 13)),
-              ],
-            ),
+          Row(
+            children: [
+              const Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Automations',
+                      style:
+                          TextStyle(fontSize: 24, fontWeight: FontWeight.w700),
+                    ),
+                    SizedBox(height: 4),
+                    Text(
+                      'Create sync-driven automations from Planning Center, Calendar, Gmail, and Rhythm.',
+                      style: TextStyle(color: Colors.black54),
+                    ),
+                  ],
+                ),
+              ),
+              FilledButton.icon(
+                onPressed: onCreate,
+                icon: const Icon(Icons.add, size: 18),
+                label: const Text('New automation'),
+              ),
+            ],
           ),
-          FilledButton.icon(
-            onPressed: onAdd,
-            icon: const Icon(Icons.add, size: 18),
-            label: const Text('New Rule'),
+          const SizedBox(height: 16),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              _StatCard(label: 'Rules', value: '$ruleCount'),
+              _StatCard(label: 'Enabled', value: '$enabledCount'),
+              _StatCard(label: 'Connected providers', value: '$providerCount'),
+              _StatCard(
+                label: 'Latest sync',
+                value: latestSync == null ? 'Never' : latestSync!.replaceFirst('T', ' '),
+              ),
+            ],
           ),
         ],
       ),
@@ -485,9 +200,40 @@ class _Header extends StatelessWidget {
   }
 }
 
+class _StatCard extends StatelessWidget {
+  const _StatCard({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 180,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFFE2E8F0)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(label, style: const TextStyle(color: Colors.black54)),
+          const SizedBox(height: 6),
+          Text(value,
+              style:
+                  const TextStyle(fontSize: 18, fontWeight: FontWeight.w700)),
+        ],
+      ),
+    );
+  }
+}
+
 class _EmptyState extends StatelessWidget {
-  const _EmptyState({required this.onAdd});
-  final VoidCallback onAdd;
+  const _EmptyState({required this.onCreate});
+
+  final VoidCallback onCreate;
 
   @override
   Widget build(BuildContext context) {
@@ -495,18 +241,82 @@ class _EmptyState extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(Icons.auto_awesome, size: 48, color: Colors.grey[400]),
+          Icon(Icons.bolt_outlined, size: 52, color: Colors.grey[400]),
           const SizedBox(height: 16),
-          const Text('No automation rules yet',
-              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500)),
+          const Text(
+            'No automations yet',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+          ),
           const SizedBox(height: 8),
-          Text('Rules run automatically during plan assembly',
-              style: TextStyle(color: Colors.grey[600])),
-          const SizedBox(height: 24),
+          Text(
+            'Connect providers, sync data, and create rules from external metadata.',
+            style: TextStyle(color: Colors.grey[600]),
+          ),
+          const SizedBox(height: 20),
           FilledButton.icon(
-            onPressed: onAdd,
-            icon: const Icon(Icons.add, size: 18),
-            label: const Text('Create your first rule'),
+            onPressed: onCreate,
+            icon: const Icon(Icons.add),
+            label: const Text('Create automation'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RuleGroup extends StatelessWidget {
+  const _RuleGroup({
+    required this.source,
+    required this.rules,
+    required this.controller,
+  });
+
+  final String source;
+  final List<AutomationRule> rules;
+  final AutomationRulesController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final account = controller.accounts
+        .where((item) => item.provider == source)
+        .cast<IntegrationAccount?>()
+        .firstOrNull;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            _labelForSource(source),
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            account == null
+                ? 'Internal Rhythm rules'
+                : '${account.accountLabel ?? account.providerDisplayName ?? account.provider} · ${account.syncSupportMode ?? 'manual'} sync',
+            style: const TextStyle(color: Colors.black54),
+          ),
+          const SizedBox(height: 12),
+          ...rules.map(
+            (rule) => Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: _RuleCard(
+                rule: rule,
+                account: account,
+                trigger: controller.triggers
+                    .where((item) => item.key == rule.triggerKey)
+                    .firstOrNull,
+                action: controller.actions
+                    .where((item) => item.key == rule.actionType)
+                    .firstOrNull,
+                onEdit: () => context
+                    .findAncestorStateOfType<_AutomationRulesViewState>()
+                    ?._openBuilder(context, controller, existing: rule),
+                onDelete: () => controller.deleteRule(rule.id),
+                onToggle: () => controller.toggleEnabled(rule.id),
+              ),
+            ),
           ),
         ],
       ),
@@ -517,30 +327,38 @@ class _EmptyState extends StatelessWidget {
 class _RuleCard extends StatelessWidget {
   const _RuleCard({
     required this.rule,
-    required this.onToggle,
-    required this.onDelete,
+    required this.account,
+    required this.trigger,
+    required this.action,
     required this.onEdit,
+    required this.onDelete,
+    required this.onToggle,
   });
 
   final AutomationRule rule;
-  final VoidCallback onToggle;
-  final VoidCallback onDelete;
+  final IntegrationAccount? account;
+  final AutomationTriggerCatalogItem? trigger;
+  final AutomationActionCatalogItem? action;
   final VoidCallback onEdit;
+  final VoidCallback onDelete;
+  final VoidCallback onToggle;
 
   @override
   Widget build(BuildContext context) {
-    final dimmed = !rule.enabled;
+    final accountLabel = account?.accountLabel ??
+        account?.providerDisplayName ??
+        _labelForSource(rule.source);
     return Card(
-      margin: const EdgeInsets.only(bottom: 12),
       elevation: 0,
+      color: Colors.white,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(12),
         side: const BorderSide(color: Color(0xFFE5E7EB)),
       ),
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        padding: const EdgeInsets.all(16),
         child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Switch(value: rule.enabled, onChanged: (_) => onToggle()),
             const SizedBox(width: 12),
@@ -548,126 +366,689 @@ class _RuleCard extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    rule.name,
-                    style: TextStyle(
-                      fontWeight: FontWeight.w600,
-                      fontSize: 14,
-                      color: dimmed ? Colors.grey : null,
-                    ),
-                  ),
+                  Text(rule.name,
+                      style: const TextStyle(
+                          fontSize: 15, fontWeight: FontWeight.w700)),
                   const SizedBox(height: 6),
-                  _IfThenRow(rule: rule, dimmed: dimmed),
+                  Text(
+                    '${trigger?.label ?? rule.triggerKey} -> ${action?.label ?? rule.actionType}',
+                    style: const TextStyle(color: Color(0xFF2563EB)),
+                  ),
+                  const SizedBox(height: 8),
+                  Wrap(
+                    spacing: 10,
+                    runSpacing: 8,
+                    children: [
+                      _MetaChip(
+                        icon: Icons.account_circle_outlined,
+                        label: accountLabel,
+                      ),
+                      _MetaChip(
+                        icon: Icons.sync,
+                        label: account?.connected == true
+                            ? 'Connected'
+                            : rule.source == 'rhythm'
+                                ? 'Internal'
+                                : 'Disconnected',
+                      ),
+                      _MetaChip(
+                        icon: Icons.bolt_outlined,
+                        label: rule.lastMatchedAt == null
+                            ? 'No recent matches'
+                            : '${rule.matchCountLastRun} match(es)',
+                      ),
+                    ],
+                  ),
+                  if (rule.previewSample != null) ...[
+                    const SizedBox(height: 10),
+                    Text(
+                      _previewLabel(rule.previewSample!),
+                      style: const TextStyle(color: Colors.black54),
+                    ),
+                  ],
                 ],
               ),
             ),
-            const SizedBox(width: 8),
             IconButton(
-              icon: const Icon(Icons.edit_outlined, size: 18),
-              color: Colors.grey[600],
               onPressed: onEdit,
-              tooltip: 'Edit rule',
+              icon: const Icon(Icons.edit_outlined),
             ),
             IconButton(
-              icon: const Icon(Icons.delete_outline, size: 18),
-              color: Colors.grey,
               onPressed: onDelete,
-              tooltip: 'Delete rule',
+              icon: const Icon(Icons.delete_outline),
             ),
           ],
         ),
       ),
     );
   }
+
+  String _previewLabel(Map<String, dynamic> preview) {
+    return [
+      preview['title'],
+      preview['subject'],
+      preview['serviceTypeName'],
+      preview['positionName'],
+    ].whereType<Object>().join(' · ');
+  }
 }
 
-class _IfThenRow extends StatelessWidget {
-  const _IfThenRow({required this.rule, required this.dimmed});
+class _MetaChip extends StatelessWidget {
+  const _MetaChip({required this.icon, required this.label});
 
-  final AutomationRule rule;
-  final bool dimmed;
+  final IconData icon;
+  final String label;
 
   @override
   Widget build(BuildContext context) {
-    final baseTextStyle = TextStyle(
-      fontSize: 13,
-      color: dimmed ? Colors.grey[400] : Colors.black87,
-    );
-    final keywordStyle = baseTextStyle.copyWith(
-      fontWeight: FontWeight.w600,
-      color: dimmed ? Colors.grey[400] : Colors.black87,
-    );
-    final triggerStyle = baseTextStyle.copyWith(
-      color: dimmed ? Colors.grey[400] : const Color(0xFF1D4ED8),
-    );
-    final actionStyle = baseTextStyle.copyWith(
-      color: dimmed ? Colors.grey[400] : const Color(0xFF15803D),
-    );
-
-    return Wrap(
-      crossAxisAlignment: WrapCrossAlignment.center,
-      spacing: 4,
-      children: [
-        Text('When', style: keywordStyle),
-        Text(AutomationRule.triggerLabel(rule.triggerType),
-            style: triggerStyle),
-        Icon(
-          Icons.arrow_forward,
-          size: 13,
-          color: dimmed ? Colors.grey[400] : Colors.grey[600],
-        ),
-        Text(AutomationRule.actionLabel(rule.actionType), style: actionStyle),
-      ],
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8FAFC),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: Colors.black54),
+          const SizedBox(width: 6),
+          Text(label, style: const TextStyle(fontSize: 12)),
+        ],
+      ),
     );
   }
 }
 
-/// A simple integer input field.
-class _IntegerField extends StatefulWidget {
-  const _IntegerField({
-    required this.label,
-    required this.value,
-    required this.onChanged,
+class _AutomationDraft {
+  const _AutomationDraft({
+    required this.name,
+    required this.source,
+    required this.triggerKey,
+    required this.actionType,
+    required this.triggerConfig,
+    required this.actionConfig,
+    this.sourceAccountId,
   });
 
-  final String label;
-  final int? value;
-  final ValueChanged<int?> onChanged;
-
-  @override
-  State<_IntegerField> createState() => _IntegerFieldState();
+  final String name;
+  final String source;
+  final String triggerKey;
+  final String actionType;
+  final Map<String, dynamic>? triggerConfig;
+  final Map<String, dynamic>? actionConfig;
+  final String? sourceAccountId;
 }
 
-class _IntegerFieldState extends State<_IntegerField> {
-  late final TextEditingController _ctrl;
+class _AutomationBuilderDialog extends StatefulWidget {
+  const _AutomationBuilderDialog({
+    required this.controller,
+    this.existing,
+  });
+
+  final AutomationRulesController controller;
+  final AutomationRule? existing;
+
+  @override
+  State<_AutomationBuilderDialog> createState() =>
+      _AutomationBuilderDialogState();
+}
+
+class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _textQueryController;
+  late final TextEditingController _senderController;
+  late final TextEditingController _subjectController;
+  late final TextEditingController _titleTemplateController;
+  late final TextEditingController _notesTemplateController;
+  late final TextEditingController _messageTemplateController;
+  late final TextEditingController _templateNameController;
+  late final TextEditingController _tagController;
+  String? _selectedSource;
+  String? _selectedTriggerKey;
+  String? _selectedActionType;
+  String? _selectedAccountId;
+  String? _selectedTeamId;
+  String? _selectedPositionName;
+  String? _selectedEventType;
+  String? _selectedLabel;
+  int? _leadDays;
+  int? _dateWindowDays;
+  int? _hoursSinceReceived;
+  int? _targetDay;
+  bool _allDayOnly = false;
 
   @override
   void initState() {
     super.initState();
-    _ctrl = TextEditingController(
-        text: widget.value != null ? widget.value.toString() : '');
+    final existing = widget.existing;
+    _nameController = TextEditingController(text: existing?.name ?? '');
+    _textQueryController = TextEditingController(
+      text: existing?.triggerConfig?['textQuery']?.toString() ?? '',
+    );
+    _senderController = TextEditingController(
+      text: existing?.triggerConfig?['sender']?.toString() ?? '',
+    );
+    _subjectController = TextEditingController(
+      text: existing?.triggerConfig?['subjectContains']?.toString() ?? '',
+    );
+    _titleTemplateController = TextEditingController(
+      text: existing?.actionConfig?['titleTemplate']?.toString() ?? '',
+    );
+    _notesTemplateController = TextEditingController(
+      text: existing?.actionConfig?['notesTemplate']?.toString() ?? '',
+    );
+    _messageTemplateController = TextEditingController(
+      text: existing?.actionConfig?['messageTemplate']?.toString() ?? '',
+    );
+    _templateNameController = TextEditingController(
+      text: existing?.actionConfig?['templateName']?.toString() ?? '',
+    );
+    _tagController = TextEditingController(
+      text: existing?.actionConfig?['tag']?.toString() ?? '',
+    );
+    _selectedSource = existing?.source ?? widget.controller.providers.firstOrNull?.source;
+    _selectedTriggerKey = existing?.triggerKey;
+    _selectedActionType = existing?.actionType ?? widget.controller.actions.firstOrNull?.key;
+    _selectedAccountId = existing?.sourceAccountId;
+    _selectedTeamId = existing?.triggerConfig?['teamId']?.toString();
+    _selectedPositionName = existing?.triggerConfig?['positionName']?.toString();
+    _selectedEventType = existing?.triggerConfig?['eventType']?.toString();
+    _selectedLabel = existing?.triggerConfig?['label']?.toString();
+    _leadDays = (existing?.triggerConfig?['leadDays'] as num?)?.toInt();
+    _dateWindowDays =
+        (existing?.triggerConfig?['dateWindowDays'] as num?)?.toInt();
+    _hoursSinceReceived =
+        (existing?.triggerConfig?['hoursSinceReceived'] as num?)?.toInt();
+    _targetDay = (existing?.actionConfig?['targetDay'] as num?)?.toInt();
+    _allDayOnly = existing?.triggerConfig?['allDayOnly'] == true;
   }
 
   @override
   void dispose() {
-    _ctrl.dispose();
+    _nameController.dispose();
+    _textQueryController.dispose();
+    _senderController.dispose();
+    _subjectController.dispose();
+    _titleTemplateController.dispose();
+    _notesTemplateController.dispose();
+    _messageTemplateController.dispose();
+    _templateNameController.dispose();
+    _tagController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      controller: _ctrl,
-      keyboardType: TextInputType.number,
-      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-      decoration: InputDecoration(
-        labelText: widget.label,
-        border: const OutlineInputBorder(),
+    final triggers = widget.controller.triggers
+        .where((item) => item.source == _selectedSource)
+        .toList();
+    _selectedTriggerKey ??= triggers.firstOrNull?.key;
+    _selectedActionType ??= widget.controller.actions.firstOrNull?.key;
+    final trigger = triggers.where((item) => item.key == _selectedTriggerKey).firstOrNull;
+
+    return AlertDialog(
+      title: Text(widget.existing == null ? 'New automation' : 'Edit automation'),
+      content: SizedBox(
+        width: 620,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _stepTitle('1. Source'),
+              TextField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  labelText: 'Automation name',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<String>(
+                value: _selectedSource,
+                decoration:
+                    const InputDecoration(labelText: 'Source', border: OutlineInputBorder()),
+                items: widget.controller.providers
+                    .map((item) => DropdownMenuItem(
+                          value: item.source,
+                          child: Text(item.label),
+                        ))
+                    .toList(),
+                onChanged: (value) => setState(() {
+                  _selectedSource = value;
+                  _selectedTriggerKey = widget.controller.triggers
+                      .where((item) => item.source == value)
+                      .firstOrNull
+                      ?.key;
+                }),
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<String?>(
+                value: _selectedAccountId,
+                decoration: const InputDecoration(
+                  labelText: 'Connected account',
+                  border: OutlineInputBorder(),
+                ),
+                items: [
+                  const DropdownMenuItem<String?>(
+                    value: null,
+                    child: Text('Use default/internal source'),
+                  ),
+                  ...widget.controller.accounts
+                      .where((item) => item.provider == _selectedSource)
+                      .map((item) => DropdownMenuItem<String?>(
+                            value: item.id,
+                            child: Text(item.accountLabel ??
+                                item.providerDisplayName ??
+                                item.provider),
+                          )),
+                ],
+                onChanged: (value) => setState(() => _selectedAccountId = value),
+              ),
+              const SizedBox(height: 18),
+              _stepTitle('2. Trigger'),
+              DropdownButtonFormField<String>(
+                value: _selectedTriggerKey,
+                decoration: const InputDecoration(
+                  labelText: 'Trigger',
+                  border: OutlineInputBorder(),
+                ),
+                items: triggers
+                    .map((item) => DropdownMenuItem(
+                          value: item.key,
+                          child: Text(item.label),
+                        ))
+                    .toList(),
+                onChanged: (value) => setState(() => _selectedTriggerKey = value),
+              ),
+              if (trigger != null) ...[
+                const SizedBox(height: 8),
+                Text(trigger.description,
+                    style: const TextStyle(color: Colors.black54)),
+                const SizedBox(height: 12),
+                ..._buildTriggerFields(trigger),
+              ],
+              const SizedBox(height: 18),
+              _stepTitle('3. Action'),
+              DropdownButtonFormField<String>(
+                value: _selectedActionType,
+                decoration: const InputDecoration(
+                  labelText: 'Action',
+                  border: OutlineInputBorder(),
+                ),
+                items: widget.controller.actions
+                    .map((item) => DropdownMenuItem(
+                          value: item.key,
+                          child: Text(item.label),
+                        ))
+                    .toList(),
+                onChanged: (value) => setState(() => _selectedActionType = value),
+              ),
+              const SizedBox(height: 12),
+              ..._buildActionFields(),
+              const SizedBox(height: 18),
+              _stepTitle('4. Review'),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: const Color(0xFFF8FAFC),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(_reviewSummary(trigger)),
+              ),
+            ],
+          ),
+        ),
       ),
-      onChanged: (v) {
-        final parsed = int.tryParse(v);
-        widget.onChanged(parsed);
-      },
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () {
+            final name = _nameController.text.trim();
+            if (name.isEmpty ||
+                _selectedSource == null ||
+                _selectedTriggerKey == null ||
+                _selectedActionType == null) {
+              return;
+            }
+            Navigator.pop(
+              context,
+              _AutomationDraft(
+                name: name,
+                source: _selectedSource!,
+                triggerKey: _selectedTriggerKey!,
+                actionType: _selectedActionType!,
+                triggerConfig: _buildTriggerConfig(),
+                actionConfig: _buildActionConfig(),
+                sourceAccountId: _selectedAccountId,
+              ),
+            );
+          },
+          child: Text(widget.existing == null ? 'Create' : 'Save'),
+        ),
+      ],
+    );
+  }
+
+  Widget _stepTitle(String text) => Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Text(text,
+            style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15)),
+      );
+
+  List<Widget> _buildTriggerFields(AutomationTriggerCatalogItem trigger) {
+    if (trigger.source == 'planning_center') {
+      final options = widget.controller.planningCenterTaskOptions;
+      return [
+        if (options != null) ...[
+          DropdownButtonFormField<String>(
+            value: _selectedTeamId,
+            decoration: const InputDecoration(
+              labelText: 'Team',
+              border: OutlineInputBorder(),
+            ),
+            items: [
+              const DropdownMenuItem<String>(
+                value: null,
+                child: Text('Any team'),
+              ),
+              ...options.teams.map((team) => DropdownMenuItem(
+                    value: team.id,
+                    child: Text('${team.serviceTypeName} · ${team.name}'),
+                  )),
+            ],
+            onChanged: (value) => setState(() => _selectedTeamId = value),
+          ),
+          const SizedBox(height: 12),
+          DropdownButtonFormField<String>(
+            value: _selectedPositionName,
+            decoration: const InputDecoration(
+              labelText: 'Position',
+              border: OutlineInputBorder(),
+            ),
+            items: [
+              const DropdownMenuItem<String>(
+                value: null,
+                child: Text('Any position'),
+              ),
+              ..._positionsForTeam(options, _selectedTeamId).map(
+                (position) => DropdownMenuItem(
+                  value: position,
+                  child: Text(position),
+                ),
+              ),
+            ],
+            onChanged: (value) => setState(() => _selectedPositionName = value),
+          ),
+          const SizedBox(height: 12),
+        ],
+        _IntegerDropdown(
+          label: 'Lead-time window',
+          value: _leadDays,
+          options: const [3, 7, 14, 21, 30],
+          onChanged: (value) => setState(() => _leadDays = value),
+        ),
+      ];
+    }
+    if (trigger.source == 'google_calendar') {
+      return [
+        TextField(
+          controller: _textQueryController,
+          decoration: const InputDecoration(
+            labelText: 'Title / location / description contains',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 12),
+        DropdownButtonFormField<String>(
+          value: _selectedEventType,
+          decoration: const InputDecoration(
+            labelText: 'Event type',
+            border: OutlineInputBorder(),
+          ),
+          items: const [
+            DropdownMenuItem<String>(value: null, child: Text('Any event type')),
+            DropdownMenuItem<String>(value: 'default', child: Text('Default')),
+            DropdownMenuItem<String>(
+                value: 'focusTime', child: Text('Focus time')),
+            DropdownMenuItem<String>(
+                value: 'outOfOffice', child: Text('Out of office')),
+          ],
+          onChanged: (value) => setState(() => _selectedEventType = value),
+        ),
+        const SizedBox(height: 12),
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('All-day only'),
+          value: _allDayOnly,
+          onChanged: (value) => setState(() => _allDayOnly = value),
+        ),
+        _IntegerDropdown(
+          label: 'Date window',
+          value: _dateWindowDays,
+          options: const [0, 1, 3, 7, 14, 30],
+          onChanged: (value) => setState(() => _dateWindowDays = value),
+        ),
+      ];
+    }
+    if (trigger.source == 'gmail') {
+      return [
+        TextField(
+          controller: _senderController,
+          decoration: const InputDecoration(
+            labelText: 'Sender contains',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _subjectController,
+          decoration: const InputDecoration(
+            labelText: 'Subject contains',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 12),
+        DropdownButtonFormField<String>(
+          value: _selectedLabel,
+          decoration: const InputDecoration(
+            labelText: 'Label',
+            border: OutlineInputBorder(),
+          ),
+          items: const [
+            DropdownMenuItem<String>(value: null, child: Text('Any label')),
+            DropdownMenuItem<String>(value: 'UNREAD', child: Text('Unread')),
+            DropdownMenuItem<String>(value: 'INBOX', child: Text('Inbox')),
+          ],
+          onChanged: (value) => setState(() => _selectedLabel = value),
+        ),
+        const SizedBox(height: 12),
+        _IntegerDropdown(
+          label: 'Received within last hours',
+          value: _hoursSinceReceived,
+          options: const [1, 6, 12, 24, 48, 72],
+          onChanged: (value) => setState(() => _hoursSinceReceived = value),
+        ),
+      ];
+    }
+    return const [];
+  }
+
+  List<Widget> _buildActionFields() {
+    switch (_selectedActionType) {
+      case 'create_project_from_template':
+        return [
+          TextField(
+            controller: _templateNameController,
+            decoration: const InputDecoration(
+              labelText: 'Project template name',
+              border: OutlineInputBorder(),
+            ),
+          ),
+        ];
+      case 'send_notification':
+        return [
+          TextField(
+            controller: _messageTemplateController,
+            decoration: const InputDecoration(
+              labelText: 'Message template',
+              border: OutlineInputBorder(),
+            ),
+            maxLines: 3,
+          ),
+        ];
+      default:
+        return [
+          TextField(
+            controller: _titleTemplateController,
+            decoration: const InputDecoration(
+              labelText: 'Task title template',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _notesTemplateController,
+            decoration: const InputDecoration(
+              labelText: 'Task notes template',
+              border: OutlineInputBorder(),
+            ),
+            maxLines: 3,
+          ),
+          if (_selectedActionType == 'tag_task') ...[
+            const SizedBox(height: 12),
+            TextField(
+              controller: _tagController,
+              decoration: const InputDecoration(
+                labelText: 'Tag',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ],
+          if (_selectedActionType == 'auto_schedule') ...[
+            const SizedBox(height: 12),
+            _IntegerDropdown(
+              label: 'Target day',
+              value: _targetDay,
+              options: const [1, 2, 3, 4, 5],
+              labels: const {
+                1: 'Monday',
+                2: 'Tuesday',
+                3: 'Wednesday',
+                4: 'Thursday',
+                5: 'Friday',
+              },
+              onChanged: (value) => setState(() => _targetDay = value),
+            ),
+          ],
+        ];
+    }
+  }
+
+  Map<String, dynamic>? _buildTriggerConfig() {
+    final config = <String, dynamic>{};
+    if (_leadDays != null) config['leadDays'] = _leadDays;
+    if (_selectedTeamId != null) config['teamId'] = _selectedTeamId;
+    if (_selectedPositionName != null) config['positionName'] = _selectedPositionName;
+    if (_textQueryController.text.trim().isNotEmpty) {
+      config['textQuery'] = _textQueryController.text.trim();
+    }
+    if (_selectedEventType != null) config['eventType'] = _selectedEventType;
+    if (_allDayOnly) config['allDayOnly'] = true;
+    if (_dateWindowDays != null) config['dateWindowDays'] = _dateWindowDays;
+    if (_senderController.text.trim().isNotEmpty) {
+      config['sender'] = _senderController.text.trim();
+    }
+    if (_subjectController.text.trim().isNotEmpty) {
+      config['subjectContains'] = _subjectController.text.trim();
+    }
+    if (_selectedLabel != null) config['label'] = _selectedLabel;
+    if (_hoursSinceReceived != null) {
+      config['hoursSinceReceived'] = _hoursSinceReceived;
+    }
+    return config.isEmpty ? null : config;
+  }
+
+  Map<String, dynamic>? _buildActionConfig() {
+    final config = <String, dynamic>{};
+    if (_titleTemplateController.text.trim().isNotEmpty) {
+      config['titleTemplate'] = _titleTemplateController.text.trim();
+    }
+    if (_notesTemplateController.text.trim().isNotEmpty) {
+      config['notesTemplate'] = _notesTemplateController.text.trim();
+    }
+    if (_messageTemplateController.text.trim().isNotEmpty) {
+      config['messageTemplate'] = _messageTemplateController.text.trim();
+    }
+    if (_templateNameController.text.trim().isNotEmpty) {
+      config['templateName'] = _templateNameController.text.trim();
+    }
+    if (_tagController.text.trim().isNotEmpty) {
+      config['tag'] = _tagController.text.trim();
+    }
+    if (_targetDay != null) config['targetDay'] = _targetDay;
+    return config.isEmpty ? null : config;
+  }
+
+  String _reviewSummary(AutomationTriggerCatalogItem? trigger) {
+    final triggerLabel = trigger?.label ?? _selectedTriggerKey ?? 'Trigger';
+    final actionLabel = widget.controller.actions
+            .where((item) => item.key == _selectedActionType)
+            .firstOrNull
+            ?.label ??
+        (_selectedActionType ?? 'Action');
+    return 'When $triggerLabel from ${_labelForSource(_selectedSource)} then $actionLabel.';
+  }
+
+  List<String> _positionsForTeam(
+    PlanningCenterTaskOptions options,
+    String? teamId,
+  ) {
+    if (teamId == null) {
+      return options.positionsByTeamId.values.expand((item) => item).toSet().toList()
+        ..sort();
+    }
+    return options.positionsByTeamId[teamId] ?? const [];
+  }
+}
+
+class _IntegerDropdown extends StatelessWidget {
+  const _IntegerDropdown({
+    required this.label,
+    required this.value,
+    required this.options,
+    required this.onChanged,
+    this.labels = const {},
+  });
+
+  final String label;
+  final int? value;
+  final List<int> options;
+  final Map<int, String> labels;
+  final ValueChanged<int?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButtonFormField<int>(
+      value: value,
+      decoration: InputDecoration(labelText: label, border: const OutlineInputBorder()),
+      items: options
+          .map((item) => DropdownMenuItem(
+                value: item,
+                child: Text(labels[item] ?? item.toString()),
+              ))
+          .toList(),
+      onChanged: onChanged,
     );
   }
 }
+
+String _labelForSource(String? source) => switch (source) {
+      'planning_center' => 'Planning Center',
+      'google_calendar' => 'Google Calendar',
+      'gmail' => 'Gmail',
+      _ => 'Rhythm',
+    };

--- a/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
@@ -773,6 +773,7 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
               const SizedBox(height: 12),
               DropdownButtonFormField<String?>(
                 value: _selectedAccountId,
+                isExpanded: true,
                 decoration: const InputDecoration(
                   labelText: 'Connected account',
                   border: OutlineInputBorder(),
@@ -805,6 +806,7 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
               _stepTitle('2. Trigger'),
               DropdownButtonFormField<String>(
                 value: _selectedTriggerKey,
+                isExpanded: true,
                 decoration: const InputDecoration(
                   labelText: 'Trigger',
                   border: OutlineInputBorder(),
@@ -831,6 +833,7 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
               _stepTitle('3. Action'),
               DropdownButtonFormField<String>(
                 value: _selectedActionType,
+                isExpanded: true,
                 decoration: const InputDecoration(
                   labelText: 'Action',
                   border: OutlineInputBorder(),

--- a/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
@@ -81,6 +81,9 @@ class WeeklyPlannerController extends ChangeNotifier {
       if (task.sourceType == 'project_step') {
         await _repository.updateTask(task.id,
             dueDate: date, sourceType: task.sourceType);
+      } else if (task.dueDate == null && task.scheduledDate == null) {
+        await _repository.updateTask(task.id,
+            dueDate: date, scheduledDate: date, sourceType: task.sourceType);
       } else {
         await _repository.scheduleTask(task.id, date);
       }

--- a/apps/desktop_flutter/macos/Runner.xcodeproj/project.pbxproj
+++ b/apps/desktop_flutter/macos/Runner.xcodeproj/project.pbxproj
@@ -592,8 +592,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 56Q69NYP9H;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -726,8 +728,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 56Q69NYP9H;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -747,8 +751,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 56Q69NYP9H;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/apps/desktop_flutter/test/automation_rules_test.dart
+++ b/apps/desktop_flutter/test/automation_rules_test.dart
@@ -1,0 +1,325 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:rhythm_desktop/features/integrations/models/integration_account.dart';
+import 'package:rhythm_desktop/features/integrations/models/planning_center_task_options.dart';
+import 'package:rhythm_desktop/features/tasks/controllers/automation_rules_controller.dart';
+import 'package:rhythm_desktop/features/tasks/data/automation_rules_data_source.dart';
+import 'package:rhythm_desktop/features/tasks/models/automation_catalog.dart';
+import 'package:rhythm_desktop/features/tasks/models/automation_rule.dart';
+import 'package:rhythm_desktop/features/tasks/repositories/automation_rules_repository.dart';
+import 'package:rhythm_desktop/features/tasks/views/automation_rules_view.dart';
+
+void main() {
+  test(
+      'AutomationRulesController loads catalog, accounts, and preview metadata',
+      () async {
+    final repository = _FakeAutomationRulesRepository()
+      ..rulesFixture = [
+        _rule(
+          id: 'rule-1',
+          source: 'gmail',
+          triggerKey: 'gmail.unread_message_matching_filter',
+          actionType: 'create_task',
+          previewSample: const {
+            'subject': 'Invoice approval',
+            'fromEmail': 'finance@example.com',
+          },
+        ),
+      ]
+      ..triggersFixture = const [
+        AutomationTriggerCatalogItem(
+          key: 'gmail.unread_message_matching_filter',
+          source: 'gmail',
+          label: 'Unread Gmail message matches filter',
+          description: 'Match unread Gmail messages by sender and subject.',
+          signalTypes: ['gmail_unread_message_seen'],
+          configSchema: {
+            'fields': ['sender', 'subjectContains']
+          },
+        ),
+      ]
+      ..actionsFixture = const [
+        AutomationActionCatalogItem(
+          key: 'create_task',
+          label: 'Create task',
+          description: 'Create a follow-up task in Rhythm.',
+          configSchema: {
+            'fields': ['titleTemplate']
+          },
+        ),
+      ]
+      ..providersFixture = const [
+        AutomationProviderCatalogItem(
+          source: 'gmail',
+          label: 'Gmail',
+          description: 'Metadata-driven Gmail message triggers.',
+          syncSupport: 'push_capable',
+          triggerKeys: ['gmail.unread_message_matching_filter'],
+        ),
+      ]
+      ..accountsFixture = [
+        IntegrationAccount(
+          id: 'gmail-account-1',
+          provider: 'gmail',
+          status: 'connected',
+          connected: true,
+          email: 'owner@example.com',
+          accountLabel: 'owner@example.com',
+          providerDisplayName: 'Gmail',
+          lastSyncedAt: '2026-04-01T18:00:00.000Z',
+          availableTriggerFamilies: const ['gmail'],
+          syncSupportMode: 'push_capable',
+        ),
+      ]
+      ..planningCenterTaskOptionsFixture = PlanningCenterTaskOptions(
+        teams: [
+          PlanningCenterTeamOption(
+            id: 'team-1',
+            name: 'Band',
+            serviceTypeId: 'svc-1',
+            serviceTypeName: 'Weekend Service',
+          ),
+        ],
+        positionsByTeamId: const {
+          'team-1': ['Guitar'],
+        },
+      )
+      ..previewFixture = const AutomationRulePreview(
+        ruleId: 'rule-1',
+        summary:
+            'Finance unread: gmail.unread_message_matching_filter -> create_task',
+        previewSample: {
+          'subject': 'Invoice approval',
+        },
+        lastMatchedAt: '2026-04-01T18:00:00.000Z',
+        lastEvaluatedAt: '2026-04-01T18:00:00.000Z',
+        matchCountLastRun: 1,
+      );
+    final controller = AutomationRulesController(repository);
+
+    await controller.load();
+    await controller.loadPreview('rule-1');
+
+    expect(controller.status, AutomationRulesStatus.idle);
+    expect(controller.rules, hasLength(1));
+    expect(controller.triggers.single.source, 'gmail');
+    expect(controller.accounts.single.accountLabel, 'owner@example.com');
+    expect(controller.planningCenterTaskOptions?.positionsByTeamId['team-1'],
+        ['Guitar']);
+    expect(controller.selectedPreview?.summary,
+        'Finance unread: gmail.unread_message_matching_filter -> create_task');
+  });
+
+  testWidgets(
+      'AutomationRulesView shows grouped provider cards with account and match metadata',
+      (tester) async {
+    final repository = _FakeAutomationRulesRepository()
+      ..rulesFixture = [
+        _rule(
+          id: 'rule-1',
+          source: 'planning_center',
+          triggerKey: 'planning_center.plan_person_declined',
+          actionType: 'create_task',
+          sourceAccountId: 'pco-account-1',
+          matchCountLastRun: 2,
+          lastMatchedAt: '2026-04-01T18:00:00.000Z',
+          previewSample: const {
+            'serviceTypeName': 'Weekend Service',
+            'positionName': 'Guitar',
+          },
+        ),
+      ]
+      ..triggersFixture = const [
+        AutomationTriggerCatalogItem(
+          key: 'planning_center.plan_person_declined',
+          source: 'planning_center',
+          label: 'Volunteer declined',
+          description: 'Declined volunteer',
+          signalTypes: ['team_member_declined'],
+          configSchema: {
+            'fields': ['teamId']
+          },
+        ),
+      ]
+      ..actionsFixture = const [
+        AutomationActionCatalogItem(
+          key: 'create_task',
+          label: 'Create task',
+          description: 'Create task.',
+          configSchema: {
+            'fields': ['titleTemplate']
+          },
+        ),
+      ]
+      ..providersFixture = const [
+        AutomationProviderCatalogItem(
+          source: 'planning_center',
+          label: 'Planning Center',
+          description: 'Sync-derived staffing triggers.',
+          syncSupport: 'push_capable',
+          triggerKeys: ['planning_center.plan_person_declined'],
+        ),
+      ]
+      ..accountsFixture = [
+        IntegrationAccount(
+          id: 'pco-account-1',
+          provider: 'planning_center',
+          status: 'connected',
+          connected: true,
+          email: 'team@church.test',
+          accountLabel: 'team@church.test',
+          providerDisplayName: 'Planning Center',
+          lastSyncedAt: '2026-04-01T18:00:00.000Z',
+          availableTriggerFamilies: const ['planning_center'],
+          syncSupportMode: 'push_capable',
+        ),
+      ];
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => AutomationRulesController(repository),
+        child: const MaterialApp(home: AutomationRulesView()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Planning Center'), findsOneWidget);
+    expect(find.text('team@church.test'), findsOneWidget);
+    expect(find.text('Connected'), findsOneWidget);
+    expect(find.text('2 match(es)'), findsOneWidget);
+    expect(find.text('Weekend Service · Guitar'), findsOneWidget);
+  });
+
+  testWidgets(
+      'AutomationRulesView builder shows Gmail-specific trigger controls for Gmail source',
+      (tester) async {
+    final repository = _FakeAutomationRulesRepository()
+      ..triggersFixture = const [
+        AutomationTriggerCatalogItem(
+          key: 'gmail.unread_message_matching_filter',
+          source: 'gmail',
+          label: 'Unread Gmail message matches filter',
+          description: 'Match unread Gmail messages by sender and subject.',
+          signalTypes: ['gmail_unread_message_seen'],
+          configSchema: {
+            'fields': ['sender', 'subjectContains', 'label']
+          },
+        ),
+      ]
+      ..actionsFixture = const [
+        AutomationActionCatalogItem(
+          key: 'create_task',
+          label: 'Create task',
+          description: 'Create task.',
+          configSchema: {
+            'fields': ['titleTemplate']
+          },
+        ),
+      ]
+      ..providersFixture = const [
+        AutomationProviderCatalogItem(
+          source: 'gmail',
+          label: 'Gmail',
+          description: 'Metadata-driven Gmail message triggers.',
+          syncSupport: 'push_capable',
+          triggerKeys: ['gmail.unread_message_matching_filter'],
+        ),
+      ]
+      ..accountsFixture = [
+        IntegrationAccount(
+          id: 'gmail-account-1',
+          provider: 'gmail',
+          status: 'connected',
+          connected: true,
+          email: 'owner@example.com',
+          accountLabel: 'owner@example.com',
+          providerDisplayName: 'Gmail',
+          availableTriggerFamilies: const ['gmail'],
+          syncSupportMode: 'push_capable',
+        ),
+      ];
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider(
+        create: (_) => AutomationRulesController(repository),
+        child: const MaterialApp(home: AutomationRulesView()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Create automation').last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Sender contains'), findsOneWidget);
+    expect(find.text('Subject contains'), findsOneWidget);
+    expect(find.text('Received within last hours'), findsOneWidget);
+  });
+}
+
+AutomationRule _rule({
+  required String id,
+  required String source,
+  required String triggerKey,
+  required String actionType,
+  String? sourceAccountId,
+  int matchCountLastRun = 0,
+  String? lastMatchedAt,
+  Map<String, dynamic>? previewSample,
+}) {
+  return AutomationRule(
+    id: id,
+    name: 'Automation $id',
+    source: source,
+    triggerKey: triggerKey,
+    actionType: actionType,
+    enabled: true,
+    sourceAccountId: sourceAccountId,
+    lastMatchedAt: lastMatchedAt,
+    matchCountLastRun: matchCountLastRun,
+    previewSample: previewSample,
+    createdAt: '2026-04-01T18:00:00.000Z',
+    updatedAt: '2026-04-01T18:00:00.000Z',
+  );
+}
+
+class _FakeAutomationRulesRepository extends AutomationRulesRepository {
+  _FakeAutomationRulesRepository()
+      : super(AutomationRulesDataSource(baseUrl: 'http://example.invalid'));
+
+  List<AutomationRule> rulesFixture = [];
+  List<AutomationTriggerCatalogItem> triggersFixture = [];
+  List<AutomationActionCatalogItem> actionsFixture = [];
+  List<AutomationProviderCatalogItem> providersFixture = [];
+  List<IntegrationAccount> accountsFixture = [];
+  PlanningCenterTaskOptions? planningCenterTaskOptionsFixture;
+  AutomationRulePreview previewFixture = const AutomationRulePreview(
+    ruleId: 'rule-1',
+    summary: '',
+  );
+
+  @override
+  Future<List<AutomationRule>> getAll() async => rulesFixture;
+
+  @override
+  Future<List<AutomationTriggerCatalogItem>> getTriggers() async =>
+      triggersFixture;
+
+  @override
+  Future<List<AutomationActionCatalogItem>> getActions() async =>
+      actionsFixture;
+
+  @override
+  Future<List<AutomationProviderCatalogItem>> getProviders() async =>
+      providersFixture;
+
+  @override
+  Future<List<IntegrationAccount>> getAccounts() async => accountsFixture;
+
+  @override
+  Future<PlanningCenterTaskOptions?> getPlanningCenterTaskOptions() async =>
+      planningCenterTaskOptionsFixture;
+
+  @override
+  Future<AutomationRulePreview> getPreview(String id) async => previewFixture;
+}

--- a/apps/desktop_flutter/test/controller_regressions_test.dart
+++ b/apps/desktop_flutter/test/controller_regressions_test.dart
@@ -39,7 +39,8 @@ void main() {
     expect(controller.selectedThreadId, 22);
   });
 
-  test('MessagesController polls threads globally and current thread while visible',
+  test(
+      'MessagesController polls threads globally and current thread while visible',
       () async {
     final repository = _FakeMessagesRepository();
     final controller = MessagesController(

--- a/apps/desktop_flutter/test/controller_regressions_test.dart
+++ b/apps/desktop_flutter/test/controller_regressions_test.dart
@@ -1,4 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:rhythm_desktop/app/core/auth/auth_data_source.dart';
+import 'package:rhythm_desktop/app/core/auth/auth_session_service.dart';
 import 'package:rhythm_desktop/app/core/auth/auth_user.dart';
 import 'package:rhythm_desktop/features/dashboard/controllers/dashboard_controller.dart';
 import 'package:rhythm_desktop/features/dashboard/data/dashboard_data_source.dart';
@@ -9,6 +12,10 @@ import 'package:rhythm_desktop/features/messages/models/message_thread.dart';
 import 'package:rhythm_desktop/features/messages/repositories/messages_repository.dart';
 import 'package:rhythm_desktop/features/tasks/models/recurring_task_rule.dart';
 import 'package:rhythm_desktop/features/tasks/models/task.dart';
+import 'package:rhythm_desktop/features/weekly_planner/controllers/weekly_planner_controller.dart';
+import 'package:rhythm_desktop/features/weekly_planner/data/weekly_plan_data_source.dart';
+import 'package:rhythm_desktop/features/weekly_planner/models/weekly_plan.dart';
+import 'package:rhythm_desktop/features/weekly_planner/repositories/weekly_plan_repository.dart';
 
 void main() {
   test('DashboardController refreshes recent tasks after toggling done',
@@ -37,6 +44,164 @@ void main() {
     expect(repository.getThreadsCallCount, greaterThanOrEqualTo(2));
     expect(controller.threads, hasLength(2));
     expect(controller.selectedThreadId, 22);
+  });
+
+  test('MessagesController totals unread counts across threads', () async {
+    final repository = _FakeMessagesRepository()
+      ..threadFixtures = [
+        MessageThread(
+          id: 11,
+          title: 'Existing thread',
+          updatedAt: DateTime.parse('2026-03-31T00:00:00.000Z'),
+          unreadCount: 2,
+        ),
+        MessageThread(
+          id: 12,
+          title: 'Another thread',
+          updatedAt: DateTime.parse('2026-03-31T00:10:00.000Z'),
+          unreadCount: 1,
+        ),
+      ];
+    final controller = MessagesController(repository);
+
+    await controller.loadThreads();
+
+    expect(controller.totalUnreadCount, 3);
+  });
+
+  test('MessagesController polls only while the screen is active', () async {
+    final repository = _FakeMessagesRepository();
+    final controller = MessagesController(
+      repository,
+      pollInterval: const Duration(milliseconds: 10),
+    );
+
+    controller.setScreenActive(true);
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+    final callsWhileActive = repository.getThreadsCallCount;
+
+    controller.setScreenActive(false);
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+
+    expect(callsWhileActive, greaterThanOrEqualTo(2));
+    expect(repository.getThreadsCallCount, callsWhileActive);
+  });
+
+  test('MessagesController raises an incoming notice for new messages in the open thread',
+      () async {
+    SharedPreferences.setMockInitialValues({
+      'session_token': 'persisted-token',
+    });
+    final authService = AuthSessionService(_FakeAuthDataSource());
+    await authService.restoreSession();
+
+    final repository = _FakeMessagesRepository();
+    final controller = MessagesController(
+      repository,
+      pollInterval: const Duration(milliseconds: 10),
+    );
+
+    await controller.loadThreads();
+    await controller.selectThread(11);
+
+    repository.messageFixtures = [
+      Message(
+        id: 1,
+        threadId: 11,
+        senderName: 'Alice',
+        content: 'Hello',
+        createdAt: DateTime.parse('2026-03-31T01:00:00.000Z'),
+      ),
+      Message(
+        id: 2,
+        threadId: 11,
+        senderName: 'Bob',
+        content: 'Reply',
+        createdAt: DateTime.parse('2026-03-31T01:01:00.000Z'),
+      ),
+    ];
+
+    controller.setScreenActive(true);
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+    controller.setScreenActive(false);
+
+    expect(controller.incomingNotice, isNotNull);
+    expect(controller.incomingNotice?.senderName, 'Bob');
+    expect(controller.incomingNotice?.preview, 'Reply');
+  });
+
+  test('MessagesController raises an incoming notice for unread activity in another thread',
+      () async {
+    SharedPreferences.setMockInitialValues({
+      'session_token': 'persisted-token',
+    });
+    final authService = AuthSessionService(_FakeAuthDataSource());
+    await authService.restoreSession();
+
+    final repository = _FakeMessagesRepository();
+    final controller = MessagesController(repository);
+
+    await controller.loadThreads();
+
+    repository.threadFixtures = [
+      MessageThread(
+        id: 99,
+        title: 'Rhythm Bot',
+        updatedAt: DateTime.parse('2026-03-31T01:05:00.000Z'),
+        unreadCount: 1,
+        lastMessage: 'Your facility reservation was deleted.',
+      ),
+      ...repository.threadFixtures,
+    ];
+
+    await controller.loadThreads(silent: true);
+
+    expect(controller.incomingNotice, isNotNull);
+    expect(controller.incomingNotice?.senderName, 'Rhythm Bot');
+    expect(
+      controller.incomingNotice?.preview,
+      'Your facility reservation was deleted.',
+    );
+  });
+
+  test('WeeklyPlannerController assigns due date when dragging an unscheduled task',
+      () async {
+    final repository = _FakeWeeklyPlanRepository();
+    final controller = WeeklyPlannerController(repository);
+    final task = Task(
+      id: 'task-1',
+      title: 'Unscheduled',
+      status: 'open',
+      createdAt: '2026-03-31T00:00:00.000Z',
+      updatedAt: '2026-03-31T00:00:00.000Z',
+    );
+
+    await controller.scheduleTask(task, '2026-04-02');
+
+    expect(repository.lastUpdatedTaskId, 'task-1');
+    expect(repository.lastUpdatedDueDate, '2026-04-02');
+    expect(repository.lastUpdatedScheduledDate, '2026-04-02');
+    expect(repository.scheduleTaskCallCount, 0);
+  });
+
+  test('AuthSessionService restores and clears sessions cleanly', () async {
+    SharedPreferences.setMockInitialValues({
+      'session_token': 'persisted-token',
+    });
+    final dataSource = _FakeAuthDataSource();
+    final service = AuthSessionService(dataSource);
+
+    await service.restoreSession();
+    expect(service.isAuthenticated, isTrue);
+    expect(service.currentUser?.email, 'alice@example.com');
+
+    await service.logout();
+    expect(service.isAuthenticated, isFalse);
+    expect(service.currentUser, isNull);
+    expect(dataSource.logoutCalled, isTrue);
+
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString('session_token'), isNull);
   });
 }
 
@@ -94,7 +259,7 @@ class _FakeMessagesRepository extends MessagesRepository {
       : super(MessagesDataSource(baseUrl: 'http://example.invalid'));
 
   int getThreadsCallCount = 0;
-  final List<MessageThread> _threads = [
+  List<MessageThread> threadFixtures = [
     MessageThread(
       id: 11,
       title: 'Existing thread',
@@ -102,11 +267,20 @@ class _FakeMessagesRepository extends MessagesRepository {
       unreadCount: 0,
     ),
   ];
+  List<Message> messageFixtures = [
+    Message(
+      id: 1,
+      threadId: 11,
+      senderName: 'Alice',
+      content: 'Hello',
+      createdAt: DateTime.parse('2026-03-31T01:00:00.000Z'),
+    ),
+  ];
 
   @override
   Future<List<MessageThread>> getThreads() async {
     getThreadsCallCount += 1;
-    return List<MessageThread>.from(_threads);
+    return List<MessageThread>.from(threadFixtures);
   }
 
   @override
@@ -115,29 +289,101 @@ class _FakeMessagesRepository extends MessagesRepository {
       ];
 
   @override
-  Future<MessageThread> createThread(List<int> participantIds,
-      {String? title}) async {
+  Future<MessageThread> createThread(
+    List<int> participantIds,
+  ) async {
     final thread = MessageThread(
       id: 22,
-      title: title ?? 'Bob',
+      title: 'Alice, Bob',
       updatedAt: DateTime.parse('2026-03-31T01:00:00.000Z'),
       unreadCount: 0,
+      participants: const [
+        MessageThreadParticipant(
+            id: 1, name: 'Alice', email: 'alice@example.com'),
+        MessageThreadParticipant(id: 2, name: 'Bob', email: 'bob@example.com'),
+      ],
     );
-    _threads.insert(0, thread);
+    threadFixtures.insert(0, thread);
     return thread;
   }
 
   @override
-  Future<List<Message>> getMessages(int threadId) async => [
-        Message(
-          id: 1,
-          threadId: threadId,
-          senderName: 'Alice',
-          content: 'Hello',
-          createdAt: DateTime.parse('2026-03-31T01:00:00.000Z'),
-        ),
-      ];
+  Future<List<Message>> getMessages(int threadId) async => messageFixtures;
 
   @override
   Future<void> markRead(int threadId) async {}
+}
+
+class _FakeAuthDataSource extends AuthDataSource {
+  _FakeAuthDataSource() : super(baseUrl: 'http://example.invalid');
+
+  bool logoutCalled = false;
+
+  @override
+  Future<AuthUser> me(String sessionToken) async => const AuthUser(
+        id: 1,
+        name: 'Alice',
+        email: 'alice@example.com',
+        role: 'member',
+      );
+
+  @override
+  Future<void> logout() async {
+    logoutCalled = true;
+  }
+}
+
+class _FakeWeeklyPlanRepository extends WeeklyPlanRepository {
+  _FakeWeeklyPlanRepository()
+      : super(WeeklyPlanDataSource(baseUrl: 'http://example.invalid'));
+
+  int scheduleTaskCallCount = 0;
+  String? lastUpdatedTaskId;
+  String? lastUpdatedDueDate;
+  String? lastUpdatedScheduledDate;
+
+  @override
+  Future<WeeklyPlan> fetchPlan(String weekLabel) async => WeeklyPlan(
+        weekLabel: weekLabel,
+        weekStart: '2026-03-30',
+        days: const [],
+        backlog: const [],
+      );
+
+  @override
+  Future<Task> scheduleTask(String taskId, String date, {bool locked = false}) async {
+    scheduleTaskCallCount += 1;
+    return Task(
+      id: taskId,
+      title: 'Scheduled',
+      status: 'open',
+      createdAt: '2026-03-31T00:00:00.000Z',
+      updatedAt: '2026-03-31T00:00:00.000Z',
+      scheduledDate: date,
+    );
+  }
+
+  @override
+  Future<Task> updateTask(
+    String taskId, {
+    String? notes,
+    String? status,
+    String? dueDate,
+    String? scheduledDate,
+    String? sourceType,
+  }) async {
+    lastUpdatedTaskId = taskId;
+    lastUpdatedDueDate = dueDate;
+    lastUpdatedScheduledDate = scheduledDate;
+    return Task(
+      id: taskId,
+      title: 'Updated',
+      status: status ?? 'open',
+      createdAt: '2026-03-31T00:00:00.000Z',
+      updatedAt: '2026-03-31T00:00:00.000Z',
+      dueDate: dueDate,
+      scheduledDate: scheduledDate,
+      sourceType: sourceType,
+    );
+  }
 }

--- a/apps/desktop_flutter/test/controller_regressions_test.dart
+++ b/apps/desktop_flutter/test/controller_regressions_test.dart
@@ -38,6 +38,56 @@ void main() {
     expect(controller.threads, hasLength(2));
     expect(controller.selectedThreadId, 22);
   });
+
+  test('MessagesController polls threads globally and current thread while visible',
+      () async {
+    final repository = _FakeMessagesRepository();
+    final controller = MessagesController(
+      repository,
+      pollInterval: const Duration(milliseconds: 10),
+    );
+
+    await controller.loadThreads();
+    await controller.selectThread(11);
+    repository.getThreadsCallCount = 0;
+    repository.getMessagesCallCount = 0;
+    repository.markReadCallCount = 0;
+
+    controller.setPollingEnabled(true);
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+    final hiddenThreadCalls = repository.getThreadsCallCount;
+
+    expect(hiddenThreadCalls, greaterThanOrEqualTo(2));
+    expect(repository.getMessagesCallCount, 0);
+    expect(repository.markReadCallCount, 0);
+
+    controller.setScreenActive(true);
+    repository.messageFixtures = [
+      Message(
+        id: 1,
+        threadId: 11,
+        senderName: 'Alice',
+        content: 'Hello',
+        createdAt: DateTime.parse('2026-03-31T01:00:00.000Z'),
+      ),
+      Message(
+        id: 2,
+        threadId: 11,
+        senderName: 'Bob',
+        content: 'Reply',
+        createdAt: DateTime.parse('2026-03-31T01:01:00.000Z'),
+      ),
+    ];
+    await Future<void>.delayed(const Duration(milliseconds: 25));
+
+    expect(repository.getThreadsCallCount, greaterThan(hiddenThreadCalls));
+    expect(repository.getMessagesCallCount, greaterThanOrEqualTo(1));
+    expect(repository.markReadCallCount, greaterThanOrEqualTo(1));
+    expect(controller.incomingNotice, isNotNull);
+    expect(controller.incomingNotice?.senderName, 'Bob');
+
+    controller.setPollingEnabled(false);
+  });
 }
 
 class _FakeDashboardDataSource extends DashboardDataSource {
@@ -94,6 +144,8 @@ class _FakeMessagesRepository extends MessagesRepository {
       : super(MessagesDataSource(baseUrl: 'http://example.invalid'));
 
   int getThreadsCallCount = 0;
+  int getMessagesCallCount = 0;
+  int markReadCallCount = 0;
   final List<MessageThread> _threads = [
     MessageThread(
       id: 11,
@@ -127,17 +179,24 @@ class _FakeMessagesRepository extends MessagesRepository {
     return thread;
   }
 
-  @override
-  Future<List<Message>> getMessages(int threadId) async => [
-        Message(
-          id: 1,
-          threadId: threadId,
-          senderName: 'Alice',
-          content: 'Hello',
-          createdAt: DateTime.parse('2026-03-31T01:00:00.000Z'),
-        ),
-      ];
+  List<Message> messageFixtures = [
+    Message(
+      id: 1,
+      threadId: 11,
+      senderName: 'Alice',
+      content: 'Hello',
+      createdAt: DateTime.parse('2026-03-31T01:00:00.000Z'),
+    ),
+  ];
 
   @override
-  Future<void> markRead(int threadId) async {}
+  Future<List<Message>> getMessages(int threadId) async {
+    getMessagesCallCount += 1;
+    return messageFixtures;
+  }
+
+  @override
+  Future<void> markRead(int threadId) async {
+    markReadCallCount += 1;
+  }
 }

--- a/apps/web/.vite/deps/_metadata.json
+++ b/apps/web/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "c8374197",
+  "configHash": "bfe276e2",
+  "lockfileHash": "e3b0c442",
+  "browserHash": "c72fb5cd",
+  "optimized": {},
+  "chunks": {}
+}

--- a/apps/web/.vite/deps/package.json
+++ b/apps/web/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/apps/web/.vite/deps_temp_29dc3d00/package.json
+++ b/apps/web/.vite/deps_temp_29dc3d00/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
## Summary
- overhaul automations around external sync-driven triggers for Planning Center, Google Calendar, and Gmail
- add catalog/preview support, richer automation rule metadata, and a source-aware Flutter builder
- refresh expired provider tokens during sync and tighten Gmail task dedupe to one follow-up per thread

## Testing
- npm run build
- npm test
- flutter analyze
- flutter test

## Note
This PR includes other local work that was already on local `main` before the automation merge, including the local-main commit `fix: surface unread activity and facility previews`.