### PR TITLE
fix: build universal binary (arm64 + x86_64)

### DIFF
--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -91,6 +91,8 @@ jobs:
           CODE_SIGNING_ALLOWED=NO
           CODE_SIGNING_REQUIRED=NO
           CODE_SIGN_IDENTITY=""
+          ONLY_ACTIVE_ARCH=NO
+          ARCHS="arm64 x86_64"
           build
 
       - name: Bundle API server into app


### PR DESCRIPTION
xcodebuild was inheriting ONLY_ACTIVE_ARCH=YES from the project, so the arm64 CI runner produced an arm64-only binary. Intel Macs get an immediate kernel kill when trying to run it. Adding ONLY_ACTIVE_ARCH=NO and ARCHS="arm64 x86_64" produces a universal binary.