### PR TITLE
style: fix dart format violation breaking release

### DIFF
--- a/apps/desktop_flutter/lib/app/core/workspace/workspace_onboarding_view.dart
+++ b/apps/desktop_flutter/lib/app/core/workspace/workspace_onboarding_view.dart
@@ -96,9 +96,8 @@ class _WorkspaceOnboardingViewState extends State<WorkspaceOnboardingView> {
                       child: OutlinedButton(
                         onPressed: () => setState(() => _isJoining = false),
                         style: OutlinedButton.styleFrom(
-                          backgroundColor: !_isJoining
-                              ? const Color(0xFF4F6AF5)
-                              : null,
+                          backgroundColor:
+                              !_isJoining ? const Color(0xFF4F6AF5) : null,
                           foregroundColor: !_isJoining ? Colors.white : null,
                         ),
                         child: const Text('Create'),
@@ -109,9 +108,8 @@ class _WorkspaceOnboardingViewState extends State<WorkspaceOnboardingView> {
                       child: OutlinedButton(
                         onPressed: () => setState(() => _isJoining = true),
                         style: OutlinedButton.styleFrom(
-                          backgroundColor: _isJoining
-                              ? const Color(0xFF4F6AF5)
-                              : null,
+                          backgroundColor:
+                              _isJoining ? const Color(0xFF4F6AF5) : null,
                           foregroundColor: _isJoining ? Colors.white : null,
                         ),
                         child: const Text('Join'),


### PR DESCRIPTION
## Summary
- Fixes the `dart format --set-exit-if-changed` failure in the latest desktop release CI run
- Two ternary expressions in `workspace_onboarding_view.dart` were formatted in a style that `dart format` (after `flutter pub get` resolves `analysis_options.yaml`) rewrites to a different layout

## Test plan
- [x] `dart format --output=none --set-exit-if-changed .` passes locally after `flutter pub get`
- [ ] Re-run the desktop release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)