### PR TITLE
Finish messages, weekly planner, and rhythms hardening

### DIFF
--- a/apps/api_server/src/__tests__/recurrence_service.test.ts
+++ b/apps/api_server/src/__tests__/recurrence_service.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../database/migrations';
+import { setDb } from '../database/db';
+import { UsersRepository } from '../repositories/users_repository';
+import { RecurringTaskRulesRepository } from '../repositories/recurring_task_rules_repository';
+import { TasksRepository } from '../repositories/tasks_repository';
+import { RecurrenceService } from '../services/recurrence_service';
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+  runMigrations(db);
+  return db;
+}
+
+describe('Recurring rules and recurrence generation', () => {
+  let usersRepo: UsersRepository;
+  let rulesRepo: RecurringTaskRulesRepository;
+  let tasksRepo: TasksRepository;
+  let service: RecurrenceService;
+  let ownerId: number;
+  let assigneeId: number;
+
+  beforeEach(() => {
+    const db = makeDb();
+    setDb(db);
+    usersRepo = new UsersRepository();
+    rulesRepo = new RecurringTaskRulesRepository();
+    tasksRepo = new TasksRepository();
+    service = new RecurrenceService();
+    ownerId = usersRepo.create({ name: 'Alice', email: 'alice@example.com' }).id;
+    assigneeId = usersRepo.create({ name: 'Bob', email: 'bob@example.com' }).id;
+  });
+
+  it('persists workflow steps on recurring rules', () => {
+    const rule = rulesRepo.create({
+      title: 'Weekly workflow',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      ownerId,
+      steps: [
+        { id: 'prep', title: 'Prep', assigneeId: ownerId },
+        { id: 'lead', title: 'Lead', assigneeId },
+      ],
+    });
+
+    const reloaded = rulesRepo.findById(rule.id);
+    expect(reloaded.steps).toHaveLength(2);
+    expect(reloaded.steps.map((step) => step.title)).toEqual(['Prep', 'Lead']);
+    expect(reloaded.steps[0].assigneeId).toBe(ownerId);
+    expect(reloaded.steps[1].assigneeId).toBe(assigneeId);
+  });
+
+  it('generates one task per step per recurrence date and preserves legacy rules', () => {
+    const stepRule = rulesRepo.create({
+      title: 'Weekly workflow',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      ownerId,
+      steps: [
+        { id: 'prep', title: 'Prep', assigneeId: ownerId },
+        { id: 'lead', title: 'Lead', assigneeId: assigneeId },
+      ],
+    });
+
+    const legacyRule = rulesRepo.create({
+      title: 'Legacy rhythm',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      ownerId,
+    });
+
+    const from = new Date('2026-03-23T00:00:00.000Z');
+    const to = new Date('2026-03-23T23:59:59.999Z');
+
+    service.generateInstances(stepRule, from, to);
+    service.generateInstances(legacyRule, from, to);
+
+    const generated = tasksRepo.findAll().filter((task) => task.sourceType === 'recurring_rule');
+    expect(generated).toHaveLength(3);
+    expect(generated.map((task) => task.title).sort()).toEqual([
+      'Lead',
+      'Legacy rhythm',
+      'Prep',
+    ]);
+    expect(
+      generated.find((task) => task.title === 'Prep')?.sourceId,
+    ).toBe(`${stepRule.id}:prep`);
+    expect(
+      generated.find((task) => task.title === 'Lead')?.sourceId,
+    ).toBe(`${stepRule.id}:lead`);
+    expect(
+      generated.find((task) => task.title === 'Legacy rhythm')?.sourceId,
+    ).toBe(legacyRule.id);
+    expect(
+      generated.find((task) => task.title === 'Prep')?.ownerId,
+    ).toBe(ownerId);
+    expect(
+      generated.find((task) => task.title === 'Lead')?.ownerId,
+    ).toBe(assigneeId);
+  });
+});

--- a/apps/api_server/src/controllers/messages_controller.ts
+++ b/apps/api_server/src/controllers/messages_controller.ts
@@ -60,4 +60,13 @@ export class MessagesController {
       next(err);
     }
   }
+
+  markUnread(req: Request, res: Response, next: NextFunction) {
+    try {
+      repo.markThreadUnread(Number(req.params.id), req.auth!.user.id);
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  }
 }

--- a/apps/api_server/src/controllers/recurring_rules_controller.ts
+++ b/apps/api_server/src/controllers/recurring_rules_controller.ts
@@ -3,9 +3,15 @@ import { AppError } from '../errors/app_error';
 import { RecurringTaskRulesRepository } from '../repositories/recurring_task_rules_repository';
 import { RecurrenceService } from '../services/recurrence_service';
 import { TasksRepository } from '../repositories/tasks_repository';
+import { UsersRepository } from '../repositories/users_repository';
+import { v4 as uuidv4 } from 'uuid';
+import type { RecurringTaskRule, RecurringTaskRuleStep, RecurringTaskRuleProgress } from '../models/recurring_task_rule';
+import type { Task } from '../models/task';
 
 const repo = new RecurringTaskRulesRepository();
 const recurrenceService = new RecurrenceService();
+const tasksRepo = new TasksRepository();
+const usersRepo = new UsersRepository();
 
 const DEFAULT_LOOKAHEAD_WEEKS = 8;
 
@@ -14,7 +20,7 @@ const VALID_FREQUENCIES = ['weekly', 'monthly', 'annual'] as const;
 export class RecurringRulesController {
   getAll(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(repo.findAll(req.auth?.user.id));
+      res.json(this.decorateRules(repo.findAll(req.auth?.user.id), req.auth?.user.id));
     } catch (err) {
       next(err);
     }
@@ -22,7 +28,7 @@ export class RecurringRulesController {
 
   getById(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(repo.findById(req.params.id, req.auth?.user.id));
+      res.json(this.decorateRule(repo.findById(req.params.id, req.auth?.user.id), req.auth?.user.id));
     } catch (err) {
       next(err);
     }
@@ -30,7 +36,7 @@ export class RecurringRulesController {
 
   create(req: Request, res: Response, next: NextFunction) {
     try {
-      const { title, frequency, dayOfWeek, dayOfMonth, month } = req.body as Record<string, unknown>;
+      const { title, frequency, dayOfWeek, dayOfMonth, month, steps } = req.body as Record<string, unknown>;
 
       if (!title || typeof title !== 'string') throw AppError.badRequest('title is required');
       if (!frequency || !VALID_FREQUENCIES.includes(frequency as never)) {
@@ -44,6 +50,7 @@ export class RecurringRulesController {
         dayOfMonth: dayOfMonth as number ?? null,
         month: month as number ?? null,
         ownerId: req.auth?.user.id ?? null,
+        steps: parseSteps(steps),
       });
 
       // Immediately generate task instances so they appear in the weekly planner
@@ -54,7 +61,7 @@ export class RecurringRulesController {
       to.setUTCDate(to.getUTCDate() + weeks * 7);
       recurrenceService.generateInstances(rule, from, to);
 
-      res.status(201).json(rule);
+      res.status(201).json(this.decorateRule(rule, req.auth?.user.id));
     } catch (err) {
       next(err);
     }
@@ -64,9 +71,8 @@ export class RecurringRulesController {
     try {
       const body = req.body as Record<string, unknown>;
       const rule = repo.update(req.params.id, body, req.auth?.user.id);
-      if (body.enabled === false) {
-        new TasksRepository().deleteFutureOpenBySourceId('recurring_rule', rule.id);
-      } else if (body.enabled === true) {
+      tasksRepo.deleteFutureOpenBySourceId('recurring_rule', rule.id);
+      if (rule.enabled) {
         const weeks = parseInt(process.env.RECURRENCE_LOOKAHEAD_WEEKS ?? '', 10);
         const lookahead = isNaN(weeks) ? DEFAULT_LOOKAHEAD_WEEKS : weeks;
         const from = new Date();
@@ -74,7 +80,7 @@ export class RecurringRulesController {
         to.setUTCDate(to.getUTCDate() + lookahead * 7);
         recurrenceService.generateInstances(rule, from, to);
       }
-      res.json(rule);
+      res.json(this.decorateRule(rule, req.auth?.user.id));
     } catch (err) {
       next(err);
     }
@@ -88,4 +94,98 @@ export class RecurringRulesController {
       next(err);
     }
   }
+
+  private decorateRules(rules: RecurringTaskRule[], currentUserId?: number) {
+    return rules.map((rule) => this.decorateRule(rule, currentUserId));
+  }
+
+  private decorateRule(rule: RecurringTaskRule, currentUserId?: number) {
+    const visibleTasks = tasksRepo.findAll();
+    const usersById = new Map(usersRepo.findAll().map((user) => [user.id, user]));
+    const matchingTasks = visibleTasks.filter((task) => this.matchesRule(task, rule.id));
+    const orderedTasks = [...matchingTasks].sort((a, b) => {
+      const aOrder = this.taskOrder(a);
+      const bOrder = this.taskOrder(b);
+      if (aOrder !== bOrder) return aOrder - bOrder;
+      return a.title.localeCompare(b.title);
+    });
+    const completedCount = orderedTasks.filter((task) => task.status === 'done').length;
+    const remainingTasks = orderedTasks.filter((task) => task.status !== 'done');
+    const personalRemainingCount = currentUserId == null
+      ? remainingTasks.length
+      : remainingTasks.filter((task) => task.ownerId === currentUserId).length;
+    const waitingTask = remainingTasks.find((task) => {
+      if (currentUserId == null) return task.ownerId != null;
+      return task.ownerId != null && task.ownerId !== currentUserId;
+    });
+
+    const progress: RecurringTaskRuleProgress = {
+      totalCount: orderedTasks.length,
+      completedCount,
+      remainingCount: remainingTasks.length,
+      personalRemainingCount,
+      waitingOnUserId: waitingTask?.ownerId ?? null,
+      waitingOnUserName: waitingTask?.ownerId != null
+        ? usersById.get(waitingTask.ownerId)?.name ?? null
+        : null,
+      nextDueDate: remainingTasks.find((task) => task.dueDate != null)?.dueDate ?? null,
+      completionRatio: orderedTasks.length === 0 ? 0 : completedCount / orderedTasks.length,
+    };
+
+    return {
+      ...rule,
+      steps: rule.steps.map((step) => this.decorateStep(step, usersById)),
+      progress,
+    };
+  }
+
+  private decorateStep(step: RecurringTaskRuleStep, usersById: Map<number, { name: string }>) {
+    return {
+      ...step,
+      assigneeName: step.assigneeId != null ? usersById.get(step.assigneeId)?.name ?? null : null,
+    };
+  }
+
+  private matchesRule(task: Task, ruleId: string): boolean {
+    if (task.sourceType !== 'recurring_rule' || task.sourceId == null) return false;
+    return task.sourceId === ruleId || task.sourceId.startsWith(`${ruleId}:`);
+  }
+
+  private taskOrder(task: Task): number {
+    if (task.scheduledOrder != null) return task.scheduledOrder;
+    if (task.dueDate != null) {
+      const date = Date.parse(task.dueDate);
+      if (!Number.isNaN(date)) return date;
+    }
+    return Date.parse(task.createdAt) || 0;
+  }
+}
+
+function parseSteps(raw: unknown): RecurringTaskRuleStep[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((step, index) => normalizeStep(step, index))
+    .filter((step): step is RecurringTaskRuleStep => step != null);
+}
+
+function normalizeStep(step: unknown, index: number): RecurringTaskRuleStep | null {
+  if (step == null || typeof step !== 'object') return null;
+  const record = step as Record<string, unknown>;
+  const title = typeof record.title === 'string' ? record.title.trim() : '';
+  if (!title) return null;
+  const id =
+    typeof record.id === 'string' && record.id.trim().length > 0
+      ? record.id.trim()
+      : `step-${index + 1}-${uuidv4()}`;
+  const assigneeId =
+    typeof record.assigneeId === 'number'
+      ? record.assigneeId
+      : typeof record.assigneeId === 'string' && record.assigneeId.trim() !== ''
+        ? Number(record.assigneeId)
+        : null;
+  return {
+    id,
+    title,
+    assigneeId: Number.isFinite(assigneeId as number) ? (assigneeId as number) : null,
+  };
 }

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -20,6 +20,7 @@ export function runMigrations(db: Database.Database): void {
       day_of_week INTEGER,
       day_of_month INTEGER,
       month INTEGER,
+      steps_json TEXT NOT NULL DEFAULT '[]',
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
@@ -241,6 +242,9 @@ export function runMigrations(db: Database.Database): void {
   if (!taskCols.includes('owner_id')) {
     db.exec(`ALTER TABLE tasks ADD COLUMN owner_id INTEGER REFERENCES users(id)`);
   }
+  if (!taskCols.includes('scheduled_order')) {
+    db.exec(`ALTER TABLE tasks ADD COLUMN scheduled_order INTEGER`);
+  }
 
   const stepCols = (db.pragma('table_info(project_instance_steps)') as { name: string }[]).map((c) => c.name);
   if (!stepCols.includes('notes')) {
@@ -258,6 +262,9 @@ export function runMigrations(db: Database.Database): void {
   }
   if (!recurringRuleCols.includes('owner_id')) {
     db.exec(`ALTER TABLE recurring_task_rules ADD COLUMN owner_id INTEGER REFERENCES users(id)`);
+  }
+  if (!recurringRuleCols.includes('steps_json')) {
+    db.exec(`ALTER TABLE recurring_task_rules ADD COLUMN steps_json TEXT NOT NULL DEFAULT '[]'`);
   }
 
   const userCols = (db.pragma('table_info(users)') as { name: string }[]).map((c) => c.name);

--- a/apps/api_server/src/models/recurring_task_rule.ts
+++ b/apps/api_server/src/models/recurring_task_rule.ts
@@ -1,3 +1,21 @@
+export interface RecurringTaskRuleStep {
+  id: string;
+  title: string;
+  assigneeId: number | null;
+  assigneeName?: string | null;
+}
+
+export interface RecurringTaskRuleProgress {
+  totalCount: number;
+  completedCount: number;
+  remainingCount: number;
+  personalRemainingCount: number;
+  waitingOnUserId: number | null;
+  waitingOnUserName: string | null;
+  nextDueDate: string | null;
+  completionRatio: number;
+}
+
 export interface RecurringTaskRule {
   id: string;
   title: string;
@@ -7,6 +25,8 @@ export interface RecurringTaskRule {
   month: number | null;
   enabled: boolean;
   ownerId: number | null;
+  steps: RecurringTaskRuleStep[];
+  progress?: RecurringTaskRuleProgress;
   createdAt: string;
 }
 
@@ -18,6 +38,7 @@ export interface CreateRecurringTaskRuleDto {
   month?: number | null;
   enabled?: boolean;
   ownerId?: number | null;
+  steps?: RecurringTaskRuleStep[];
 }
 
 export interface UpdateRecurringTaskRuleDto {
@@ -28,4 +49,5 @@ export interface UpdateRecurringTaskRuleDto {
   month?: number | null;
   enabled?: boolean;
   ownerId?: number | null;
+  steps?: RecurringTaskRuleStep[];
 }

--- a/apps/api_server/src/models/task.ts
+++ b/apps/api_server/src/models/task.ts
@@ -4,11 +4,15 @@ export interface Task {
   notes: string | null;
   dueDate: string | null;
   scheduledDate: string | null;
+  scheduledOrder: number | null;
   locked: boolean;
   status: 'open' | 'done';
   sourceType: string | null;
   sourceId: string | null;
   sourceName: string | null;
+  startsAt?: string | null;
+  endsAt?: string | null;
+  isAllDay?: boolean;
   ownerId: number | null;
   createdAt: string;
   updatedAt: string;
@@ -20,6 +24,7 @@ export interface CreateTaskDto {
   dueDate?: string | null;
   status?: 'open' | 'done';
   scheduledDate?: string | null;
+  scheduledOrder?: number | null;
   locked?: boolean;
   sourceType?: string | null;
   sourceId?: string | null;
@@ -32,6 +37,7 @@ export interface UpdateTaskDto {
   dueDate?: string | null;
   status?: 'open' | 'done';
   scheduledDate?: string | null;
+  scheduledOrder?: number | null;
   locked?: boolean;
   ownerId?: number | null;
 }

--- a/apps/api_server/src/repositories/messages_repository.ts
+++ b/apps/api_server/src/repositories/messages_repository.ts
@@ -257,4 +257,16 @@ export class MessagesRepository {
       )
       .run(threadId, userId, new Date().toISOString());
   }
+
+  markThreadUnread(threadId: number, userId: number): void {
+    this.findThreadByIdForUser(threadId, userId);
+    getDb()
+      .prepare(
+        `INSERT INTO thread_reads (thread_id, user_id, last_read_at)
+         VALUES (?, ?, NULL)
+         ON CONFLICT(thread_id, user_id)
+         DO UPDATE SET last_read_at = NULL`,
+      )
+      .run(threadId, userId);
+  }
 }

--- a/apps/api_server/src/repositories/recurring_task_rules_repository.ts
+++ b/apps/api_server/src/repositories/recurring_task_rules_repository.ts
@@ -4,6 +4,7 @@ import { AppError } from '../errors/app_error';
 import type {
   CreateRecurringTaskRuleDto,
   RecurringTaskRule,
+  RecurringTaskRuleStep,
   UpdateRecurringTaskRuleDto,
 } from '../models/recurring_task_rule';
 
@@ -14,6 +15,7 @@ interface RuleRow {
   day_of_week: number | null;
   day_of_month: number | null;
   month: number | null;
+  steps_json: string | null;
   enabled: number;
   owner_id: number | null;
   created_at: string;
@@ -29,8 +31,55 @@ function rowToRule(row: RuleRow): RecurringTaskRule {
     month: row.month,
     enabled: row.enabled === 1,
     ownerId: row.owner_id,
+    steps: parseSteps(row.steps_json),
     createdAt: row.created_at,
   };
+}
+
+function parseSteps(raw: string | null): RecurringTaskRuleStep[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((step, index) => normalizeStep(step, index))
+      .filter((step): step is RecurringTaskRuleStep => step != null);
+  } catch {
+    return [];
+  }
+}
+
+function normalizeStep(step: unknown, fallbackIndex: number): RecurringTaskRuleStep | null {
+  if (step == null || typeof step !== 'object') return null;
+  const record = step as Record<string, unknown>;
+  const title = typeof record.title === 'string' ? record.title.trim() : '';
+  if (!title) return null;
+  const id =
+    typeof record.id === 'string' && record.id.trim().length > 0
+      ? record.id.trim()
+      : `step-${fallbackIndex + 1}-${uuidv4()}`;
+  const assigneeId =
+    typeof record.assigneeId === 'number'
+      ? record.assigneeId
+      : typeof record.assigneeId === 'string' && record.assigneeId.trim() !== ''
+        ? Number(record.assigneeId)
+        : null;
+  return {
+    id,
+    title,
+    assigneeId: Number.isFinite(assigneeId as number) ? (assigneeId as number) : null,
+    assigneeName: typeof record.assigneeName === 'string' ? record.assigneeName : null,
+  };
+}
+
+function serializeSteps(steps?: RecurringTaskRuleStep[]): string {
+  return JSON.stringify(
+    (steps ?? []).map((step, index) => ({
+      id: step.id.trim().length > 0 ? step.id.trim() : `step-${index + 1}-${uuidv4()}`,
+      title: step.title.trim(),
+      assigneeId: step.assigneeId ?? null,
+    })),
+  );
 }
 
 export class RecurringTaskRulesRepository {
@@ -72,8 +121,8 @@ export class RecurringTaskRulesRepository {
     const enabled = data.enabled !== false ? 1 : 0;
     getDb()
       .prepare(
-        `INSERT INTO recurring_task_rules (id, title, frequency, day_of_week, day_of_month, month, enabled, owner_id, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO recurring_task_rules (id, title, frequency, day_of_week, day_of_month, month, steps_json, enabled, owner_id, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         id,
@@ -82,6 +131,7 @@ export class RecurringTaskRulesRepository {
         data.dayOfWeek ?? null,
         data.dayOfMonth ?? null,
         data.month ?? null,
+        serializeSteps(data.steps),
         enabled,
         data.ownerId ?? null,
         now,
@@ -96,10 +146,12 @@ export class RecurringTaskRulesRepository {
   ): RecurringTaskRule {
     const existing = this.findById(id, userId);
     const enabled = data.enabled !== undefined ? (data.enabled ? 1 : 0) : (existing.enabled ? 1 : 0);
+    const steps =
+      data.steps !== undefined ? data.steps : existing.steps;
     getDb()
       .prepare(
         `UPDATE recurring_task_rules
-         SET title = ?, frequency = ?, day_of_week = ?, day_of_month = ?, month = ?, enabled = ?, owner_id = ?
+         SET title = ?, frequency = ?, day_of_week = ?, day_of_month = ?, month = ?, steps_json = ?, enabled = ?, owner_id = ?
          WHERE id = ?`,
       )
       .run(
@@ -108,6 +160,7 @@ export class RecurringTaskRulesRepository {
         data.dayOfWeek !== undefined ? data.dayOfWeek : existing.dayOfWeek,
         data.dayOfMonth !== undefined ? data.dayOfMonth : existing.dayOfMonth,
         data.month !== undefined ? data.month : existing.month,
+        serializeSteps(steps),
         enabled,
         data.ownerId !== undefined ? data.ownerId : existing.ownerId,
         id,

--- a/apps/api_server/src/repositories/tasks_repository.ts
+++ b/apps/api_server/src/repositories/tasks_repository.ts
@@ -9,6 +9,7 @@ interface TaskRow {
   notes: string | null;
   due_date: string | null;
   scheduled_date: string | null;
+  scheduled_order: number | null;
   locked: number;
   status: string;
   source_type: string | null;
@@ -26,6 +27,7 @@ function rowToTask(row: TaskRow): Task {
     notes: row.notes ?? null,
     dueDate: row.due_date,
     scheduledDate: row.scheduled_date ?? null,
+    scheduledOrder: row.scheduled_order ?? null,
     locked: row.locked === 1,
     status: row.status as Task['status'],
     sourceType: row.source_type,
@@ -53,7 +55,7 @@ const TASK_SELECT = `
     ON pi.template_id = pt.id
   LEFT JOIN recurring_task_rules rr
     ON tasks.source_type = 'recurring_rule'
-   AND tasks.source_id = rr.id
+   AND (tasks.source_id = rr.id OR tasks.source_id LIKE rr.id || ':%')
 `;
 
 export class TasksRepository {
@@ -63,13 +65,13 @@ export class TasksRepository {
         .prepare(
           `${TASK_SELECT}
            WHERE tasks.owner_id = ? OR tasks.owner_id IS NULL
-           ORDER BY tasks.due_date ASC, tasks.created_at ASC`,
+           ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
         )
         .all(userId) as TaskRow[];
       return rows.map(rowToTask);
     }
     const rows = getDb()
-      .prepare(`${TASK_SELECT} ORDER BY tasks.due_date ASC, tasks.created_at ASC`)
+      .prepare(`${TASK_SELECT} ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`)
       .all() as TaskRow[];
     return rows.map(rowToTask);
   }
@@ -102,10 +104,10 @@ export class TasksRepository {
       const rows = getDb()
           .prepare(
             `${TASK_SELECT}
-           WHERE (tasks.owner_id = ? OR tasks.owner_id IS NULL)
+          WHERE (tasks.owner_id = ? OR tasks.owner_id IS NULL)
              AND (tasks.due_date BETWEEN ? AND ? OR tasks.scheduled_date BETWEEN ? AND ?)
-           ORDER BY tasks.due_date ASC, tasks.created_at ASC`,
-        )
+         ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
+      )
         .all(userId, weekStart, weekEnd, weekStart, weekEnd) as TaskRow[];
       return rows.map(rowToTask);
     }
@@ -126,9 +128,9 @@ export class TasksRepository {
       .prepare(
         `INSERT INTO tasks (
           id, title, notes, due_date, scheduled_date, locked, status,
-          source_type, source_id, owner_id, created_at, updated_at
+          scheduled_order, source_type, source_id, owner_id, created_at, updated_at
         )
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         id,
@@ -138,6 +140,7 @@ export class TasksRepository {
         data.scheduledDate ?? null,
         data.locked ? 1 : 0,
         data.status ?? 'open',
+        data.scheduledOrder ?? null,
         data.sourceType ?? null,
         data.sourceId ?? null,
         data.ownerId ?? null,
@@ -165,6 +168,7 @@ export class TasksRepository {
       notes: data.notes ?? null,
       dueDate: data.dueDate ?? null,
       scheduledDate: data.scheduledDate ?? null,
+      scheduledOrder: data.scheduledOrder ?? null,
       status: data.status ?? 'open',
       locked: data.locked ?? existing.locked,
     });
@@ -208,9 +212,13 @@ export class TasksRepository {
     const today = new Date().toISOString().substring(0, 10);
     const result = getDb()
       .prepare(
-        `DELETE FROM tasks WHERE source_type = ? AND source_id = ? AND status = 'open' AND (due_date IS NULL OR due_date >= ?)`,
+        `DELETE FROM tasks
+         WHERE source_type = ?
+           AND (source_id = ? OR source_id LIKE ? || ':%')
+           AND status = 'open'
+           AND (due_date IS NULL OR due_date >= ?)`,
       )
-      .run(sourceType, sourceId, today);
+      .run(sourceType, sourceId, sourceId, today);
     return result.changes;
   }
 
@@ -228,11 +236,13 @@ export class TasksRepository {
     const nextDueDate = data.dueDate === '' ? null : data.dueDate;
     const nextScheduledDate =
       data.scheduledDate === '' ? null : data.scheduledDate;
+    const nextScheduledOrder =
+      data.scheduledOrder === null ? null : data.scheduledOrder;
     getDb()
       .prepare(
         `UPDATE tasks
          SET title = ?, notes = ?, due_date = ?, status = ?,
-             scheduled_date = ?, locked = ?, owner_id = ?, updated_at = ?
+             scheduled_date = ?, scheduled_order = ?, locked = ?, owner_id = ?, updated_at = ?
          WHERE id = ?`,
       )
       .run(
@@ -243,6 +253,9 @@ export class TasksRepository {
         nextScheduledDate !== undefined
             ? nextScheduledDate
             : existing.scheduledDate,
+        data.scheduledOrder !== undefined
+            ? nextScheduledOrder
+            : existing.scheduledOrder,
         data.locked !== undefined ? (data.locked ? 1 : 0) : (existing.locked ? 1 : 0),
         data.ownerId !== undefined ? data.ownerId : existing.ownerId,
         now,

--- a/apps/api_server/src/routes/messages_routes.ts
+++ b/apps/api_server/src/routes/messages_routes.ts
@@ -11,3 +11,4 @@ messagesRouter.post('/', controller.createThread.bind(controller));
 messagesRouter.get('/:id/messages', controller.getMessages.bind(controller));
 messagesRouter.post('/:id/messages', controller.createMessage.bind(controller));
 messagesRouter.post('/:id/read', controller.markRead.bind(controller));
+messagesRouter.post('/:id/unread', controller.markUnread.bind(controller));

--- a/apps/api_server/src/services/automation_engine_service.test.ts
+++ b/apps/api_server/src/services/automation_engine_service.test.ts
@@ -51,7 +51,7 @@ describe('Automation overhaul backend', () => {
       triggerConfig: {
         sender: 'finance@',
         subjectContains: 'invoice',
-        hoursSinceReceived: 24,
+        hoursSinceReceived: 48,
       },
       actionType: 'create_task',
       actionConfig: {

--- a/apps/api_server/src/services/recurrence_service.ts
+++ b/apps/api_server/src/services/recurrence_service.ts
@@ -13,24 +13,33 @@ export class RecurrenceService {
   generateInstances(rule: RecurringTaskRule, from: Date, to: Date): Task[] {
     const dates = this.computeDates(rule, from, to);
     const created: Task[] = [];
+    const hasWorkflowSteps = rule.steps.length > 0;
 
     for (const date of dates) {
       const dateStr = toDateStr(date);
-      const existing = getDb()
-        .prepare('SELECT id FROM tasks WHERE source_type = ? AND source_id = ? AND due_date = ?')
-        .get('recurring_rule', rule.id, dateStr);
+      const steps = hasWorkflowSteps
+        ? rule.steps
+        : [{ id: rule.id, title: rule.title, assigneeId: rule.ownerId }];
 
-      if (!existing) {
-        const task = this.tasksRepo.create({
-          title: rule.title,
-          dueDate: dateStr,
-          status: 'open',
-          sourceType: 'recurring_rule',
-          sourceId: rule.id,
-          ownerId: rule.ownerId,
-        });
-        created.push(task);
-      }
+      steps.forEach((step, index) => {
+        const sourceId = hasWorkflowSteps ? `${rule.id}:${step.id}` : rule.id;
+        const existing = getDb()
+          .prepare('SELECT id FROM tasks WHERE source_type = ? AND source_id = ? AND due_date = ?')
+          .get('recurring_rule', sourceId, dateStr);
+
+        if (!existing) {
+          const task = this.tasksRepo.create({
+            title: step.title,
+            dueDate: dateStr,
+            status: 'open',
+            sourceType: 'recurring_rule',
+            sourceId,
+            ownerId: step.assigneeId ?? rule.ownerId,
+            scheduledOrder: hasWorkflowSteps ? (index + 1) * 10000 : null,
+          });
+          created.push(task);
+        }
+      });
     }
 
     return created;

--- a/apps/api_server/src/services/weekly_planning_service.ts
+++ b/apps/api_server/src/services/weekly_planning_service.ts
@@ -31,6 +31,7 @@ interface TaskRow {
   notes: string | null;
   due_date: string | null;
   scheduled_date: string | null;
+  scheduled_order: number | null;
   locked: number;
   status: string;
   source_type: string | null;
@@ -111,7 +112,7 @@ export class WeeklyPlanningService {
         ON pi.template_id = pt.id
       LEFT JOIN recurring_task_rules rr
         ON tasks.source_type = 'recurring_rule'
-       AND tasks.source_id = rr.id
+       AND (tasks.source_id = rr.id OR tasks.source_id LIKE rr.id || ':%')
     `;
     const taskRows =
       userId != null
@@ -141,6 +142,7 @@ export class WeeklyPlanningService {
         title: row.title,
         dueDate: row.due_date,
         scheduledDate: row.scheduled_date ?? null,
+        scheduledOrder: row.scheduled_order ?? null,
         notes: row.notes ?? null,
         locked: row.locked === 1,
         status: row.status as Task['status'],
@@ -175,6 +177,7 @@ export class WeeklyPlanningService {
         notes: row.notes ?? null,
         dueDate: row.due_date,
         scheduledDate: null,
+        scheduledOrder: null,
         locked: false,
         status: row.status as Task['status'],
         sourceType: 'project_step',
@@ -218,11 +221,15 @@ export class WeeklyPlanningService {
         notes: detailBits.join(' • '),
         dueDate: dayKey,
         scheduledDate: dayKey,
+        scheduledOrder: null,
         locked: true,
         status: 'open',
         sourceType: 'calendar_shadow_event',
         sourceId: event.externalId,
         sourceName: event.sourceName,
+        startsAt: event.startAt,
+        endsAt: event.endAt,
+        isAllDay: event.isAllDay,
         ownerId: event.ownerId,
         createdAt: event.createdAt,
         updatedAt: event.updatedAt,
@@ -273,6 +280,7 @@ export class WeeklyPlanningService {
       notes: row.notes ?? null,
       dueDate: row.due_date ?? null,
       scheduledDate: row.scheduled_date ?? null,
+      scheduledOrder: row.scheduled_order ?? null,
       locked: row.locked === 1,
       status: row.status as Task['status'],
       sourceType: row.source_type,
@@ -301,6 +309,7 @@ export class WeeklyPlanningService {
         notes: row.notes ?? null,
         dueDate: null,
         scheduledDate: null,
+        scheduledOrder: null,
         locked: false,
         status: row.status as Task['status'],
         sourceType: 'project_step',
@@ -333,6 +342,7 @@ export class WeeklyPlanningService {
         notes: row.notes ?? null,
         dueDate: row.due_date ?? null,
         scheduledDate: null,
+        scheduledOrder: null,
         locked: false,
         status: row.status as Task['status'],
         sourceType: 'project_step',
@@ -344,6 +354,27 @@ export class WeeklyPlanningService {
       })),
     );
 
+    for (const day of days) {
+      day.tasks.sort(compareTaskVisualOrder);
+    }
+    backlog.sort(compareTaskVisualOrder);
+
     return { weekLabel, weekStart: startStr, days, backlog };
   }
+}
+
+function compareTaskVisualOrder(a: Task, b: Task): number {
+  const compare = taskVisualOrder(a) - taskVisualOrder(b);
+  if (compare !== 0) return compare;
+  return a.title.toLowerCase().localeCompare(b.title.toLowerCase());
+}
+
+function taskVisualOrder(task: Task): number {
+  if (task.sourceType === 'calendar_shadow_event' && task.startsAt != null) {
+    const date = new Date(task.startsAt);
+    if (!Number.isNaN(date.getTime())) {
+      return ((date.getUTCHours() * 60) + date.getUTCMinutes()) * 10000;
+    }
+  }
+  return task.scheduledOrder ?? 10000000;
 }

--- a/apps/desktop_flutter/lib/app/core/notifications/local_notification_service.dart
+++ b/apps/desktop_flutter/lib/app/core/notifications/local_notification_service.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+class LocalNotificationService {
+  LocalNotificationService()
+      : _plugin = FlutterLocalNotificationsPlugin();
+
+  final FlutterLocalNotificationsPlugin _plugin;
+  bool _initialized = false;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+
+    const macos = DarwinInitializationSettings();
+    const linux = LinuxInitializationSettings(defaultActionName: 'Open');
+    const settings = InitializationSettings(
+      macOS: macos,
+      linux: linux,
+    );
+    await _plugin.initialize(settings);
+    _initialized = true;
+  }
+
+  Future<void> showMessageNotification({
+    required int id,
+    required String title,
+    required String body,
+  }) async {
+    if (!_initialized) {
+      await initialize();
+    }
+
+    const details = NotificationDetails(
+      macOS: DarwinNotificationDetails(
+        presentAlert: true,
+        presentBadge: true,
+        presentSound: true,
+      ),
+      linux: LinuxNotificationDetails(),
+    );
+
+    await _plugin.show(id, title, body, details);
+  }
+}

--- a/apps/desktop_flutter/lib/features/dashboard/controllers/dashboard_controller.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/controllers/dashboard_controller.dart
@@ -152,7 +152,10 @@ class DashboardController extends ChangeNotifier {
       if (!rule.enabled) continue;
       final ruleTasks = tasks
           .where((task) =>
-              task.sourceType == 'recurring_rule' && task.sourceId == rule.id)
+              task.sourceType == 'recurring_rule' &&
+              task.sourceId != null &&
+              (task.sourceId == rule.id ||
+                  task.sourceId!.startsWith('${rule.id}:')))
           .toList()
         ..sort(_compareTasks);
       final completed = ruleTasks.where((task) => task.status == 'done').length;

--- a/apps/desktop_flutter/lib/features/messages/controllers/messages_controller.dart
+++ b/apps/desktop_flutter/lib/features/messages/controllers/messages_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../../../app/core/notifications/local_notification_service.dart';
 import '../../../app/core/auth/auth_user.dart';
 import '../models/message.dart';
 import '../models/message_thread.dart';
@@ -22,11 +23,15 @@ class IncomingMessageNotice {
 }
 
 class MessagesController extends ChangeNotifier {
-  MessagesController(this._repository,
-      {Duration pollInterval = const Duration(seconds: 30)})
-      : _pollInterval = pollInterval;
+  MessagesController(
+    this._repository, {
+    required LocalNotificationService notifications,
+    Duration pollInterval = const Duration(seconds: 30),
+  })  : _notifications = notifications,
+        _pollInterval = pollInterval;
 
   final MessagesRepository _repository;
+  final LocalNotificationService _notifications;
   final Duration _pollInterval;
 
   List<MessageThread> _threads = [];
@@ -165,6 +170,30 @@ class MessagesController extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> markThreadRead(int threadId) async {
+    _markThreadReadLocally(threadId);
+    notifyListeners();
+    try {
+      await _repository.markRead(threadId);
+      await loadThreads(silent: true);
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = MessagesStatus.error;
+      notifyListeners();
+    }
+  }
+
+  Future<void> markThreadUnread(int threadId) async {
+    try {
+      await _repository.markUnread(threadId);
+      await loadThreads(silent: true);
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = MessagesStatus.error;
+      notifyListeners();
+    }
+  }
+
   void startPolling() {
     _pollTimer ??= Timer.periodic(
       _pollInterval,
@@ -242,6 +271,11 @@ class MessagesController extends ChangeNotifier {
       senderName: latest.senderName,
       preview: latest.content,
     );
+    _showSystemNotification(
+      id: latest.id,
+      title: latest.senderName,
+      body: latest.content,
+    );
   }
 
   void _maybeNotifyForUnreadThreadActivity(
@@ -265,8 +299,27 @@ class MessagesController extends ChangeNotifier {
         senderName: thread.title,
         preview: thread.lastMessage ?? 'New message',
       );
+      _showSystemNotification(
+        id: (thread.id * 1000) + thread.unreadCount,
+        title: thread.title,
+        body: thread.lastMessage ?? 'New unread message',
+      );
       return;
     }
+  }
+
+  void _showSystemNotification({
+    required int id,
+    required String title,
+    required String body,
+  }) {
+    unawaited(
+      _notifications.showMessageNotification(
+        id: id,
+        title: title,
+        body: body,
+      ),
+    );
   }
 
   @override

--- a/apps/desktop_flutter/lib/features/messages/data/messages_data_source.dart
+++ b/apps/desktop_flutter/lib/features/messages/data/messages_data_source.dart
@@ -88,6 +88,16 @@ class MessagesDataSource {
     }
   }
 
+  Future<void> markUnread(int threadId) async {
+    final response = await http.post(
+      Uri.parse('$_baseUrl/message-threads/$threadId/unread'),
+      headers: AuthSessionStore.headers(),
+    );
+    if (response.statusCode != 204) {
+      _assertOk(response);
+    }
+  }
+
   void _assertOk(http.Response response) {
     if (response.statusCode >= 400) {
       final body = jsonDecode(response.body) as Map<String, dynamic>?;

--- a/apps/desktop_flutter/lib/features/messages/repositories/messages_repository.dart
+++ b/apps/desktop_flutter/lib/features/messages/repositories/messages_repository.dart
@@ -23,4 +23,6 @@ class MessagesRepository {
       _dataSource.sendMessage(threadId, content);
 
   Future<void> markRead(int threadId) => _dataSource.markRead(threadId);
+
+  Future<void> markUnread(int threadId) => _dataSource.markUnread(threadId);
 }

--- a/apps/desktop_flutter/lib/features/messages/views/messages_view.dart
+++ b/apps/desktop_flutter/lib/features/messages/views/messages_view.dart
@@ -142,6 +142,14 @@ class _ThreadListPanel extends StatelessWidget {
                               context.read<MessagesController>().selectThread(
                                     filtered[i].id,
                                   ),
+                          onToggleUnread: () {
+                            final messages = context.read<MessagesController>();
+                            if (filtered[i].isUnread) {
+                              messages.markThreadRead(filtered[i].id);
+                            } else {
+                              messages.markThreadUnread(filtered[i].id);
+                            }
+                          },
                         ),
                       ),
           ),
@@ -258,11 +266,13 @@ class _ThreadRow extends StatelessWidget {
     required this.thread,
     required this.isSelected,
     required this.onTap,
+    required this.onToggleUnread,
   });
 
   final MessageThread thread;
   final bool isSelected;
   final VoidCallback onTap;
+  final VoidCallback onToggleUnread;
 
   @override
   Widget build(BuildContext context) {
@@ -299,13 +309,13 @@ class _ThreadRow extends StatelessWidget {
             Container(
               width: 32,
               height: 32,
+              alignment: Alignment.center,
               decoration: BoxDecoration(
                 color: isSelected ? _kPrimary : const Color(0xFFE9EEF9),
                 borderRadius: BorderRadius.circular(10),
-            ),
-            alignment: Alignment.center,
-            child: Text(
-              initial,
+              ),
+              child: Text(
+                initial,
                 style: TextStyle(
                   fontSize: 13,
                   fontWeight: FontWeight.w700,
@@ -359,25 +369,52 @@ class _ThreadRow extends StatelessWidget {
                 ],
               ),
             ),
-            if (thread.isUnread) ...[
-              const SizedBox(width: 10),
-              Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-                decoration: BoxDecoration(
-                  color: _kPrimary,
-                  borderRadius: BorderRadius.circular(999),
-                ),
-                child: Text(
-                  '${thread.unreadCount}',
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 11,
-                    fontWeight: FontWeight.w700,
+            const SizedBox(width: 8),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                PopupMenuButton<String>(
+                  tooltip: 'Thread actions',
+                  icon: const Icon(
+                    Icons.more_horiz,
+                    size: 18,
+                    color: _kTextMuted,
                   ),
+                  color: _kSurface,
+                  surfaceTintColor: _kSurface,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+                    side: const BorderSide(color: _kDivider),
+                  ),
+                  itemBuilder: (context) => [
+                    PopupMenuItem<String>(
+                      value: thread.isUnread ? 'read' : 'unread',
+                      child: Text(
+                        thread.isUnread ? 'Mark as read' : 'Mark as unread',
+                      ),
+                    ),
+                  ],
+                  onSelected: (_) => onToggleUnread(),
                 ),
-              ),
-            ],
+                if (thread.isUnread)
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                    decoration: BoxDecoration(
+                      color: _kPrimary,
+                      borderRadius: BorderRadius.circular(999),
+                    ),
+                    child: Text(
+                      '${thread.unreadCount}',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
           ],
         ),
       ),

--- a/apps/desktop_flutter/lib/features/rhythms/controllers/rhythms_controller.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/controllers/rhythms_controller.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import '../../../app/core/auth/auth_user.dart';
 import '../../../features/tasks/models/recurring_task_rule.dart';
 import '../repositories/rhythms_repository.dart';
 
@@ -10,10 +11,12 @@ class RhythmsController extends ChangeNotifier {
   final RhythmsRepository _repository;
 
   List<RecurringTaskRule> _rules = [];
+  List<AuthUser> _users = [];
   RhythmsStatus _status = RhythmsStatus.idle;
   String? _errorMessage;
 
   List<RecurringTaskRule> get rules => _rules;
+  List<AuthUser> get users => _users;
   RhythmsStatus get status => _status;
   String? get errorMessage => _errorMessage;
 
@@ -23,7 +26,12 @@ class RhythmsController extends ChangeNotifier {
     notifyListeners();
 
     try {
-      _rules = await _repository.getAll();
+      final results = await Future.wait([
+        _repository.getAll(),
+        _repository.getUsers(),
+      ]);
+      _rules = results[0] as List<RecurringTaskRule>;
+      _users = results[1] as List<AuthUser>;
       _status = RhythmsStatus.idle;
     } catch (e) {
       _errorMessage = e.toString();
@@ -40,6 +48,7 @@ class RhythmsController extends ChangeNotifier {
     int? dayOfMonth,
     int? month,
     bool? enabled,
+    List<RecurringTaskRuleStep>? steps,
   }) async {
     try {
       final updated = await _repository.update(id,
@@ -48,7 +57,8 @@ class RhythmsController extends ChangeNotifier {
           dayOfWeek: dayOfWeek,
           dayOfMonth: dayOfMonth,
           month: month,
-          enabled: enabled);
+          enabled: enabled,
+          steps: steps);
       _rules = _rules.map((r) => r.id == id ? updated : r).toList();
       notifyListeners();
     } catch (e) {
@@ -64,6 +74,7 @@ class RhythmsController extends ChangeNotifier {
     int? dayOfWeek,
     int? dayOfMonth,
     int? month,
+    List<RecurringTaskRuleStep>? steps,
   }) async {
     try {
       final rule = await _repository.create(
@@ -72,6 +83,7 @@ class RhythmsController extends ChangeNotifier {
         dayOfWeek: dayOfWeek,
         dayOfMonth: dayOfMonth,
         month: month,
+        steps: steps,
       );
       _rules = [..._rules, rule];
       notifyListeners();

--- a/apps/desktop_flutter/lib/features/rhythms/data/rhythms_data_source.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/data/rhythms_data_source.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import '../../../app/core/auth/auth_user.dart';
 import '../../../app/core/auth/auth_session_store.dart';
 import '../../../app/core/constants/app_constants.dart';
 import '../../../app/core/errors/app_error.dart';
@@ -23,12 +24,23 @@ class RhythmsDataSource {
         .toList();
   }
 
+  Future<List<AuthUser>> fetchUsers() async {
+    final response = await http.get(
+      Uri.parse('$_baseUrl/users'),
+      headers: AuthSessionStore.headers(),
+    );
+    _assertOk(response);
+    final list = jsonDecode(response.body) as List<dynamic>;
+    return list.map((j) => AuthUser.fromJson(j as Map<String, dynamic>)).toList();
+  }
+
   Future<RecurringTaskRule> create({
     required String title,
     required String frequency,
     int? dayOfWeek,
     int? dayOfMonth,
     int? month,
+    List<RecurringTaskRuleStep>? steps,
   }) async {
     final response = await http.post(
       Uri.parse('$_baseUrl/recurring-rules'),
@@ -39,6 +51,8 @@ class RhythmsDataSource {
         if (dayOfWeek != null) 'dayOfWeek': dayOfWeek,
         if (dayOfMonth != null) 'dayOfMonth': dayOfMonth,
         if (month != null) 'month': month,
+        if (steps != null)
+          'steps': steps.map((step) => step.toJson()).toList(),
       }),
     );
     _assertOk(response);
@@ -54,6 +68,7 @@ class RhythmsDataSource {
     int? dayOfMonth,
     int? month,
     bool? enabled,
+    List<RecurringTaskRuleStep>? steps,
   }) async {
     final response = await http.patch(
       Uri.parse('$_baseUrl/recurring-rules/$id'),
@@ -65,6 +80,8 @@ class RhythmsDataSource {
         if (dayOfMonth != null) 'dayOfMonth': dayOfMonth,
         if (month != null) 'month': month,
         if (enabled != null) 'enabled': enabled,
+        if (steps != null)
+          'steps': steps.map((step) => step.toJson()).toList(),
       }),
     );
     _assertOk(response);

--- a/apps/desktop_flutter/lib/features/rhythms/repositories/rhythms_repository.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/repositories/rhythms_repository.dart
@@ -1,5 +1,6 @@
 import '../../../features/tasks/models/recurring_task_rule.dart';
 import '../data/rhythms_data_source.dart';
+import '../../../app/core/auth/auth_user.dart';
 
 class RhythmsRepository {
   RhythmsRepository(this._dataSource);
@@ -8,12 +9,15 @@ class RhythmsRepository {
 
   Future<List<RecurringTaskRule>> getAll() => _dataSource.fetchAll();
 
+  Future<List<AuthUser>> getUsers() => _dataSource.fetchUsers();
+
   Future<RecurringTaskRule> create({
     required String title,
     required String frequency,
     int? dayOfWeek,
     int? dayOfMonth,
     int? month,
+    List<RecurringTaskRuleStep>? steps,
   }) =>
       _dataSource.create(
         title: title,
@@ -21,6 +25,7 @@ class RhythmsRepository {
         dayOfWeek: dayOfWeek,
         dayOfMonth: dayOfMonth,
         month: month,
+        steps: steps,
       );
 
   Future<RecurringTaskRule> update(
@@ -31,6 +36,7 @@ class RhythmsRepository {
     int? dayOfMonth,
     int? month,
     bool? enabled,
+    List<RecurringTaskRuleStep>? steps,
   }) =>
       _dataSource.update(id,
           title: title,
@@ -38,7 +44,8 @@ class RhythmsRepository {
           dayOfWeek: dayOfWeek,
           dayOfMonth: dayOfMonth,
           month: month,
-          enabled: enabled);
+          enabled: enabled,
+          steps: steps);
 
   Future<void> delete(String id) => _dataSource.delete(id);
 }

--- a/apps/desktop_flutter/lib/features/rhythms/views/rhythms_view.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/views/rhythms_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import '../../../app/core/auth/auth_user.dart';
 import '../../../app/core/widgets/error_banner.dart';
 import '../../../app/theme/rhythm_tokens.dart';
 import '../controllers/rhythms_controller.dart';
@@ -18,6 +19,7 @@ const _kTextSecondary = RhythmTokens.textSecondary;
 const _kTextMuted = RhythmTokens.textMuted;
 const _kPrimary = RhythmTokens.accent;
 const _kPrimarySoft = RhythmTokens.accentSoft;
+const _kWarm = RhythmTokens.accentWarm;
 
 class RhythmsView extends StatefulWidget {
   const RhythmsView({super.key});
@@ -272,6 +274,10 @@ class _RuleTileState extends State<_RuleTile> {
                               color: _kTextSecondary,
                             ),
                       ),
+                      if (widget.rule.progress != null) ...[
+                        const SizedBox(height: 12),
+                        _ProgressStrip(rule: widget.rule),
+                      ],
                     ],
                   ),
                 ),
@@ -348,6 +354,40 @@ class _RuleTileState extends State<_RuleTile> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      if (widget.rule.steps.isNotEmpty) ...[
+                        Row(
+                          children: [
+                            const Icon(
+                              Icons.route_outlined,
+                              size: 14,
+                              color: _kTextMuted,
+                            ),
+                            const SizedBox(width: 6),
+                            Text(
+                              'Workflow steps',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelMedium
+                                  ?.copyWith(
+                                    color: _kTextSecondary,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 10),
+                        Column(
+                          children: widget.rule.steps
+                              .map(
+                                (step) => Padding(
+                                  padding: const EdgeInsets.only(bottom: 8),
+                                  child: _WorkflowStepTile(step: step),
+                                ),
+                              )
+                              .toList(),
+                        ),
+                        const SizedBox(height: 8),
+                      ],
                       Row(
                         children: [
                           const Icon(
@@ -404,7 +444,7 @@ class _RuleTileState extends State<_RuleTile> {
               ),
               crossFadeState: _expanded
                   ? CrossFadeState.showSecond
-                  : CrossFadeState.showFirst,
+              : CrossFadeState.showFirst,
               duration: const Duration(milliseconds: 180),
             ),
           ],
@@ -445,9 +485,196 @@ class _RuleTileState extends State<_RuleTile> {
   }
 }
 
+class _ProgressStrip extends StatelessWidget {
+  const _ProgressStrip({required this.rule});
+
+  final RecurringTaskRule rule;
+
+  @override
+  Widget build(BuildContext context) {
+    final progress = rule.progress;
+    if (progress == null) return const SizedBox.shrink();
+    final percent = (progress.completionRatio * 100).round().clamp(0, 100);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            _InlineMetric(
+              label: 'Remaining',
+              value: '${progress.remainingCount}',
+              color: _kPrimary,
+            ),
+            const SizedBox(width: 8),
+            _InlineMetric(
+              label: 'Personal',
+              value: '${progress.personalRemainingCount}',
+              color: _kWarm,
+            ),
+            const SizedBox(width: 8),
+            _InlineMetric(
+              label: 'Complete',
+              value: '$percent%',
+              color: _kPrimary,
+            ),
+            const SizedBox(width: 8),
+            if (progress.waitingOnUserName != null)
+              Flexible(
+                child: _InlineMetric(
+                  label: 'Waiting on',
+                  value: progress.waitingOnUserName!,
+                  color: _kTextSecondary,
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(999),
+          child: LinearProgressIndicator(
+            minHeight: 7,
+            value: progress.totalCount == 0 ? 0 : progress.completionRatio,
+            backgroundColor: _kBorderSoft,
+            valueColor: const AlwaysStoppedAnimation<Color>(_kPrimary),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _InlineMetric extends StatelessWidget {
+  const _InlineMetric({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+        border: Border.all(color: color.withValues(alpha: 0.14)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: _kTextMuted,
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _WorkflowStepTile extends StatelessWidget {
+  const _WorkflowStepTile({required this.step});
+
+  final RecurringTaskRuleStep step;
+
+  @override
+  Widget build(BuildContext context) {
+    final assignee = step.assigneeName?.trim().isNotEmpty == true
+        ? step.assigneeName!
+        : 'Unassigned';
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: _kSurface,
+        borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+        border: Border.all(color: _kBorderSoft),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 22,
+            height: 22,
+            decoration: BoxDecoration(
+              color: _kPrimarySoft,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: const Icon(Icons.checklist, size: 13, color: _kPrimary),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  step.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                        color: _kTextPrimary,
+                        fontWeight: FontWeight.w700,
+                      ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  assignee,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: _kTextSecondary,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Create Rule Dialog
 // ---------------------------------------------------------------------------
+
+class _StepEditorModel {
+  _StepEditorModel({required this.id, String? title, this.assigneeId})
+      : titleController = TextEditingController(text: title ?? '');
+
+  final String id;
+  final TextEditingController titleController;
+  int? assigneeId;
+
+  void dispose() => titleController.dispose();
+
+  RecurringTaskRuleStep toStep() {
+    return RecurringTaskRuleStep(
+      id: id,
+      title: titleController.text.trim(),
+      assigneeId: assigneeId,
+    );
+  }
+}
 
 class _CreateRuleDialog extends StatefulWidget {
   const _CreateRuleDialog({required this.controller});
@@ -464,6 +691,7 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
   int _dayOfMonth = 1;
   int _month = 1;
   bool _saving = false;
+  final List<_StepEditorModel> _steps = [];
 
   static const _weekdays = [
     'Sunday',
@@ -491,6 +719,9 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
 
   @override
   void dispose() {
+    for (final step in _steps) {
+      step.dispose();
+    }
     _titleController.dispose();
     super.dispose();
   }
@@ -500,66 +731,146 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
     return AlertDialog(
       title: const Text('New Recurring Rule'),
       content: SizedBox(
-        width: 400,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TextField(
-              controller: _titleController,
-              decoration: const InputDecoration(
-                  labelText: 'Title', border: OutlineInputBorder()),
-              autofocus: true,
-            ),
-            const SizedBox(height: 16),
-            DropdownButtonFormField<String>(
-              value: _frequency,
-              decoration: const InputDecoration(
-                  labelText: 'Frequency', border: OutlineInputBorder()),
-              items: const [
-                DropdownMenuItem(value: 'weekly', child: Text('Weekly')),
-                DropdownMenuItem(value: 'monthly', child: Text('Monthly')),
-                DropdownMenuItem(value: 'annual', child: Text('Annual')),
-              ],
-              onChanged: (v) => setState(() => _frequency = v!),
-            ),
-            const SizedBox(height: 16),
-            if (_frequency == 'weekly') ...[
-              DropdownButtonFormField<int>(
-                value: _dayOfWeek,
+        width: 620,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: _titleController,
                 decoration: const InputDecoration(
-                    labelText: 'Day of Week', border: OutlineInputBorder()),
-                items: List.generate(
+                  labelText: 'Title',
+                  border: OutlineInputBorder(),
+                ),
+                autofocus: true,
+              ),
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                value: _frequency,
+                decoration: const InputDecoration(
+                  labelText: 'Frequency',
+                  border: OutlineInputBorder(),
+                ),
+                items: const [
+                  DropdownMenuItem(value: 'weekly', child: Text('Weekly')),
+                  DropdownMenuItem(value: 'monthly', child: Text('Monthly')),
+                  DropdownMenuItem(value: 'annual', child: Text('Annual')),
+                ],
+                onChanged: (v) => setState(() => _frequency = v!),
+              ),
+              const SizedBox(height: 16),
+              if (_frequency == 'weekly') ...[
+                DropdownButtonFormField<int>(
+                  value: _dayOfWeek,
+                  decoration: const InputDecoration(
+                    labelText: 'Day of Week',
+                    border: OutlineInputBorder(),
+                  ),
+                  items: List.generate(
                     7,
-                    (i) =>
-                        DropdownMenuItem(value: i, child: Text(_weekdays[i]))),
-                onChanged: (v) => setState(() => _dayOfWeek = v!),
-              ),
-            ],
-            if (_frequency == 'monthly') ...[
-              _DayOfMonthField(
-                value: _dayOfMonth,
-                onChanged: (v) => setState(() => _dayOfMonth = v),
-              ),
-            ],
-            if (_frequency == 'annual') ...[
-              DropdownButtonFormField<int>(
-                value: _month,
-                decoration: const InputDecoration(
-                    labelText: 'Month', border: OutlineInputBorder()),
-                items: List.generate(
+                    (i) => DropdownMenuItem(value: i, child: Text(_weekdays[i])),
+                  ),
+                  onChanged: (v) => setState(() => _dayOfWeek = v!),
+                ),
+              ],
+              if (_frequency == 'monthly') ...[
+                _DayOfMonthField(
+                  value: _dayOfMonth,
+                  onChanged: (v) => setState(() => _dayOfMonth = v),
+                ),
+              ],
+              if (_frequency == 'annual') ...[
+                DropdownButtonFormField<int>(
+                  value: _month,
+                  decoration: const InputDecoration(
+                    labelText: 'Month',
+                    border: OutlineInputBorder(),
+                  ),
+                  items: List.generate(
                     12,
-                    (i) => DropdownMenuItem(
-                        value: i + 1, child: Text(_months[i]))),
-                onChanged: (v) => setState(() => _month = v!),
+                    (i) => DropdownMenuItem(value: i + 1, child: Text(_months[i])),
+                  ),
+                  onChanged: (v) => setState(() => _month = v!),
+                ),
+                const SizedBox(height: 12),
+                _DayOfMonthField(
+                  value: _dayOfMonth,
+                  onChanged: (v) => setState(() => _dayOfMonth = v),
+                ),
+              ],
+              const SizedBox(height: 18),
+              Row(
+                children: [
+                  const Expanded(
+                    child: Text(
+                      'Workflow steps',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: _kTextPrimary,
+                      ),
+                    ),
+                  ),
+                  TextButton.icon(
+                    onPressed: () {
+                      setState(() {
+                        _steps.add(
+                          _StepEditorModel(
+                            id: _newStepId(_steps.length),
+                          ),
+                        );
+                      });
+                    },
+                    icon: const Icon(Icons.add, size: 16),
+                    label: const Text('Add step'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              Text(
+                'Leave this empty to use the rhythm title as a single recurring task.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: _kTextMuted,
+                    ),
               ),
               const SizedBox(height: 12),
-              _DayOfMonthField(
-                value: _dayOfMonth,
-                onChanged: (v) => setState(() => _dayOfMonth = v),
-              ),
+              if (_steps.isEmpty)
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: _kSurfaceMuted,
+                    borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+                    border: Border.all(color: _kBorderSoft),
+                  ),
+                  child: const Text(
+                    'No steps yet. Add one if this rhythm needs multiple tasks or assignees.',
+                    style: TextStyle(color: _kTextMuted, fontSize: 12),
+                  ),
+                )
+              else
+                Column(
+                  children: [
+                    for (var i = 0; i < _steps.length; i++) ...[
+                      _StepEditorRow(
+                        step: _steps[i],
+                        users: widget.controller.users,
+                        onAssigneeChanged: (value) =>
+                            setState(() => _steps[i].assigneeId = value),
+                        onRemove: () {
+                          setState(() {
+                            _steps[i].dispose();
+                            _steps.removeAt(i);
+                          });
+                        },
+                      ),
+                      if (i != _steps.length - 1) const SizedBox(height: 10),
+                    ],
+                  ],
+                ),
             ],
-          ],
+          ),
         ),
       ),
       actions: [
@@ -580,9 +891,18 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
     );
   }
 
+  String _newStepId(int index) {
+    return 'step-${DateTime.now().microsecondsSinceEpoch}-$index';
+  }
+
   Future<void> _save() async {
     final title = _titleController.text.trim();
     if (title.isEmpty) return;
+
+    final steps = _steps
+        .map((step) => step.toStep())
+        .where((step) => step.title.trim().isNotEmpty)
+        .toList();
 
     setState(() => _saving = true);
     await widget.controller.createRule(
@@ -593,6 +913,7 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
           ? _dayOfMonth
           : null,
       month: _frequency == 'annual' ? _month : null,
+      steps: steps,
     );
     if (mounted) Navigator.pop(context);
   }
@@ -614,6 +935,7 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
   late int _dayOfMonth;
   late int _month;
   bool _saving = false;
+  final List<_StepEditorModel> _steps = [];
 
   static const _weekdays = [
     'Sunday',
@@ -647,10 +969,22 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
     _dayOfWeek = widget.rule.dayOfWeek ?? 1;
     _dayOfMonth = widget.rule.dayOfMonth ?? 1;
     _month = widget.rule.month ?? 1;
+    _steps.addAll(
+      widget.rule.steps.map(
+        (step) => _StepEditorModel(
+          id: step.id,
+          title: step.title,
+          assigneeId: step.assigneeId,
+        ),
+      ),
+    );
   }
 
   @override
   void dispose() {
+    for (final step in _steps) {
+      step.dispose();
+    }
     _titleController.dispose();
     super.dispose();
   }
@@ -660,68 +994,151 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
     return AlertDialog(
       title: const Text('Edit Rule'),
       content: SizedBox(
-        width: 400,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TextField(
-              controller: _titleController,
-              decoration: const InputDecoration(
-                  labelText: 'Title', border: OutlineInputBorder()),
-              autofocus: true,
-            ),
-            const SizedBox(height: 16),
-            DropdownButtonFormField<String>(
-              value: _frequency,
-              decoration: const InputDecoration(
-                  labelText: 'Frequency', border: OutlineInputBorder()),
-              items: const [
-                DropdownMenuItem(value: 'weekly', child: Text('Weekly')),
-                DropdownMenuItem(value: 'monthly', child: Text('Monthly')),
-                DropdownMenuItem(value: 'annual', child: Text('Annual')),
-              ],
-              onChanged: (v) => setState(() => _frequency = v!),
-            ),
-            const SizedBox(height: 16),
-            if (_frequency == 'weekly')
-              DropdownButtonFormField<int>(
-                value: _dayOfWeek,
+        width: 620,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: _titleController,
                 decoration: const InputDecoration(
-                    labelText: 'Day of Week', border: OutlineInputBorder()),
-                items: List.generate(
-                    7,
-                    (i) =>
-                        DropdownMenuItem(value: i, child: Text(_weekdays[i]))),
-                onChanged: (v) => setState(() => _dayOfWeek = v!),
+                  labelText: 'Title',
+                  border: OutlineInputBorder(),
+                ),
+                autofocus: true,
               ),
-            if (_frequency == 'monthly')
-              _DayOfMonthField(
-                  value: _dayOfMonth,
-                  onChanged: (v) => setState(() => _dayOfMonth = v)),
-            if (_frequency == 'annual') ...[
-              DropdownButtonFormField<int>(
-                value: _month,
+              const SizedBox(height: 16),
+              DropdownButtonFormField<String>(
+                value: _frequency,
                 decoration: const InputDecoration(
-                    labelText: 'Month', border: OutlineInputBorder()),
-                items: List.generate(
+                  labelText: 'Frequency',
+                  border: OutlineInputBorder(),
+                ),
+                items: const [
+                  DropdownMenuItem(value: 'weekly', child: Text('Weekly')),
+                  DropdownMenuItem(value: 'monthly', child: Text('Monthly')),
+                  DropdownMenuItem(value: 'annual', child: Text('Annual')),
+                ],
+                onChanged: (v) => setState(() => _frequency = v!),
+              ),
+              const SizedBox(height: 16),
+              if (_frequency == 'weekly')
+                DropdownButtonFormField<int>(
+                  value: _dayOfWeek,
+                  decoration: const InputDecoration(
+                    labelText: 'Day of Week',
+                    border: OutlineInputBorder(),
+                  ),
+                  items: List.generate(
+                    7,
+                    (i) => DropdownMenuItem(value: i, child: Text(_weekdays[i])),
+                  ),
+                  onChanged: (v) => setState(() => _dayOfWeek = v!),
+                ),
+              if (_frequency == 'monthly')
+                _DayOfMonthField(
+                  value: _dayOfMonth,
+                  onChanged: (v) => setState(() => _dayOfMonth = v),
+                ),
+              if (_frequency == 'annual') ...[
+                DropdownButtonFormField<int>(
+                  value: _month,
+                  decoration: const InputDecoration(
+                    labelText: 'Month',
+                    border: OutlineInputBorder(),
+                  ),
+                  items: List.generate(
                     12,
-                    (i) => DropdownMenuItem(
-                        value: i + 1, child: Text(_months[i]))),
-                onChanged: (v) => setState(() => _month = v!),
+                    (i) => DropdownMenuItem(value: i + 1, child: Text(_months[i])),
+                  ),
+                  onChanged: (v) => setState(() => _month = v!),
+                ),
+                const SizedBox(height: 12),
+                _DayOfMonthField(
+                  value: _dayOfMonth,
+                  onChanged: (v) => setState(() => _dayOfMonth = v),
+                ),
+              ],
+              const SizedBox(height: 18),
+              Row(
+                children: [
+                  const Expanded(
+                    child: Text(
+                      'Workflow steps',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: _kTextPrimary,
+                      ),
+                    ),
+                  ),
+                  TextButton.icon(
+                    onPressed: () {
+                      setState(() {
+                        _steps.add(
+                          _StepEditorModel(
+                            id: _newStepId(_steps.length),
+                          ),
+                        );
+                      });
+                    },
+                    icon: const Icon(Icons.add, size: 16),
+                    label: const Text('Add step'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              Text(
+                'Leave this empty to keep the rhythm as a single task.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: _kTextMuted,
+                    ),
               ),
               const SizedBox(height: 12),
-              _DayOfMonthField(
-                  value: _dayOfMonth,
-                  onChanged: (v) => setState(() => _dayOfMonth = v)),
+              if (_steps.isEmpty)
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: _kSurfaceMuted,
+                    borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+                    border: Border.all(color: _kBorderSoft),
+                  ),
+                  child: const Text(
+                    'No steps yet. Add one if this rhythm needs multiple tasks or assignees.',
+                    style: TextStyle(color: _kTextMuted, fontSize: 12),
+                  ),
+                )
+              else
+                Column(
+                  children: [
+                    for (var i = 0; i < _steps.length; i++) ...[
+                      _StepEditorRow(
+                        step: _steps[i],
+                        users: widget.controller.users,
+                        onAssigneeChanged: (value) =>
+                            setState(() => _steps[i].assigneeId = value),
+                        onRemove: () {
+                          setState(() {
+                            _steps[i].dispose();
+                            _steps.removeAt(i);
+                          });
+                        },
+                      ),
+                      if (i != _steps.length - 1) const SizedBox(height: 10),
+                    ],
+                  ],
+                ),
             ],
-          ],
+          ),
         ),
       ),
       actions: [
         TextButton(
-            onPressed: _saving ? null : () => Navigator.pop(context),
-            child: const Text('Cancel')),
+          onPressed: _saving ? null : () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
         FilledButton(
           onPressed: _saving ? null : _save,
           child: _saving
@@ -735,9 +1152,17 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
     );
   }
 
+  String _newStepId(int index) {
+    return 'step-${DateTime.now().microsecondsSinceEpoch}-$index';
+  }
+
   Future<void> _save() async {
     final title = _titleController.text.trim();
     if (title.isEmpty) return;
+    final steps = _steps
+        .map((step) => step.toStep())
+        .where((step) => step.title.trim().isNotEmpty)
+        .toList();
     setState(() => _saving = true);
     await widget.controller.updateRule(
       widget.rule.id,
@@ -748,8 +1173,87 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
           ? _dayOfMonth
           : null,
       month: _frequency == 'annual' ? _month : null,
+      steps: steps,
     );
     if (mounted) Navigator.pop(context);
+  }
+}
+
+class _StepEditorRow extends StatelessWidget {
+  const _StepEditorRow({
+    required this.step,
+    required this.users,
+    required this.onAssigneeChanged,
+    required this.onRemove,
+  });
+
+  final _StepEditorModel step;
+  final List<AuthUser> users;
+  final ValueChanged<int?> onAssigneeChanged;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: _kSurfaceMuted,
+        borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+        border: Border.all(color: _kBorderSoft),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Expanded(
+                child: Text(
+                  'Step',
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: _kTextSecondary,
+                  ),
+                ),
+              ),
+              IconButton(
+                onPressed: onRemove,
+                icon: const Icon(Icons.delete_outline, size: 18),
+                tooltip: 'Remove step',
+              ),
+            ],
+          ),
+          TextField(
+            controller: step.titleController,
+            decoration: const InputDecoration(
+              labelText: 'Task title',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 12),
+          DropdownButtonFormField<int?>(
+            value: step.assigneeId,
+            decoration: const InputDecoration(
+              labelText: 'Assign to',
+              border: OutlineInputBorder(),
+            ),
+            items: [
+              const DropdownMenuItem<int?>(
+                value: null,
+                child: Text('Unassigned'),
+              ),
+              ...users.map(
+                (user) => DropdownMenuItem<int?>(
+                  value: user.id,
+                  child: Text(user.name),
+                ),
+              ),
+            ],
+            onChanged: onAssigneeChanged,
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/apps/desktop_flutter/lib/features/tasks/models/recurring_task_rule.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/recurring_task_rule.dart
@@ -1,3 +1,67 @@
+class RecurringTaskRuleStep {
+  RecurringTaskRuleStep({
+    required this.id,
+    required this.title,
+    this.assigneeId,
+    this.assigneeName,
+  });
+
+  factory RecurringTaskRuleStep.fromJson(Map<String, dynamic> json) {
+    return RecurringTaskRuleStep(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      assigneeId: json['assigneeId'] as int?,
+      assigneeName: json['assigneeName'] as String?,
+    );
+  }
+
+  final String id;
+  final String title;
+  final int? assigneeId;
+  final String? assigneeName;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'assigneeId': assigneeId,
+      };
+}
+
+class RecurringTaskRuleProgress {
+  RecurringTaskRuleProgress({
+    required this.totalCount,
+    required this.completedCount,
+    required this.remainingCount,
+    required this.personalRemainingCount,
+    required this.waitingOnUserId,
+    required this.waitingOnUserName,
+    required this.nextDueDate,
+    required this.completionRatio,
+  });
+
+  factory RecurringTaskRuleProgress.fromJson(Map<String, dynamic> json) {
+    return RecurringTaskRuleProgress(
+      totalCount: json['totalCount'] as int? ?? 0,
+      completedCount: json['completedCount'] as int? ?? 0,
+      remainingCount: json['remainingCount'] as int? ?? 0,
+      personalRemainingCount: json['personalRemainingCount'] as int? ?? 0,
+      waitingOnUserId: json['waitingOnUserId'] as int?,
+      waitingOnUserName: json['waitingOnUserName'] as String?,
+      nextDueDate: json['nextDueDate'] as String?,
+      completionRatio: (json['completionRatio'] as num?)?.toDouble() ?? 0,
+    );
+  }
+
+  final int totalCount;
+  final int completedCount;
+  final int remainingCount;
+  final int personalRemainingCount;
+  final int? waitingOnUserId;
+  final String? waitingOnUserName;
+  final String? nextDueDate;
+  final double completionRatio;
+}
+
 class RecurringTaskRule {
   RecurringTaskRule({
     required this.id,
@@ -8,6 +72,8 @@ class RecurringTaskRule {
     this.dayOfMonth,
     this.month,
     this.enabled = true,
+    this.steps = const [],
+    this.progress,
   });
 
   factory RecurringTaskRule.fromJson(Map<String, dynamic> json) {
@@ -20,6 +86,16 @@ class RecurringTaskRule {
       month: json['month'] as int?,
       createdAt: json['createdAt'] as String,
       enabled: (json['enabled'] as bool?) ?? true,
+      steps: ((json['steps'] as List<dynamic>?) ?? const [])
+          .map((step) => RecurringTaskRuleStep.fromJson(
+                step as Map<String, dynamic>,
+              ))
+          .toList(),
+      progress: json['progress'] is Map<String, dynamic>
+          ? RecurringTaskRuleProgress.fromJson(
+              json['progress'] as Map<String, dynamic>,
+            )
+          : null,
     );
   }
 
@@ -31,6 +107,8 @@ class RecurringTaskRule {
   final int? month; // 1-12 (annual)
   final bool enabled;
   final String createdAt;
+  final List<RecurringTaskRuleStep> steps;
+  final RecurringTaskRuleProgress? progress;
 
   RecurringTaskRule copyWith({bool? enabled}) {
     return RecurringTaskRule(
@@ -42,8 +120,17 @@ class RecurringTaskRule {
       month: month,
       createdAt: createdAt,
       enabled: enabled ?? this.enabled,
+      steps: steps,
+      progress: progress,
     );
   }
+
+  bool get hasWorkflowSteps => steps.isNotEmpty;
+  double get completionFraction => progress?.completionRatio ?? 0;
+  int get remainingCount => progress?.remainingCount ?? 0;
+  int get personalRemainingCount => progress?.personalRemainingCount ?? 0;
+  String? get waitingOnUserName => progress?.waitingOnUserName;
+  String? get nextDueDate => progress?.nextDueDate;
 
   String get patternDescription {
     switch (frequency) {

--- a/apps/desktop_flutter/lib/features/tasks/models/task.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/task.dart
@@ -8,10 +8,14 @@ class Task {
     this.notes,
     this.dueDate,
     this.scheduledDate,
+    this.scheduledOrder,
     this.locked = false,
     this.sourceType,
     this.sourceId,
     this.sourceName,
+    this.startsAt,
+    this.endsAt,
+    this.isAllDay = false,
   });
 
   factory Task.fromJson(Map<String, dynamic> json) {
@@ -21,11 +25,15 @@ class Task {
       notes: json['notes'] as String?,
       dueDate: json['dueDate'] as String?,
       scheduledDate: json['scheduledDate'] as String?,
+      scheduledOrder: json['scheduledOrder'] as int?,
       locked: (json['locked'] as bool?) ?? false,
       status: json['status'] as String? ?? 'open',
       sourceType: json['sourceType'] as String?,
       sourceId: json['sourceId'] as String?,
       sourceName: json['sourceName'] as String?,
+      startsAt: json['startsAt'] as String?,
+      endsAt: json['endsAt'] as String?,
+      isAllDay: (json['isAllDay'] as bool?) ?? false,
       createdAt: json['createdAt'] as String? ?? '',
       updatedAt: json['updatedAt'] as String? ?? '',
     );
@@ -36,11 +44,15 @@ class Task {
   final String? notes;
   final String? dueDate;
   final String? scheduledDate;
+  final int? scheduledOrder;
   final bool locked;
   final String status;
   final String? sourceType;
   final String? sourceId;
   final String? sourceName;
+  final String? startsAt;
+  final String? endsAt;
+  final bool isAllDay;
   final String createdAt;
   final String updatedAt;
 
@@ -50,11 +62,15 @@ class Task {
         'notes': notes,
         'dueDate': dueDate,
         'scheduledDate': scheduledDate,
+        'scheduledOrder': scheduledOrder,
         'locked': locked,
         'status': status,
         'sourceType': sourceType,
         'sourceId': sourceId,
         'sourceName': sourceName,
+        'startsAt': startsAt,
+        'endsAt': endsAt,
+        'isAllDay': isAllDay,
         'createdAt': createdAt,
         'updatedAt': updatedAt,
       };
@@ -64,6 +80,7 @@ class Task {
     String? notes,
     String? dueDate,
     String? scheduledDate,
+    int? scheduledOrder,
     bool? locked,
     String? status,
   }) {
@@ -73,11 +90,15 @@ class Task {
       notes: notes ?? this.notes,
       dueDate: dueDate ?? this.dueDate,
       scheduledDate: scheduledDate ?? this.scheduledDate,
+      scheduledOrder: scheduledOrder ?? this.scheduledOrder,
       locked: locked ?? this.locked,
       status: status ?? this.status,
       sourceType: sourceType,
       sourceId: sourceId,
       sourceName: sourceName,
+      startsAt: startsAt,
+      endsAt: endsAt,
+      isAllDay: isAllDay,
       createdAt: createdAt,
       updatedAt: updatedAt,
     );

--- a/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
@@ -286,7 +286,8 @@ class _EmptyState extends StatelessWidget {
   Widget build(BuildContext context) {
     return Center(
       child: Container(
-        padding: const EdgeInsets.all(28),
+        constraints: const BoxConstraints(maxWidth: 520),
+        padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 18),
         decoration: BoxDecoration(
           color: RhythmTokens.surfaceStrong,
           borderRadius: BorderRadius.circular(RhythmTokens.radiusL),
@@ -297,34 +298,35 @@ class _EmptyState extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Container(
-              width: 56,
-              height: 56,
+              width: 40,
+              height: 40,
               decoration: BoxDecoration(
                 color: RhythmTokens.accentSoft,
                 borderRadius: BorderRadius.circular(RhythmTokens.radiusM),
               ),
               child: const Icon(
                 Icons.bolt_outlined,
-                size: 28,
+                size: 20,
                 color: RhythmTokens.accent,
               ),
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: 10),
             const Text(
               'No automations yet',
               style: TextStyle(
-                fontSize: 18,
+                fontSize: 16,
                 fontWeight: FontWeight.w600,
                 color: RhythmTokens.textPrimary,
               ),
             ),
-            const SizedBox(height: 8),
+            const SizedBox(height: 6),
             const Text(
               'Connect providers, sync data, and create rules from external metadata.',
+              maxLines: 2,
               style: TextStyle(color: RhythmTokens.textSecondary),
               textAlign: TextAlign.center,
             ),
-            const SizedBox(height: 20),
+            const SizedBox(height: 12),
             FilledButton.icon(
               onPressed: onCreate,
               icon: const Icon(Icons.add),

--- a/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
@@ -78,14 +78,19 @@ class WeeklyPlannerController extends ChangeNotifier {
 
   Future<void> scheduleTask(Task task, String date) async {
     try {
+      final scheduledOrder = _defaultScheduledOrderForDate(date);
       if (task.sourceType == 'project_step') {
         await _repository.updateTask(task.id,
             dueDate: date, sourceType: task.sourceType);
       } else if (task.dueDate == null && task.scheduledDate == null) {
         await _repository.updateTask(task.id,
-            dueDate: date, scheduledDate: date, sourceType: task.sourceType);
+            dueDate: date,
+            scheduledDate: date,
+            scheduledOrder: scheduledOrder,
+            sourceType: task.sourceType);
       } else {
-        await _repository.scheduleTask(task.id, date);
+        await _repository.scheduleTask(task.id, date,
+            scheduledOrder: scheduledOrder);
       }
       await load();
     } catch (e) {
@@ -108,12 +113,16 @@ class WeeklyPlannerController extends ChangeNotifier {
   }
 
   Future<void> updateTask(Task task,
-      {String? notes, String? dueDate, String? scheduledDate}) async {
+      {String? notes,
+      String? dueDate,
+      String? scheduledDate,
+      int? scheduledOrder}) async {
     try {
       await _repository.updateTask(task.id,
           notes: notes,
           dueDate: dueDate,
           scheduledDate: scheduledDate,
+          scheduledOrder: scheduledOrder,
           sourceType: task.sourceType);
       await load();
     } catch (e) {
@@ -150,6 +159,73 @@ class WeeklyPlannerController extends ChangeNotifier {
       _status = WeeklyPlannerStatus.error;
       notifyListeners();
     }
+  }
+
+  Future<void> moveTaskEarlier(Task task) async {
+    await _repositionTask(task, earlier: true);
+  }
+
+  Future<void> moveTaskLater(Task task) async {
+    await _repositionTask(task, earlier: false);
+  }
+
+  Future<void> _repositionTask(Task task, {required bool earlier}) async {
+    if (task.sourceType == 'calendar_shadow_event') return;
+    final date = task.scheduledDate ?? task.dueDate;
+    final plan = _plan;
+    if (date == null || plan == null) return;
+    final sameDay = [
+      ...plan.tasksForDate(date),
+    ]..sort(_compareVisualOrder);
+    final currentIndex = sameDay.indexWhere((item) => item.id == task.id);
+    if (currentIndex == -1) return;
+    final targetIndex = earlier ? currentIndex - 1 : currentIndex + 1;
+    if (targetIndex < 0 || targetIndex >= sameDay.length) return;
+
+    final target = sameDay[targetIndex];
+    final beforeAnchorIndex = earlier ? targetIndex - 1 : targetIndex;
+    final afterAnchorIndex = earlier ? targetIndex : targetIndex + 1;
+
+    final beforeOrder = beforeAnchorIndex >= 0
+        ? _visualOrderForTask(sameDay[beforeAnchorIndex])
+        : _visualOrderForTask(target) - 10000;
+    final afterOrder = afterAnchorIndex < sameDay.length
+        ? _visualOrderForTask(sameDay[afterAnchorIndex])
+        : _visualOrderForTask(target) + 10000;
+
+    final nextOrder = ((beforeOrder + afterOrder) / 2).round();
+
+    await updateTask(
+      task,
+      scheduledOrder: nextOrder,
+    );
+  }
+
+  int _defaultScheduledOrderForDate(String date) {
+    final dayTasks = [
+      ...?_plan?.tasksForDate(date),
+    ];
+    if (dayTasks.isEmpty) return 10000000;
+    final maxOrder = dayTasks
+        .map(_visualOrderForTask)
+        .reduce((value, element) => value > element ? value : element);
+    return maxOrder + 10000;
+  }
+
+  static int _compareVisualOrder(Task a, Task b) {
+    final compare = _visualOrderForTask(a).compareTo(_visualOrderForTask(b));
+    if (compare != 0) return compare;
+    return a.title.toLowerCase().compareTo(b.title.toLowerCase());
+  }
+
+  static int _visualOrderForTask(Task task) {
+    if (task.sourceType == 'calendar_shadow_event' && task.startsAt != null) {
+      final dateTime = DateTime.tryParse(task.startsAt!);
+      if (dateTime != null) {
+        return ((dateTime.hour * 60) + dateTime.minute) * 10000;
+      }
+    }
+    return task.scheduledOrder ?? 10000000;
   }
 
   // ── ISO week helpers ──────────────────────────────────────────────────────

--- a/apps/desktop_flutter/lib/features/weekly_planner/data/weekly_plan_data_source.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/data/weekly_plan_data_source.dart
@@ -22,11 +22,15 @@ class WeeklyPlanDataSource {
   }
 
   Future<Task> scheduleTask(String taskId, String date,
-      {bool locked = false}) async {
+      {bool locked = false, int? scheduledOrder}) async {
     final response = await http.patch(
       Uri.parse('$_baseUrl/weekly-plan/tasks/$taskId'),
       headers: AuthSessionStore.headers(json: true),
-      body: jsonEncode({'scheduledDate': date, 'locked': locked}),
+      body: jsonEncode({
+        'scheduledDate': date,
+        'locked': locked,
+        if (scheduledOrder != null) 'scheduledOrder': scheduledOrder,
+      }),
     );
     _assertOk(response);
     return Task.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
@@ -37,6 +41,7 @@ class WeeklyPlanDataSource {
       String? status,
       String? dueDate,
       String? scheduledDate,
+      int? scheduledOrder,
       String? sourceType}) async {
     final isProjectStep = sourceType == 'project_step';
     final response = await http.patch(
@@ -50,6 +55,8 @@ class WeeklyPlanDataSource {
         if (dueDate != null) 'dueDate': dueDate,
         if (!isProjectStep && scheduledDate != null)
           'scheduledDate': scheduledDate,
+        if (!isProjectStep && scheduledOrder != null)
+          'scheduledOrder': scheduledOrder,
       }),
     );
     _assertOk(response);
@@ -63,6 +70,7 @@ class WeeklyPlanDataSource {
             updatedAt: '',
             notes: body['notes'] as String?,
             dueDate: body['dueDate'] as String?,
+            scheduledOrder: body['scheduledOrder'] as int?,
             sourceType: 'project_step',
             sourceName: body['sourceName'] as String?,
           )

--- a/apps/desktop_flutter/lib/features/weekly_planner/repositories/weekly_plan_repository.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/repositories/weekly_plan_repository.dart
@@ -11,20 +11,27 @@ class WeeklyPlanRepository {
       _dataSource.fetchPlan(weekLabel);
 
   Future<Task> scheduleTask(String taskId, String date,
-          {bool locked = false}) =>
-      _dataSource.scheduleTask(taskId, date, locked: locked);
+          {bool locked = false, int? scheduledOrder}) =>
+      _dataSource.scheduleTask(
+        taskId,
+        date,
+        locked: locked,
+        scheduledOrder: scheduledOrder,
+      );
 
   Future<Task> updateTask(String taskId,
           {String? notes,
           String? status,
           String? dueDate,
           String? scheduledDate,
+          int? scheduledOrder,
           String? sourceType}) =>
       _dataSource.updateTask(taskId,
           notes: notes,
           status: status,
           dueDate: dueDate,
           scheduledDate: scheduledDate,
+          scheduledOrder: scheduledOrder,
           sourceType: sourceType);
 
   Future<void> createTask(String title, {String? dueDate}) {

--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -115,7 +115,7 @@ class _WeekHeader extends StatelessWidget {
     final hasSelection = controller.selectedTaskIds.isNotEmpty;
     return Container(
       padding: const EdgeInsets.fromLTRB(20, 18, 20, 16),
-      decoration: BoxDecoration(
+      decoration: const BoxDecoration(
         color: _kSurface,
         border: Border(bottom: BorderSide(color: _kBorder)),
       ),
@@ -425,7 +425,7 @@ class _PlannerBody extends StatelessWidget {
     }
     final plan = controller.plan;
     if (plan == null) {
-      return Center(
+      return const Center(
         child: _EmptyWorkspaceState(
           icon: Icons.view_week_outlined,
           title: 'No weekly plan loaded',
@@ -840,6 +840,45 @@ class _DayColumnState extends State<_DayColumn> {
     final displayTasks = widget.showCompleted
         ? widget.tasks
         : widget.tasks.where((t) => t.status != 'done').toList();
+    final addButton = Padding(
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, 8),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+        onTap: () => _showAddTaskDialog(context),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(
+            horizontal: 10,
+            vertical: 8,
+          ),
+          decoration: BoxDecoration(
+            color: _kSurface,
+            borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+            border: Border.all(color: _kBorder),
+          ),
+          child: Row(
+            children: [
+              const Icon(
+                Icons.add,
+                size: 13,
+                color: _kTextSecondary,
+              ),
+              const SizedBox(width: 6),
+              Expanded(
+                child: Text(
+                  'Add task to ${widget.dayName}',
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: _kTextSecondary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
 
     return DragTarget<Task>(
       onWillAcceptWithDetails: (_) {
@@ -931,75 +970,31 @@ class _DayColumnState extends State<_DayColumn> {
                 ),
               ),
               Expanded(
-                child: Column(
-                  children: [
-                    Expanded(
-                      child: displayTasks.isEmpty
-                          ? const SizedBox.shrink()
-                          : ListView.separated(
-                              padding: const EdgeInsets.fromLTRB(8, 8, 8, 10),
-                              itemCount: displayTasks.length,
-                              separatorBuilder: (_, __) =>
-                                  const SizedBox(height: 6),
-                              itemBuilder: (context, i) => _TaskTile(
-                                task: displayTasks[i],
-                                controller: widget.controller,
-                                draggable: true,
-                                compact: true,
-                              ),
+                child: displayTasks.isEmpty
+                    ? Align(
+                        alignment: Alignment.topCenter,
+                        child: addButton,
+                      )
+                    : ListView.builder(
+                        padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
+                        itemCount: displayTasks.length + 1,
+                        itemBuilder: (context, index) {
+                          if (index == displayTasks.length) {
+                            return addButton;
+                          }
+                          return Padding(
+                            padding: EdgeInsets.only(
+                              top: index == 0 ? 8 : 6,
                             ),
-                    ),
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(
-                        8,
-                        displayTasks.isEmpty ? 8 : 0,
-                        8,
-                        8,
+                            child: _TaskTile(
+                              task: displayTasks[index],
+                              controller: widget.controller,
+                              draggable: true,
+                              compact: true,
+                            ),
+                          );
+                        },
                       ),
-                      child: InkWell(
-                        borderRadius:
-                            BorderRadius.circular(RhythmTokens.radiusS),
-                        onTap: () => _showAddTaskDialog(context),
-                        child: Container(
-                          width: double.infinity,
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 10,
-                            vertical: 8,
-                          ),
-                          decoration: BoxDecoration(
-                            color: _kSurface,
-                            borderRadius:
-                                BorderRadius.circular(RhythmTokens.radiusS),
-                            border: Border.all(color: _kBorder),
-                          ),
-                          child: Row(
-                            children: [
-                              const Icon(
-                                Icons.add,
-                                size: 13,
-                                color: _kTextSecondary,
-                              ),
-                              const SizedBox(width: 6),
-                              Expanded(
-                                child: Text(
-                                  'Add task to ${widget.dayName}',
-                                  overflow: TextOverflow.ellipsis,
-                                  style: Theme.of(context)
-                                      .textTheme
-                                      .labelSmall
-                                      ?.copyWith(
-                                        color: _kTextSecondary,
-                                        fontWeight: FontWeight.w600,
-                                      ),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
               ),
             ],
           ),
@@ -1110,6 +1105,7 @@ class _TaskTile extends StatelessWidget {
     final isMultiSelected = controller.selectedTaskIds.contains(task.id);
     final isDone = task.status == 'done';
     final isShadowEvent = task.sourceType == 'calendar_shadow_event';
+    final shadowTimeLabel = isShadowEvent ? _shadowEventLabel(task) : null;
     final isPastDue = DateFormatters.isPastDue(
       dueDate: task.dueDate,
       scheduledDate: task.scheduledDate,
@@ -1129,36 +1125,71 @@ class _TaskTile extends StatelessWidget {
           vertical: compact ? 6 : 10,
         ),
         decoration: BoxDecoration(
-          color: isSelected || isMultiSelected ? _kPrimarySoft : _kSurface,
+          color: isShadowEvent
+              ? const Color(0xFFFFF7ED)
+              : isSelected || isMultiSelected
+                  ? _kPrimarySoft
+                  : _kSurface,
           borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
           border: Border.all(
-            color: isSelected || isMultiSelected ? _kPrimary : _kBorder,
+            color: isShadowEvent
+                ? _kWarm.withValues(alpha: 0.45)
+                : isSelected || isMultiSelected
+                    ? _kPrimary
+                    : _kBorder,
           ),
           boxShadow:
               isSelected || isMultiSelected ? RhythmTokens.shadow : const [],
         ),
         child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SizedBox(
-              width: compact ? 14 : 16,
-              height: compact ? 14 : 16,
-              child: Checkbox(
-                value: isShadowEvent ? false : isDone,
-                onChanged: isShadowEvent
-                    ? null
-                    : (_) => controller.toggleTaskDone(task, isDone),
-                materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                visualDensity: compact
-                    ? const VisualDensity(horizontal: -4, vertical: -4)
-                    : VisualDensity.compact,
+            if (isShadowEvent)
+              Container(
+                width: 3,
+                margin: const EdgeInsets.only(top: 2, right: 7),
+                decoration: BoxDecoration(
+                  color: _kWarm,
+                  borderRadius: BorderRadius.circular(999),
+                ),
+              )
+            else ...[
+              SizedBox(
+                width: compact ? 14 : 16,
+                height: compact ? 14 : 16,
+                child: Checkbox(
+                  value: isDone,
+                  onChanged: (_) => controller.toggleTaskDone(task, isDone),
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  visualDensity: compact
+                      ? const VisualDensity(horizontal: -4, vertical: -4)
+                      : VisualDensity.compact,
+                ),
               ),
-            ),
-            SizedBox(width: compact ? 6 : 8),
+              SizedBox(width: compact ? 6 : 8),
+            ],
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  if (shadowTimeLabel != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 3),
+                      child: Text(
+                        shadowTimeLabel,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: (compact
+                                ? Theme.of(context).textTheme.labelSmall
+                                : Theme.of(context).textTheme.bodySmall)
+                            ?.copyWith(
+                          fontSize: compact ? 9.5 : 10.5,
+                          fontWeight: FontWeight.w700,
+                          color: _kWarm,
+                        ),
+                      ),
+                    ),
                   if (task.sourceName != null && task.sourceName!.isNotEmpty)
                     Padding(
                       padding: const EdgeInsets.only(bottom: 2),
@@ -1210,13 +1241,30 @@ class _TaskTile extends StatelessWidget {
                 ],
               ),
             ),
+            if (!isShadowEvent && compact) ...[
+              const SizedBox(width: 6),
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _MiniMoveButton(
+                    icon: Icons.keyboard_arrow_up,
+                    onPressed: () => controller.moveTaskEarlier(task),
+                  ),
+                  const SizedBox(height: 4),
+                  _MiniMoveButton(
+                    icon: Icons.keyboard_arrow_down,
+                    onPressed: () => controller.moveTaskLater(task),
+                  ),
+                ],
+              ),
+            ],
             if (isMultiSelected && !compact) ...[
               const SizedBox(width: 6),
-              Icon(Icons.done_all, size: 14, color: _kPrimary),
+              const Icon(Icons.done_all, size: 14, color: _kPrimary),
             ],
             if (task.locked && !compact) ...[
               const SizedBox(width: 6),
-              Icon(Icons.lock, size: 11, color: _kTextSecondary),
+              const Icon(Icons.lock, size: 11, color: _kTextSecondary),
             ],
           ],
         ),
@@ -1346,6 +1394,7 @@ class _DetailPaneState extends State<_DetailPane> {
     final task = widget.task;
     final isDone = task.status == 'done';
     final isShadowEvent = task.sourceType == 'calendar_shadow_event';
+    final timeLabel = _shadowEventLabel(task);
     return Container(
       decoration: BoxDecoration(
         color: _kSurfaceMuted,
@@ -1458,6 +1507,8 @@ class _DetailPaneState extends State<_DetailPane> {
                       DateFormatters.fullDate(_plannerDate!,
                           fallback: _plannerDate!),
                     ),
+                  if (isShadowEvent && timeLabel != null)
+                    _row(context, 'Time', timeLabel),
                   if (task.sourceType != null)
                     _row(context, 'Source', _sourceLabel(task.sourceType!)),
                   if (task.sourceName != null && task.sourceName!.isNotEmpty)
@@ -1551,6 +1602,35 @@ class _DetailPaneState extends State<_DetailPane> {
                         ),
                       ],
                     ),
+                  if (!isShadowEvent) ...[
+                    const SizedBox(height: 10),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        OutlinedButton.icon(
+                          onPressed: () => widget.controller.moveTaskEarlier(task),
+                          icon: const Icon(Icons.arrow_upward, size: 14),
+                          label: const Text('Move earlier'),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: _kTextPrimary,
+                            side: const BorderSide(color: _kBorderStrong),
+                            backgroundColor: _kSurface,
+                          ),
+                        ),
+                        OutlinedButton.icon(
+                          onPressed: () => widget.controller.moveTaskLater(task),
+                          icon: const Icon(Icons.arrow_downward, size: 14),
+                          label: const Text('Move later'),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor: _kTextPrimary,
+                            side: const BorderSide(color: _kBorderStrong),
+                            backgroundColor: _kSurface,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
                 ],
               ),
             ),
@@ -1649,6 +1729,34 @@ class _DetailPaneState extends State<_DetailPane> {
 // Shared
 // ---------------------------------------------------------------------------
 
+class _MiniMoveButton extends StatelessWidget {
+  const _MiniMoveButton({
+    required this.icon,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onPressed,
+      borderRadius: BorderRadius.circular(999),
+      child: Container(
+        width: 18,
+        height: 18,
+        decoration: BoxDecoration(
+          color: _kSurfaceMuted,
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: _kBorder),
+        ),
+        child: Icon(icon, size: 12, color: _kTextSecondary),
+      ),
+    );
+  }
+}
+
 class _SourceChip extends StatelessWidget {
   const _SourceChip({required this.sourceType});
   final String sourceType;
@@ -1674,6 +1782,27 @@ class _SourceChip extends StatelessWidget {
               fontSize: 9.5, fontWeight: FontWeight.bold, color: color)),
     );
   }
+}
+
+String? _shadowEventLabel(Task task) {
+  if (task.isAllDay) return 'All day';
+  final start = task.startsAt == null ? null : DateTime.tryParse(task.startsAt!);
+  final end = task.endsAt == null ? null : DateTime.tryParse(task.endsAt!);
+  if (start == null) return null;
+  final startLabel = _formatClockTime(start);
+  if (end == null) return startLabel;
+  return '$startLabel - ${_formatClockTime(end)}';
+}
+
+String _formatClockTime(DateTime dateTime) {
+  final hour = dateTime.hour == 0
+      ? 12
+      : dateTime.hour > 12
+          ? dateTime.hour - 12
+          : dateTime.hour;
+  final minute = dateTime.minute.toString().padLeft(2, '0');
+  final suffix = dateTime.hour >= 12 ? 'PM' : 'AM';
+  return '$hour:$minute $suffix';
 }
 
 String _sourceLabel(String t) => switch (t) {

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -6,6 +6,7 @@ import 'app/core/constants/app_constants.dart';
 import 'app/core/auth/auth_data_source.dart';
 import 'app/core/auth/auth_session_service.dart';
 import 'app/core/layout/app_shell.dart';
+import 'app/core/notifications/local_notification_service.dart';
 import 'app/core/server/api_server_controller.dart';
 import 'app/core/server/api_server_service.dart';
 import 'app/core/services/server_config_service.dart';
@@ -65,9 +66,12 @@ void main() async {
     ..initialize();
   final authSessionService =
       AuthSessionService(AuthDataSource(baseUrl: serverConfigService.url));
+  final localNotificationService = LocalNotificationService();
+  await localNotificationService.initialize();
 
   runApp(RhythmApp(
     authSessionService: authSessionService,
+    localNotificationService: localNotificationService,
     serverController: serverController,
     serverConfigService: serverConfigService,
   ));
@@ -77,11 +81,13 @@ class RhythmApp extends StatelessWidget {
   const RhythmApp({
     super.key,
     required this.authSessionService,
+    required this.localNotificationService,
     required this.serverController,
     required this.serverConfigService,
   });
 
   final AuthSessionService authSessionService;
+  final LocalNotificationService localNotificationService;
   final ApiServerController serverController;
   final ServerConfigService serverConfigService;
 
@@ -132,6 +138,7 @@ class RhythmApp extends StatelessWidget {
         ChangeNotifierProvider(
           create: (_) => MessagesController(
             MessagesRepository(MessagesDataSource(baseUrl: baseUrl)),
+            notifications: localNotificationService,
           ),
         ),
         ChangeNotifierProvider(

--- a/apps/desktop_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/desktop_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import flutter_local_notifications
 import google_sign_in_ios
 import package_info_plus
 import screen_retriever
@@ -13,6 +14,7 @@ import url_launcher_macos
 import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   ScreenRetrieverPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverPlugin"))

--- a/apps/desktop_flutter/macos/Podfile.lock
+++ b/apps/desktop_flutter/macos/Podfile.lock
@@ -9,6 +9,8 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
+  - flutter_local_notifications (0.0.1):
+    - FlutterMacOS
   - FlutterMacOS (1.0.0)
   - google_sign_in_ios (0.0.1):
     - Flutter
@@ -51,6 +53,7 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
+  - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - google_sign_in_ios (from `Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
@@ -70,6 +73,8 @@ SPEC REPOS:
     - PromisesObjC
 
 EXTERNAL SOURCES:
+  flutter_local_notifications:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   google_sign_in_ios:
@@ -88,6 +93,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
+  flutter_local_notifications: 7e5a17a1dbc00d83dc10d43c2c4c05f2ceed233c
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   google_sign_in_ios: 205742c688aea0e64db9da03c33121694a365109
   GoogleSignIn: fcee2257188d5eda57a5e2b6a715550ffff9206d

--- a/apps/desktop_flutter/pubspec.yaml
+++ b/apps/desktop_flutter/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   google_sign_in: ^7.2.0
+  flutter_local_notifications: ^17.2.1+2
   http: ^1.2.0
   package_info_plus: ^8.0.2
   provider: ^6.1.2

--- a/apps/desktop_flutter/test/controller_regressions_test.dart
+++ b/apps/desktop_flutter/test/controller_regressions_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:rhythm_desktop/app/core/notifications/local_notification_service.dart';
 import 'package:rhythm_desktop/app/core/auth/auth_user.dart';
 import 'package:rhythm_desktop/features/dashboard/controllers/dashboard_controller.dart';
 import 'package:rhythm_desktop/features/dashboard/data/dashboard_data_source.dart';
@@ -10,6 +11,9 @@ import 'package:rhythm_desktop/features/messages/repositories/messages_repositor
 import 'package:rhythm_desktop/features/projects/models/project_instance.dart';
 import 'package:rhythm_desktop/features/projects/models/project_template.dart';
 import 'package:rhythm_desktop/features/dashboard/models/dashboard_overview_models.dart';
+import 'package:rhythm_desktop/features/rhythms/controllers/rhythms_controller.dart';
+import 'package:rhythm_desktop/features/rhythms/data/rhythms_data_source.dart';
+import 'package:rhythm_desktop/features/rhythms/repositories/rhythms_repository.dart';
 import 'package:rhythm_desktop/features/tasks/models/recurring_task_rule.dart';
 import 'package:rhythm_desktop/features/tasks/models/task.dart';
 
@@ -39,7 +43,10 @@ void main() {
 
   test('MessagesController reloads threads after creating a thread', () async {
     final repository = _FakeMessagesRepository();
-    final controller = MessagesController(repository);
+    final controller = MessagesController(
+      repository,
+      notifications: _FakeLocalNotificationService(),
+    );
 
     await controller.loadThreads();
     expect(controller.threads, hasLength(1));
@@ -57,6 +64,7 @@ void main() {
     final repository = _FakeMessagesRepository();
     final controller = MessagesController(
       repository,
+      notifications: _FakeLocalNotificationService(),
       pollInterval: const Duration(milliseconds: 10),
     );
 
@@ -101,6 +109,53 @@ void main() {
 
     controller.setPollingEnabled(false);
   });
+
+  test('RhythmsController loads users and forwards workflow steps', () async {
+    final repository = _FakeRhythmsRepository();
+    final controller = RhythmsController(repository);
+
+    await controller.load();
+    expect(controller.users, hasLength(2));
+    expect(controller.rules, hasLength(1));
+    expect(controller.rules.first.steps, hasLength(2));
+
+    await controller.createRule(
+      title: 'New rhythm',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      steps: [
+        RecurringTaskRuleStep(id: 'prep', title: 'Prep', assigneeId: 2),
+      ],
+    );
+
+    expect(repository.lastCreateSteps, hasLength(1));
+    expect(repository.lastCreateSteps.first.title, 'Prep');
+    expect(controller.rules, hasLength(2));
+
+    await controller.updateRule(
+      'rule-1',
+      title: 'Updated rhythm',
+      steps: [
+        RecurringTaskRuleStep(id: 'lead', title: 'Lead', assigneeId: null),
+      ],
+    );
+
+    expect(repository.lastUpdateSteps, hasLength(1));
+    expect(repository.lastUpdateSteps.first.id, 'lead');
+    expect(controller.rules.first.title, 'Updated rhythm');
+  });
+}
+
+class _FakeLocalNotificationService extends LocalNotificationService {
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<void> showMessageNotification({
+    required int id,
+    required String title,
+    required String body,
+  }) async {}
 }
 
 class _FakeDashboardDataSource extends DashboardDataSource {
@@ -296,4 +351,100 @@ class _FakeMessagesRepository extends MessagesRepository {
   Future<void> markRead(int threadId) async {
     markReadCallCount += 1;
   }
+}
+
+class _FakeRhythmsRepository extends RhythmsRepository {
+  _FakeRhythmsRepository() : super(_FakeRhythmsDataSource());
+
+  List<RecurringTaskRuleStep> lastCreateSteps = const [];
+  List<RecurringTaskRuleStep> lastUpdateSteps = const [];
+
+  final List<RecurringTaskRule> _rules = [
+    RecurringTaskRule(
+      id: 'rule-1',
+      title: 'Weekly Rhythm',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      dayOfMonth: null,
+      month: null,
+      enabled: true,
+      createdAt: '2026-03-29T00:00:00.000Z',
+      steps: [
+        RecurringTaskRuleStep(id: 'prep', title: 'Prep', assigneeId: 2),
+        RecurringTaskRuleStep(id: 'lead', title: 'Lead', assigneeId: null),
+      ],
+    ),
+  ];
+
+  @override
+  Future<List<RecurringTaskRule>> getAll() async => List.of(_rules);
+
+  @override
+  Future<List<AuthUser>> getUsers() async => const [
+        AuthUser(id: 1, name: 'Alice', email: 'alice@example.com', role: 'member'),
+        AuthUser(id: 2, name: 'Bob', email: 'bob@example.com', role: 'member'),
+      ];
+
+  @override
+  Future<RecurringTaskRule> create({
+    required String title,
+    required String frequency,
+    int? dayOfWeek,
+    int? dayOfMonth,
+    int? month,
+    List<RecurringTaskRuleStep>? steps,
+  }) async {
+    lastCreateSteps = List.of(steps ?? const []);
+    final rule = RecurringTaskRule(
+      id: 'rule-created',
+      title: title,
+      frequency: frequency,
+      dayOfWeek: dayOfWeek,
+      dayOfMonth: dayOfMonth,
+      month: month,
+      enabled: true,
+      createdAt: '2026-04-01T00:00:00.000Z',
+      steps: steps ?? const [],
+    );
+    _rules.add(rule);
+    return rule;
+  }
+
+  @override
+  Future<RecurringTaskRule> update(
+    String id, {
+    String? title,
+    String? frequency,
+    int? dayOfWeek,
+    int? dayOfMonth,
+    int? month,
+    bool? enabled,
+    List<RecurringTaskRuleStep>? steps,
+  }) async {
+    lastUpdateSteps = List.of(steps ?? const []);
+    final index = _rules.indexWhere((rule) => rule.id == id);
+    final existing = _rules[index];
+    final updated = RecurringTaskRule(
+      id: existing.id,
+      title: title ?? existing.title,
+      frequency: frequency ?? existing.frequency,
+      dayOfWeek: dayOfWeek ?? existing.dayOfWeek,
+      dayOfMonth: dayOfMonth ?? existing.dayOfMonth,
+      month: month ?? existing.month,
+      enabled: enabled ?? existing.enabled,
+      createdAt: existing.createdAt,
+      steps: steps ?? existing.steps,
+    );
+    _rules[index] = updated;
+    return updated;
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    _rules.removeWhere((rule) => rule.id == id);
+  }
+}
+
+class _FakeRhythmsDataSource extends RhythmsDataSource {
+  _FakeRhythmsDataSource() : super(baseUrl: 'http://example.invalid');
 }


### PR DESCRIPTION
## Summary
- finish message unread hardening with mark-read / mark-unread controls and local desktop notifications
- complete weekly planner carryover + shadow-event behavior, including time-aware shadow events and manual task ordering
- overhaul rhythms into multi-step recurring workflows with assignees, progress, and waiting-on visibility
- stabilize related desktop and API tests so the branch is green end to end

## What Changed
- Added `POST /message-threads/:id/unread` and desktop thread actions to mark conversations read or unread.
- Added local macOS notifications for new unread message activity and replies in the active thread.
- Extended weekly planner task/order models with `scheduledOrder`, plus time-aware shadow-event rendering and carryover-aware backlog rules.
- Updated weekly planner day lanes so backlog only appears when meaningful, shadow events render distinctly, and tasks can be moved earlier/later around timed events.
- Extended recurring rules with ordered workflow steps and optional assignees.
- Updated recurrence generation to create one task per step per recurrence date while preserving legacy single-step rules.
- Added rhythm progress, personal remaining counts, and waiting-on context to the Rhythms page.
- Fixed the flaky automation-engine Gmail test window and compacted the automations empty state so the full desktop suite stays green.

## Verification
- `cd apps/api_server && npm run build`
- `cd apps/api_server && npm test`
- `cd apps/api_server && npx vitest run src/__tests__/auth_and_messaging.test.ts src/__tests__/weekly_planning_service.test.ts src/__tests__/recurrence_service.test.ts`
- `cd apps/desktop_flutter && flutter pub get`
- `cd apps/desktop_flutter && flutter analyze lib/features/messages/views/messages_view.dart lib/features/messages/controllers/messages_controller.dart lib/main.dart lib/app/core/notifications/local_notification_service.dart lib/features/weekly_planner/views/weekly_planner_view.dart lib/features/weekly_planner/controllers/weekly_planner_controller.dart lib/features/weekly_planner/data/weekly_plan_data_source.dart lib/features/weekly_planner/repositories/weekly_plan_repository.dart lib/features/tasks/models/task.dart lib/features/rhythms/views/rhythms_view.dart lib/features/rhythms/controllers/rhythms_controller.dart lib/features/rhythms/data/rhythms_data_source.dart lib/features/rhythms/repositories/rhythms_repository.dart lib/features/tasks/models/recurring_task_rule.dart test/controller_regressions_test.dart`
- `cd apps/desktop_flutter && flutter test`
- `cd apps/desktop_flutter && flutter build macos --debug`

Closes #125
Closes #128
Closes #129
Closes #136