### PR TITLE
feat: add workspace assignment collaboration flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,17 @@ npm-debug.log*
 # Logs
 *.log
 coverage/
+
+# Local runtime data
+rhythm.db
+rhythm.db-shm
+rhythm.db-wal
+db-backups/
+
+# Local scratch/output artifacts
+tmp/
+output/
+.superpowers/
+
+# Local planning scratch docs
+docs/superpowers/plans/

--- a/apps/desktop_flutter/lib/app/core/workspace/workspace_controller.dart
+++ b/apps/desktop_flutter/lib/app/core/workspace/workspace_controller.dart
@@ -31,6 +31,20 @@ class WorkspaceController extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> addMemberDirect(int userId) async {
+    try {
+      _members = await _repository.addMemberDirect(userId);
+      _errorMessage = null;
+      _status = WorkspaceStatus.idle;
+      notifyListeners();
+    } catch (e) {
+      _errorMessage = e.toString();
+      _status = WorkspaceStatus.error;
+      notifyListeners();
+      rethrow;
+    }
+  }
+
   Future<void> updateMemberRole(int userId, String role) async {
     await _repository.updateMemberRole(userId, role);
     await loadMembers();

--- a/apps/desktop_flutter/lib/app/core/workspace/workspace_data_source.dart
+++ b/apps/desktop_flutter/lib/app/core/workspace/workspace_data_source.dart
@@ -48,6 +48,19 @@ class WorkspaceDataSource {
         .toList();
   }
 
+  Future<List<WorkspaceMember>> addMemberDirect(int userId) async {
+    final response = await http.post(
+      Uri.parse('$_baseUrl/workspaces/me/members/add'),
+      headers: AuthSessionStore.headers(json: true),
+      body: jsonEncode({'userId': userId}),
+    );
+    assertOk(response);
+    final list = jsonDecode(response.body) as List<dynamic>;
+    return list
+        .map((item) => WorkspaceMember.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
   Future<void> updateMemberRole(int userId, String role) async {
     final response = await http.patch(
       Uri.parse('$_baseUrl/workspaces/me/members/$userId'),

--- a/apps/desktop_flutter/lib/app/core/workspace/workspace_repository.dart
+++ b/apps/desktop_flutter/lib/app/core/workspace/workspace_repository.dart
@@ -10,6 +10,8 @@ class WorkspaceRepository {
   Future<WorkspaceInfo> create(String name) => _dataSource.create(name);
   Future<WorkspaceInfo> join(String joinCode) => _dataSource.join(joinCode);
   Future<List<WorkspaceMember>> listMembers() => _dataSource.listMembers();
+  Future<List<WorkspaceMember>> addMemberDirect(int userId) =>
+      _dataSource.addMemberDirect(userId);
   Future<void> updateMemberRole(int userId, String role) =>
       _dataSource.updateMemberRole(userId, role);
   Future<void> removeMember(int userId) => _dataSource.removeMember(userId);

--- a/apps/desktop_flutter/lib/features/projects/controllers/project_template_controller.dart
+++ b/apps/desktop_flutter/lib/features/projects/controllers/project_template_controller.dart
@@ -71,12 +71,16 @@ class ProjectTemplateController extends ChangeNotifier {
   }
 
   Future<void> updateStep(String templateId, String stepId,
-      {String? title, int? offsetDays, String? offsetDescription}) async {
+      {String? title,
+      int? offsetDays,
+      String? offsetDescription,
+      int? assigneeId}) async {
     try {
       await _repository.updateStep(templateId, stepId,
           title: title,
           offsetDays: offsetDays,
-          offsetDescription: offsetDescription);
+          offsetDescription: offsetDescription,
+          assigneeId: assigneeId);
       await load();
     } catch (e) {
       _errorMessage = e.toString();
@@ -102,6 +106,7 @@ class ProjectTemplateController extends ChangeNotifier {
     required int offsetDays,
     String? offsetDescription,
     int? sortOrder,
+    int? assigneeId,
   }) async {
     try {
       await _repository.addStep(
@@ -110,6 +115,7 @@ class ProjectTemplateController extends ChangeNotifier {
         offsetDays: offsetDays,
         offsetDescription: offsetDescription,
         sortOrder: sortOrder,
+        assigneeId: assigneeId,
       );
       // Reload to get updated template with new step
       await load();

--- a/apps/desktop_flutter/lib/features/projects/data/projects_local_data_source.dart
+++ b/apps/desktop_flutter/lib/features/projects/data/projects_local_data_source.dart
@@ -46,6 +46,7 @@ class ProjectsLocalDataSource {
     required int offsetDays,
     String? offsetDescription,
     int? sortOrder,
+    int? assigneeId,
   }) async {
     final response = await http.post(
       Uri.parse('$_baseUrl/project-templates/$templateId/steps'),
@@ -55,6 +56,7 @@ class ProjectsLocalDataSource {
         'offsetDays': offsetDays,
         if (offsetDescription != null) 'offsetDescription': offsetDescription,
         if (sortOrder != null) 'sortOrder': sortOrder,
+        'assigneeId': assigneeId,
       }),
     );
     assertOk(response);
@@ -83,6 +85,7 @@ class ProjectsLocalDataSource {
     String? title,
     int? offsetDays,
     String? offsetDescription,
+    int? assigneeId,
   }) async {
     final response = await http.patch(
       Uri.parse('$_baseUrl/project-templates/$templateId/steps/$stepId'),
@@ -91,6 +94,7 @@ class ProjectsLocalDataSource {
         if (title != null) 'title': title,
         if (offsetDays != null) 'offsetDays': offsetDays,
         if (offsetDescription != null) 'offsetDescription': offsetDescription,
+        'assigneeId': assigneeId,
       }),
     );
     assertOk(response);

--- a/apps/desktop_flutter/lib/features/projects/models/project_instance.dart
+++ b/apps/desktop_flutter/lib/features/projects/models/project_instance.dart
@@ -1,3 +1,4 @@
+import '../../../app/core/utils/json_parsing.dart';
 import '../../tasks/models/task_collaborator.dart';
 
 class ProjectInstanceStep {
@@ -9,17 +10,21 @@ class ProjectInstanceStep {
     required this.dueDate,
     required this.status,
     this.notes,
+    this.assigneeId,
+    this.assigneeName,
   });
 
   factory ProjectInstanceStep.fromJson(Map<String, dynamic> json) {
     return ProjectInstanceStep(
-      id: json['id'] as String,
-      instanceId: json['instanceId'] as String,
-      stepId: json['stepId'] as String,
-      title: json['title'] as String,
-      dueDate: json['dueDate'] as String,
-      status: json['status'] as String? ?? 'open',
-      notes: json['notes'] as String?,
+      id: asString(json['id']) ?? '',
+      instanceId: asString(json['instanceId']) ?? '',
+      stepId: asString(json['stepId']) ?? '',
+      title: asString(json['title']) ?? '',
+      dueDate: asString(json['dueDate']) ?? '',
+      status: asString(json['status']) ?? 'open',
+      notes: asString(json['notes']),
+      assigneeId: asInt(json['assigneeId']),
+      assigneeName: asString(json['assigneeName']),
     );
   }
 
@@ -30,6 +35,8 @@ class ProjectInstanceStep {
   final String dueDate;
   final String status;
   final String? notes;
+  final int? assigneeId;
+  final String? assigneeName;
 }
 
 class ProjectInstance {

--- a/apps/desktop_flutter/lib/features/projects/models/project_template_step.dart
+++ b/apps/desktop_flutter/lib/features/projects/models/project_template_step.dart
@@ -8,6 +8,8 @@ class ProjectTemplateStep {
     required this.offsetDays,
     required this.sortOrder,
     this.offsetDescription,
+    this.assigneeId,
+    this.assigneeName,
   });
 
   factory ProjectTemplateStep.fromJson(Map<String, dynamic> json) {
@@ -18,6 +20,8 @@ class ProjectTemplateStep {
       offsetDays: asInt(json['offsetDays']) ?? 0,
       offsetDescription: asString(json['offsetDescription']),
       sortOrder: asInt(json['sortOrder']) ?? 0,
+      assigneeId: asInt(json['assigneeId']),
+      assigneeName: asString(json['assigneeName']),
     );
   }
 
@@ -27,4 +31,6 @@ class ProjectTemplateStep {
   final int offsetDays;
   final String? offsetDescription;
   final int sortOrder;
+  final int? assigneeId;
+  final String? assigneeName;
 }

--- a/apps/desktop_flutter/lib/features/projects/repositories/projects_repository.dart
+++ b/apps/desktop_flutter/lib/features/projects/repositories/projects_repository.dart
@@ -20,6 +20,7 @@ class ProjectsRepository {
     required int offsetDays,
     String? offsetDescription,
     int? sortOrder,
+    int? assigneeId,
   }) =>
       _dataSource.addStep(
         templateId,
@@ -27,6 +28,7 @@ class ProjectsRepository {
         offsetDays: offsetDays,
         offsetDescription: offsetDescription,
         sortOrder: sortOrder,
+        assigneeId: assigneeId,
       );
 
   Future<ProjectTemplate> update(String id,
@@ -34,11 +36,15 @@ class ProjectsRepository {
       _dataSource.update(id, name: name, description: description);
 
   Future<ProjectTemplateStep> updateStep(String templateId, String stepId,
-          {String? title, int? offsetDays, String? offsetDescription}) =>
+          {String? title,
+          int? offsetDays,
+          String? offsetDescription,
+          int? assigneeId}) =>
       _dataSource.updateStep(templateId, stepId,
           title: title,
           offsetDays: offsetDays,
-          offsetDescription: offsetDescription);
+          offsetDescription: offsetDescription,
+          assigneeId: assigneeId);
 
   Future<void> deleteStep(String templateId, String stepId) =>
       _dataSource.deleteStep(templateId, stepId);

--- a/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
+++ b/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
 import '../../../app/core/formatters/date_formatters.dart';
+import '../../../app/core/auth/auth_session_service.dart';
 import '../../../app/core/auth/auth_session_store.dart';
 import '../controllers/project_template_controller.dart';
 import '../models/project_instance.dart';
@@ -13,6 +14,7 @@ import '../services/project_generation_service.dart';
 import '../../../app/core/services/server_config_service.dart';
 import '../../../app/core/workspace/workspace_controller.dart';
 import '../../../shared/widgets/collaborators_row.dart';
+import '../../../shared/widgets/workspace_member_picker.dart';
 import '../../tasks/data/collaborators_data_source.dart';
 
 class ProjectsView extends StatefulWidget {
@@ -34,6 +36,7 @@ class _ProjectsViewState extends State<ProjectsView> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<ProjectTemplateController>().load();
+      context.read<WorkspaceController>().loadMembers();
     });
   }
 
@@ -241,13 +244,18 @@ class _ProjectsViewState extends State<ProjectsView> {
   }
 
   Future<void> _updateActiveProjectStep(ProjectInstanceStep step,
-      {String? title, String? dueDate, String? status, String? notes}) async {
+      {String? title,
+      String? dueDate,
+      String? status,
+      String? notes,
+      int? assigneeId}) async {
     try {
       final body = <String, dynamic>{
         if (title != null) 'title': title,
         if (dueDate != null) 'dueDate': dueDate,
         if (status != null) 'status': status,
         if (notes != null) 'notes': notes.isEmpty ? null : notes,
+        'assigneeId': assigneeId,
       };
       final response = await http.patch(
         Uri.parse(
@@ -544,13 +552,18 @@ class _TemplateDetailState extends State<_TemplateDetail>
   }
 
   Future<void> _updateStep(ProjectInstanceStep step,
-      {String? title, String? dueDate, String? status, String? notes}) async {
+      {String? title,
+      String? dueDate,
+      String? status,
+      String? notes,
+      int? assigneeId}) async {
     try {
       final body = <String, dynamic>{
         if (title != null) 'title': title,
         if (dueDate != null) 'dueDate': dueDate,
         if (status != null) 'status': status,
         if (notes != null) 'notes': notes.isEmpty ? null : notes,
+        'assigneeId': assigneeId,
       };
       final response = await http.patch(
         Uri.parse(
@@ -895,7 +908,8 @@ class _InstancesPanel extends StatelessWidget {
       {String? title,
       String? dueDate,
       String? status,
-      String? notes}) onUpdateStep;
+      String? notes,
+      int? assigneeId}) onUpdateStep;
   final Future<void> Function(String instanceId) onDeleteInstance;
   final Map<String, String> templateNames;
 
@@ -936,6 +950,7 @@ class _InstancesPanel extends StatelessWidget {
       ),
       child: _InstancesList(
         instances: instances,
+        onRefresh: onRefresh,
         onUpdateStep: onUpdateStep,
         onDeleteInstance: onDeleteInstance,
         templateNames: templateNames,
@@ -947,16 +962,19 @@ class _InstancesPanel extends StatelessWidget {
 class _InstancesList extends StatefulWidget {
   const _InstancesList({
     required this.instances,
+    required this.onRefresh,
     required this.onUpdateStep,
     required this.onDeleteInstance,
     this.templateNames = const {},
   });
   final List<ProjectInstance> instances;
+  final VoidCallback onRefresh;
   final Future<void> Function(ProjectInstanceStep step,
       {String? title,
       String? dueDate,
       String? status,
-      String? notes}) onUpdateStep;
+      String? notes,
+      int? assigneeId}) onUpdateStep;
   final Future<void> Function(String instanceId) onDeleteInstance;
   final Map<String, String> templateNames;
 
@@ -1019,6 +1037,7 @@ class _InstancesListState extends State<_InstancesList> {
                   itemCount: visibleInstances.length,
                   itemBuilder: (ctx, i) => _InstanceCard(
                     instance: visibleInstances[i],
+                    onRefresh: widget.onRefresh,
                     onUpdateStep: widget.onUpdateStep,
                     onDeleteInstance: widget.onDeleteInstance,
                     showCompleted: _showCompleted,
@@ -1035,17 +1054,20 @@ class _InstancesListState extends State<_InstancesList> {
 class _InstanceCard extends StatelessWidget {
   const _InstanceCard({
     required this.instance,
+    required this.onRefresh,
     required this.onUpdateStep,
     required this.onDeleteInstance,
     required this.showCompleted,
     this.templateName,
   });
   final ProjectInstance instance;
+  final VoidCallback onRefresh;
   final Future<void> Function(ProjectInstanceStep step,
       {String? title,
       String? dueDate,
       String? status,
-      String? notes}) onUpdateStep;
+      String? notes,
+      int? assigneeId}) onUpdateStep;
   final Future<void> Function(String instanceId) onDeleteInstance;
   final bool showCompleted;
   final String? templateName;
@@ -1053,6 +1075,8 @@ class _InstanceCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final canReassign =
+        AuthSessionService.instance.currentUser?.id == instance.ownerId;
     final visibleSteps = showCompleted
         ? instance.steps
         : instance.steps.where((step) => step.status != 'done').toList();
@@ -1099,18 +1123,19 @@ class _InstanceCard extends StatelessWidget {
                 onAdd: (userId) async {
                   final ds = CollaboratorsDataSource();
                   await ds.addToProject(instance.id, userId);
-                  await context.read<ProjectTemplateController>().load();
+                  onRefresh();
                 },
                 onRemove: (userId) async {
                   final ds = CollaboratorsDataSource();
                   await ds.removeFromProject(instance.id, userId);
-                  await context.read<ProjectTemplateController>().load();
+                  onRefresh();
                 },
               ),
             ),
           ...visibleSteps.map((step) => _InstanceStepTile(
                 step: step,
                 onUpdateStep: onUpdateStep,
+                canReassign: canReassign,
               )),
         ],
       ),
@@ -1119,13 +1144,19 @@ class _InstanceCard extends StatelessWidget {
 }
 
 class _InstanceStepTile extends StatelessWidget {
-  const _InstanceStepTile({required this.step, required this.onUpdateStep});
+  const _InstanceStepTile({
+    required this.step,
+    required this.onUpdateStep,
+    required this.canReassign,
+  });
   final ProjectInstanceStep step;
   final Future<void> Function(ProjectInstanceStep step,
       {String? title,
       String? dueDate,
       String? status,
-      String? notes}) onUpdateStep;
+      String? notes,
+      int? assigneeId}) onUpdateStep;
+  final bool canReassign;
 
   @override
   Widget build(BuildContext context) {
@@ -1140,8 +1171,11 @@ class _InstanceStepTile extends StatelessWidget {
       child: ListTile(
         leading: Checkbox(
           value: isDone,
-          onChanged: (_) =>
-              onUpdateStep(step, status: isDone ? 'open' : 'done'),
+          onChanged: (_) => onUpdateStep(
+            step,
+            status: isDone ? 'open' : 'done',
+            assigneeId: step.assigneeId,
+          ),
           visualDensity: VisualDensity.compact,
           materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
         ),
@@ -1162,6 +1196,12 @@ class _InstanceStepTile extends StatelessWidget {
                     color: colorScheme.onSurfaceVariant,
                   ),
             ),
+            Text(
+              'Assignee: ${step.assigneeName ?? 'Unassigned'}',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+            ),
             if (step.notes != null && step.notes!.isNotEmpty)
               Text(
                 step.notes!,
@@ -1175,8 +1215,11 @@ class _InstanceStepTile extends StatelessWidget {
           icon: const Icon(Icons.edit_outlined, size: 16),
           onPressed: () => showDialog<void>(
             context: context,
-            builder: (_) =>
-                _EditInstanceStepDialog(step: step, onSave: onUpdateStep),
+            builder: (_) => _EditInstanceStepDialog(
+              step: step,
+              onSave: onUpdateStep,
+              canEditAssignee: canReassign,
+            ),
           ),
         ),
       ),
@@ -1185,10 +1228,19 @@ class _InstanceStepTile extends StatelessWidget {
 }
 
 class _EditInstanceStepDialog extends StatefulWidget {
-  const _EditInstanceStepDialog({required this.step, required this.onSave});
+  const _EditInstanceStepDialog({
+    required this.step,
+    required this.onSave,
+    required this.canEditAssignee,
+  });
   final ProjectInstanceStep step;
   final Future<void> Function(ProjectInstanceStep step,
-      {String? title, String? dueDate, String? status, String? notes}) onSave;
+      {String? title,
+      String? dueDate,
+      String? status,
+      String? notes,
+      int? assigneeId}) onSave;
+  final bool canEditAssignee;
 
   @override
   State<_EditInstanceStepDialog> createState() =>
@@ -1199,6 +1251,7 @@ class _EditInstanceStepDialogState extends State<_EditInstanceStepDialog> {
   late final TextEditingController _titleCtrl;
   late final TextEditingController _dueDateCtrl;
   late final TextEditingController _notesCtrl;
+  int? _assigneeId;
   bool _saving = false;
 
   @override
@@ -1207,6 +1260,7 @@ class _EditInstanceStepDialogState extends State<_EditInstanceStepDialog> {
     _titleCtrl = TextEditingController(text: widget.step.title);
     _dueDateCtrl = TextEditingController(text: widget.step.dueDate);
     _notesCtrl = TextEditingController(text: widget.step.notes ?? '');
+    _assigneeId = widget.step.assigneeId;
   }
 
   @override
@@ -1240,6 +1294,54 @@ class _EditInstanceStepDialogState extends State<_EditInstanceStepDialog> {
                   border: OutlineInputBorder()),
             ),
             const SizedBox(height: 12),
+            if (widget.canEditAssignee) ...[
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  'Assignee',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+              ),
+              const SizedBox(height: 6),
+              Container(
+                width: double.infinity,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                decoration: BoxDecoration(
+                  border: Border.all(
+                    color: Theme.of(context).colorScheme.outlineVariant,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Builder(
+                  builder: (context) {
+                    final members =
+                        context.watch<WorkspaceController>().members;
+                    final selectedId = _assigneeId != null &&
+                            members.any((m) => m.userId == _assigneeId)
+                        ? _assigneeId
+                        : null;
+                    return WorkspaceMemberPicker(
+                      workspaceMembers: members,
+                      selectedUserId: selectedId,
+                      onChanged: (value) => setState(() => _assigneeId = value),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 12),
+            ] else ...[
+              Text(
+                'Assignee: ${widget.step.assigneeName ?? 'Unassigned'}',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+              const SizedBox(height: 12),
+            ],
             TextField(
               controller: _notesCtrl,
               decoration: const InputDecoration(
@@ -1277,6 +1379,7 @@ class _EditInstanceStepDialogState extends State<_EditInstanceStepDialog> {
       dueDate:
           _dueDateCtrl.text.trim().isEmpty ? null : _dueDateCtrl.text.trim(),
       notes: _notesCtrl.text.trim(),
+      assigneeId: _assigneeId,
     );
     if (mounted) Navigator.pop(context);
   }
@@ -1320,9 +1423,19 @@ class _StepTile extends StatelessWidget {
           step.title,
           style: const TextStyle(fontWeight: FontWeight.w500),
         ),
-        subtitle: Text(
-          offsetLabel,
-          style: TextStyle(color: colorScheme.onSurfaceVariant),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              offsetLabel,
+              style: TextStyle(color: colorScheme.onSurfaceVariant),
+            ),
+            if (step.assigneeName != null)
+              Text(
+                'Assignee: ${step.assigneeName}',
+                style: TextStyle(color: colorScheme.onSurfaceVariant),
+              ),
+          ],
         ),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
@@ -1481,6 +1594,7 @@ class _EditStepDialogState extends State<_EditStepDialog> {
   late final TextEditingController _titleController;
   late final TextEditingController _offsetController;
   late final TextEditingController _descController;
+  int? _assigneeId;
   bool _saving = false;
 
   @override
@@ -1491,6 +1605,7 @@ class _EditStepDialogState extends State<_EditStepDialog> {
         TextEditingController(text: widget.step.offsetDays.toString());
     _descController =
         TextEditingController(text: widget.step.offsetDescription ?? '');
+    _assigneeId = widget.step.assigneeId;
   }
 
   @override
@@ -1527,6 +1642,42 @@ class _EditStepDialogState extends State<_EditStepDialog> {
               inputFormatters: [
                 FilteringTextInputFormatter.allow(RegExp(r'[-\d]'))
               ],
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'Assignee',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+            const SizedBox(height: 6),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: Theme.of(context).colorScheme.outlineVariant,
+                ),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Builder(
+                builder: (context) {
+                  final members = context.watch<WorkspaceController>().members;
+                  final selectedId = _assigneeId != null &&
+                          members.any((m) => m.userId == _assigneeId)
+                      ? _assigneeId
+                      : null;
+                  return WorkspaceMemberPicker(
+                    workspaceMembers: members,
+                    selectedUserId: selectedId,
+                    onChanged: (value) => setState(() => _assigneeId = value),
+                  );
+                },
+              ),
             ),
             const SizedBox(height: 12),
             TextField(
@@ -1570,6 +1721,7 @@ class _EditStepDialogState extends State<_EditStepDialog> {
       offsetDescription: _descController.text.trim().isEmpty
           ? null
           : _descController.text.trim(),
+      assigneeId: _assigneeId,
     );
     if (mounted) Navigator.pop(context);
   }
@@ -1662,6 +1814,7 @@ class _AddStepDialogState extends State<_AddStepDialog> {
   final _titleController = TextEditingController();
   final _descController = TextEditingController();
   final _offsetController = TextEditingController(text: '0');
+  int? _assigneeId;
   bool _saving = false;
 
   @override
@@ -1698,6 +1851,42 @@ class _AddStepDialogState extends State<_AddStepDialog> {
               inputFormatters: [
                 FilteringTextInputFormatter.allow(RegExp(r'[-\d]'))
               ],
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                'Assignee',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+            const SizedBox(height: 6),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: Theme.of(context).colorScheme.outlineVariant,
+                ),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Builder(
+                builder: (context) {
+                  final members = context.watch<WorkspaceController>().members;
+                  final selectedId = _assigneeId != null &&
+                          members.any((m) => m.userId == _assigneeId)
+                      ? _assigneeId
+                      : null;
+                  return WorkspaceMemberPicker(
+                    workspaceMembers: members,
+                    selectedUserId: selectedId,
+                    onChanged: (value) => setState(() => _assigneeId = value),
+                  );
+                },
+              ),
             ),
             const SizedBox(height: 12),
             TextField(
@@ -1740,6 +1929,7 @@ class _AddStepDialogState extends State<_AddStepDialog> {
           ? null
           : _descController.text.trim(),
       sortOrder: widget.template.steps.length,
+      assigneeId: _assigneeId,
     );
     if (mounted) Navigator.pop(context);
   }

--- a/apps/desktop_flutter/lib/features/rhythms/controllers/rhythms_controller.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/controllers/rhythms_controller.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import '../../../app/core/auth/auth_user.dart';
 import '../../../features/tasks/models/recurring_task_rule.dart';
 import '../repositories/rhythms_repository.dart';
 
@@ -11,12 +10,10 @@ class RhythmsController extends ChangeNotifier {
   final RhythmsRepository _repository;
 
   List<RecurringTaskRule> _rules = [];
-  List<AuthUser> _users = [];
   RhythmsStatus _status = RhythmsStatus.idle;
   String? _errorMessage;
 
   List<RecurringTaskRule> get rules => _rules;
-  List<AuthUser> get users => _users;
   RhythmsStatus get status => _status;
   String? get errorMessage => _errorMessage;
 
@@ -26,12 +23,7 @@ class RhythmsController extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final results = await Future.wait([
-        _repository.getAll(),
-        _repository.getUsers(),
-      ]);
-      _rules = results[0] as List<RecurringTaskRule>;
-      _users = results[1] as List<AuthUser>;
+      _rules = await _repository.getAll();
       _status = RhythmsStatus.idle;
     } catch (e) {
       _errorMessage = e.toString();

--- a/apps/desktop_flutter/lib/features/rhythms/data/rhythms_data_source.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/data/rhythms_data_source.dart
@@ -96,4 +96,21 @@ class RhythmsDataSource {
     );
     assertOk(response);
   }
+
+  Future<void> addCollaborator(String ruleId, int userId) async {
+    final response = await http.post(
+      Uri.parse('$_baseUrl/recurring-rules/$ruleId/collaborators'),
+      headers: AuthSessionStore.headers(json: true),
+      body: jsonEncode({'userId': userId}),
+    );
+    assertOk(response);
+  }
+
+  Future<void> removeCollaborator(String ruleId, int userId) async {
+    final response = await http.delete(
+      Uri.parse('$_baseUrl/recurring-rules/$ruleId/collaborators/$userId'),
+      headers: AuthSessionStore.headers(),
+    );
+    assertOk(response);
+  }
 }

--- a/apps/desktop_flutter/lib/features/rhythms/views/rhythms_view.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/views/rhythms_view.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
-import '../../../app/core/auth/auth_user.dart';
+import '../../../app/core/auth/auth_session_service.dart';
 import '../../../app/core/formatters/date_formatters.dart';
 import '../../../app/core/widgets/error_banner.dart';
+import '../../../app/core/workspace/workspace_controller.dart';
+import '../../../app/core/workspace/workspace_models.dart';
 import '../../../app/theme/rhythm_tokens.dart';
 import '../controllers/rhythms_controller.dart';
+import '../data/rhythms_data_source.dart';
 import '../../../features/tasks/models/recurring_task_rule.dart';
 import '../../../features/tasks/services/recurrence_service.dart';
+import '../../../shared/widgets/workspace_member_picker.dart';
 
 const _kCanvas = RhythmTokens.background;
 const _kCanvasAccent = RhythmTokens.backgroundAccent;
@@ -30,11 +34,14 @@ class RhythmsView extends StatefulWidget {
 }
 
 class _RhythmsViewState extends State<RhythmsView> {
+  final RhythmsDataSource _dataSource = RhythmsDataSource();
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<RhythmsController>().load();
+      context.read<WorkspaceController>().loadMembers();
     });
   }
 
@@ -75,6 +82,7 @@ class _RhythmsViewState extends State<RhythmsView> {
                   Expanded(
                     child: _RulesList(
                       controller: controller,
+                      dataSource: _dataSource,
                       onCreate: () => _showCreateDialog(context, controller),
                     ),
                   ),
@@ -163,8 +171,13 @@ class _Header extends StatelessWidget {
 }
 
 class _RulesList extends StatelessWidget {
-  const _RulesList({required this.controller, required this.onCreate});
+  const _RulesList({
+    required this.controller,
+    required this.dataSource,
+    required this.onCreate,
+  });
   final RhythmsController controller;
+  final RhythmsDataSource dataSource;
   final VoidCallback onCreate;
 
   @override
@@ -184,6 +197,7 @@ class _RulesList extends StatelessWidget {
       itemBuilder: (context, i) => _RuleTile(
         rule: controller.rules[i],
         controller: controller,
+        dataSource: dataSource,
         onDelete: () => controller.deleteRule(controller.rules[i].id),
       ),
     );
@@ -191,11 +205,16 @@ class _RulesList extends StatelessWidget {
 }
 
 class _RuleTile extends StatefulWidget {
-  const _RuleTile(
-      {required this.rule, required this.onDelete, required this.controller});
+  const _RuleTile({
+    required this.rule,
+    required this.onDelete,
+    required this.controller,
+    required this.dataSource,
+  });
   final RecurringTaskRule rule;
   final VoidCallback onDelete;
   final RhythmsController controller;
+  final RhythmsDataSource dataSource;
 
   @override
   State<_RuleTile> createState() => _RuleTileState();
@@ -207,6 +226,9 @@ class _RuleTileState extends State<_RuleTile> {
   @override
   Widget build(BuildContext context) {
     final dimmed = !widget.rule.enabled;
+    final currentUserId = AuthSessionService.instance.currentUser?.id;
+    final isOwner =
+        widget.rule.ownerId != null && widget.rule.ownerId == currentUserId;
     final previewDates = RecurrenceService()
         .previewNextDates(widget.rule, DateTime.now(), count: 3)
         .map(
@@ -292,6 +314,15 @@ class _RuleTileState extends State<_RuleTile> {
                 ),
               ],
             ),
+            if (widget.rule.collaborators.isNotEmpty || isOwner) ...[
+              const SizedBox(height: 12),
+              _RhythmCollaboratorsRow(
+                rule: widget.rule,
+                isOwner: isOwner,
+                dataSource: widget.dataSource,
+                onChanged: () => widget.controller.load(),
+              ),
+            ],
             const SizedBox(height: 14),
             Wrap(
               spacing: 8,
@@ -545,6 +576,167 @@ class _ProgressStrip extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+class _RhythmCollaboratorsRow extends StatelessWidget {
+  const _RhythmCollaboratorsRow({
+    required this.rule,
+    required this.isOwner,
+    required this.dataSource,
+    required this.onChanged,
+  });
+
+  final RecurringTaskRule rule;
+  final bool isOwner;
+  final RhythmsDataSource dataSource;
+  final VoidCallback onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final workspaceMembers = context.watch<WorkspaceController>().members;
+    final collaboratorIds = rule.collaborators.map((c) => c.userId).toSet();
+    final currentUserId = AuthSessionService.instance.currentUser?.id;
+    final candidates = workspaceMembers
+        .where(
+          (member) =>
+              member.userId != rule.ownerId &&
+              !collaboratorIds.contains(member.userId) &&
+              member.userId != currentUserId,
+        )
+        .toList();
+
+    if (rule.collaborators.isEmpty && !isOwner) {
+      return const SizedBox.shrink();
+    }
+
+    return Row(
+      children: [
+        Expanded(
+          child: Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              ...rule.collaborators.map(
+                (collaborator) => Tooltip(
+                  message:
+                      '${collaborator.name}${isOwner ? ' (long-press to remove)' : ''}',
+                  child: GestureDetector(
+                    onLongPress: isOwner
+                        ? () => _confirmRemoveCollaborator(
+                              context,
+                              collaborator,
+                            )
+                        : null,
+                    child: CircleAvatar(
+                      radius: 13,
+                      backgroundImage: collaborator.photoUrl != null
+                          ? NetworkImage(collaborator.photoUrl!)
+                          : null,
+                      backgroundColor: _kPrimarySoft,
+                      child: collaborator.photoUrl == null
+                          ? Text(
+                              _initialFor(collaborator.name),
+                              style: const TextStyle(
+                                fontSize: 10,
+                                color: _kPrimary,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            )
+                          : null,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (isOwner)
+          IconButton(
+            icon: const Icon(Icons.person_add_outlined, size: 18),
+            tooltip: 'Add collaborator',
+            onPressed: () => _showAddCollaboratorDialog(context, candidates),
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(minWidth: 28, minHeight: 28),
+          ),
+      ],
+    );
+  }
+
+  Future<void> _confirmRemoveCollaborator(
+    BuildContext context,
+    RhythmCollaborator collaborator,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Remove collaborator'),
+        content: Text('Remove ${collaborator.name} from this rhythm?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await dataSource.removeCollaborator(rule.id, collaborator.userId);
+    onChanged();
+  }
+
+  Future<void> _showAddCollaboratorDialog(
+    BuildContext context,
+    List<WorkspaceMember> candidates,
+  ) async {
+    if (candidates.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('No other workspace members to add')),
+      );
+      return;
+    }
+
+    final selectedUserId = await showDialog<int>(
+      context: context,
+      builder: (ctx) {
+        var selectedId = candidates.first.userId;
+        return StatefulBuilder(
+          builder: (ctx, setState) => AlertDialog(
+            title: const Text('Add collaborator'),
+            content: SizedBox(
+              width: 360,
+              child: WorkspaceMemberPicker(
+                workspaceMembers: candidates,
+                selectedUserId: selectedId,
+                allowNone: false,
+                onChanged: (value) {
+                  if (value == null) return;
+                  setState(() => selectedId = value);
+                },
+              ),
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.pop(ctx, selectedId),
+                child: const Text('Add'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+
+    if (selectedUserId == null) return;
+    await dataSource.addCollaborator(rule.id, selectedUserId);
+    onChanged();
   }
 }
 
@@ -861,7 +1053,6 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
                     for (var i = 0; i < _steps.length; i++) ...[
                       _StepEditorRow(
                         step: _steps[i],
-                        users: widget.controller.users,
                         onAssigneeChanged: (value) =>
                             setState(() => _steps[i].assigneeId = value),
                         onRemove: () {
@@ -1124,7 +1315,6 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
                     for (var i = 0; i < _steps.length; i++) ...[
                       _StepEditorRow(
                         step: _steps[i],
-                        users: widget.controller.users,
                         onAssigneeChanged: (value) =>
                             setState(() => _steps[i].assigneeId = value),
                         onRemove: () {
@@ -1187,16 +1377,20 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
   }
 }
 
+String _initialFor(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) return '?';
+  return trimmed[0].toUpperCase();
+}
+
 class _StepEditorRow extends StatelessWidget {
   const _StepEditorRow({
     required this.step,
-    required this.users,
     required this.onAssigneeChanged,
     required this.onRemove,
   });
 
   final _StepEditorModel step;
-  final List<AuthUser> users;
   final ValueChanged<int?> onAssigneeChanged;
   final VoidCallback onRemove;
 
@@ -1239,24 +1433,9 @@ class _StepEditorRow extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 12),
-          DropdownButtonFormField<int?>(
-            value: step.assigneeId,
-            decoration: const InputDecoration(
-              labelText: 'Assign to',
-              border: OutlineInputBorder(),
-            ),
-            items: [
-              const DropdownMenuItem<int?>(
-                value: null,
-                child: Text('Unassigned'),
-              ),
-              ...users.map(
-                (user) => DropdownMenuItem<int?>(
-                  value: user.id,
-                  child: Text(user.name),
-                ),
-              ),
-            ],
+          WorkspaceMemberPicker(
+            workspaceMembers: context.watch<WorkspaceController>().members,
+            selectedUserId: step.assigneeId,
             onChanged: onAssigneeChanged,
           ),
         ],

--- a/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
+++ b/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
@@ -614,6 +614,148 @@ class _WorkspaceSectionWidgetState extends State<_WorkspaceSectionWidget> {
     });
   }
 
+  Future<void> _showAddMemberDialog(BuildContext context) async {
+    final auth = context.read<AuthSessionService>();
+    if (!auth.isWorkspaceAdmin) return;
+
+    final workspaceController = context.read<WorkspaceController>();
+    final settingsController = context.read<SettingsController>();
+
+    if (workspaceController.status == WorkspaceStatus.idle &&
+        workspaceController.members.isEmpty) {
+      await workspaceController.loadMembers();
+    }
+    if (settingsController.usersStatus != SettingsUsersStatus.ready ||
+        settingsController.users.isEmpty) {
+      await settingsController.loadUsers(force: true);
+    }
+
+    if (!context.mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
+
+    final queryController = TextEditingController();
+    int? selectedUserId;
+
+    try {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) {
+          return StatefulBuilder(
+            builder: (dialogContext, setDialogState) {
+              final existingIds = workspaceController.members
+                  .map((member) => member.userId)
+                  .toSet();
+              final query = queryController.text.trim().toLowerCase();
+              final candidates = settingsController.users.where((user) {
+                if (user.role == 'system') return false;
+                if (existingIds.contains(user.id)) return false;
+                if (query.isEmpty) return true;
+                final haystack = '${user.name} ${user.email}'.toLowerCase();
+                return haystack.contains(query);
+              }).toList();
+
+              return AlertDialog(
+                title: const Text('Add workspace member'),
+                content: SizedBox(
+                  width: 420,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      TextField(
+                        controller: queryController,
+                        autofocus: true,
+                        decoration: const InputDecoration(
+                          hintText: 'Search users by name or email',
+                          isDense: true,
+                        ),
+                        onChanged: (_) {
+                          setDialogState(() {
+                            selectedUserId = null;
+                          });
+                        },
+                      ),
+                      const SizedBox(height: 12),
+                      ConstrainedBox(
+                        constraints: const BoxConstraints(maxHeight: 320),
+                        child: candidates.isEmpty
+                            ? const Center(
+                                child: Padding(
+                                  padding: EdgeInsets.symmetric(vertical: 16),
+                                  child: Text(
+                                    'No matching registered users found.',
+                                    style: TextStyle(
+                                      fontSize: 13,
+                                      color: RhythmTokens.textSecondary,
+                                    ),
+                                    textAlign: TextAlign.center,
+                                  ),
+                                ),
+                              )
+                            : ListView.separated(
+                                shrinkWrap: true,
+                                itemCount: candidates.length,
+                                separatorBuilder: (_, __) =>
+                                    const SizedBox(height: 8),
+                                itemBuilder: (_, index) {
+                                  final user = candidates[index];
+                                  return RadioListTile<int>(
+                                    value: user.id,
+                                    groupValue: selectedUserId,
+                                    dense: true,
+                                    contentPadding: EdgeInsets.zero,
+                                    title: Text(
+                                      user.name,
+                                      style: const TextStyle(
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                    subtitle: Text(user.email),
+                                    onChanged: (value) {
+                                      setDialogState(() {
+                                        selectedUserId = value;
+                                      });
+                                    },
+                                  );
+                                },
+                              ),
+                      ),
+                    ],
+                  ),
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.of(dialogContext).pop(false),
+                    child: const Text('Cancel'),
+                  ),
+                  FilledButton(
+                    onPressed: selectedUserId == null
+                        ? null
+                        : () => Navigator.of(dialogContext).pop(true),
+                    child: const Text('Add'),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+      );
+
+      if (confirmed == true && selectedUserId != null && context.mounted) {
+        await workspaceController.addMemberDirect(selectedUserId!);
+        if (!context.mounted) return;
+        messenger.showSnackBar(
+          const SnackBar(content: Text('Member added')),
+        );
+      }
+    } catch (error) {
+      if (!context.mounted) return;
+      messenger.showSnackBar(SnackBar(content: Text(error.toString())));
+    } finally {
+      queryController.dispose();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final auth = context.watch<AuthSessionService>();
@@ -712,6 +854,14 @@ class _WorkspaceSectionWidgetState extends State<_WorkspaceSectionWidget> {
                     isCurrentUserAdmin: auth.isWorkspaceAdmin,
                   ),
                 ),
+              if (auth.isWorkspaceAdmin) ...[
+                const SizedBox(height: 12),
+                OutlinedButton.icon(
+                  onPressed: () => _showAddMemberDialog(context),
+                  icon: const Icon(Icons.person_add_outlined, size: 16),
+                  label: const Text('Add member'),
+                ),
+              ],
             ],
           ),
         ),

--- a/apps/desktop_flutter/lib/features/tasks/data/tasks_local_data_source.dart
+++ b/apps/desktop_flutter/lib/features/tasks/data/tasks_local_data_source.dart
@@ -21,7 +21,8 @@ class TasksLocalDataSource {
     return list.map((j) => Task.fromJson(j as Map<String, dynamic>)).toList();
   }
 
-  Future<Task> create(String title, {String? notes, String? dueDate}) async {
+  Future<Task> create(String title,
+      {String? notes, String? dueDate, int? ownerId}) async {
     final response = await http.post(
       Uri.parse('$_baseUrl/tasks'),
       headers: AuthSessionStore.headers(json: true),
@@ -29,6 +30,7 @@ class TasksLocalDataSource {
         'title': title,
         if (notes != null && notes.isNotEmpty) 'notes': notes,
         if (dueDate != null) 'dueDate': dueDate,
+        if (ownerId != null) 'ownerId': ownerId,
       }),
     );
     assertOk(response);
@@ -36,7 +38,12 @@ class TasksLocalDataSource {
   }
 
   Future<Task> update(String id,
-      {String? title, String? notes, String? dueDate, String? status}) async {
+      {String? title,
+      String? notes,
+      String? dueDate,
+      String? status,
+      int? ownerId,
+      bool includeOwnerId = false}) async {
     final response = await http.patch(
       Uri.parse('$_baseUrl/tasks/$id'),
       headers: AuthSessionStore.headers(json: true),
@@ -45,6 +52,7 @@ class TasksLocalDataSource {
         if (notes != null) 'notes': notes,
         if (dueDate != null) 'dueDate': dueDate,
         if (status != null) 'status': status,
+        if (includeOwnerId) 'ownerId': ownerId,
       }),
     );
     assertOk(response);

--- a/apps/desktop_flutter/lib/features/tasks/models/recurring_task_rule.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/recurring_task_rule.dart
@@ -1,5 +1,28 @@
 import '../../../app/core/utils/json_parsing.dart';
 
+class RhythmCollaborator {
+  RhythmCollaborator({
+    required this.userId,
+    required this.name,
+    this.email,
+    this.photoUrl,
+  });
+
+  factory RhythmCollaborator.fromJson(Map<String, dynamic> json) {
+    return RhythmCollaborator(
+      userId: asInt(json['userId']) ?? 0,
+      name: asString(json['name']) ?? '',
+      email: asString(json['email']),
+      photoUrl: asString(json['photoUrl']),
+    );
+  }
+
+  final int userId;
+  final String name;
+  final String? email;
+  final String? photoUrl;
+}
+
 class RecurringTaskRuleStep {
   RecurringTaskRuleStep({
     required this.id,
@@ -70,11 +93,13 @@ class RecurringTaskRule {
     required this.title,
     required this.frequency,
     required this.createdAt,
+    this.ownerId,
     this.dayOfWeek,
     this.dayOfMonth,
     this.month,
     this.enabled = true,
     this.steps = const [],
+    this.collaborators = const [],
     this.progress,
   });
 
@@ -86,11 +111,17 @@ class RecurringTaskRule {
       dayOfWeek: asInt(json['dayOfWeek']),
       dayOfMonth: asInt(json['dayOfMonth']),
       month: asInt(json['month']),
+      ownerId: asInt(json['ownerId']),
       createdAt: asString(json['createdAt']) ?? '',
       enabled: asBool(json['enabled']) ?? true,
       steps: ((json['steps'] as List<dynamic>?) ?? const [])
           .map((step) => RecurringTaskRuleStep.fromJson(
                 step as Map<String, dynamic>,
+              ))
+          .toList(),
+      collaborators: ((json['collaborators'] as List<dynamic>?) ?? const [])
+          .map((item) => RhythmCollaborator.fromJson(
+                item as Map<String, dynamic>,
               ))
           .toList(),
       progress: json['progress'] is Map<String, dynamic>
@@ -104,25 +135,34 @@ class RecurringTaskRule {
   final String id;
   final String title;
   final String frequency; // 'weekly' | 'monthly' | 'annual'
+  final int? ownerId;
   final int? dayOfWeek; // 0=Sun..6=Sat (weekly)
   final int? dayOfMonth; // 1-31 (monthly / annual)
   final int? month; // 1-12 (annual)
   final bool enabled;
   final String createdAt;
   final List<RecurringTaskRuleStep> steps;
+  final List<RhythmCollaborator> collaborators;
   final RecurringTaskRuleProgress? progress;
 
-  RecurringTaskRule copyWith({bool? enabled}) {
+  RecurringTaskRule copyWith({
+    bool? enabled,
+    List<RecurringTaskRuleStep>? steps,
+    List<RhythmCollaborator>? collaborators,
+    int? ownerId,
+  }) {
     return RecurringTaskRule(
       id: id,
       title: title,
       frequency: frequency,
+      ownerId: ownerId ?? this.ownerId,
       dayOfWeek: dayOfWeek,
       dayOfMonth: dayOfMonth,
       month: month,
       createdAt: createdAt,
       enabled: enabled ?? this.enabled,
-      steps: steps,
+      steps: steps ?? this.steps,
+      collaborators: collaborators ?? this.collaborators,
       progress: progress,
     );
   }

--- a/apps/desktop_flutter/lib/features/tasks/repositories/tasks_repository.dart
+++ b/apps/desktop_flutter/lib/features/tasks/repositories/tasks_repository.dart
@@ -8,13 +8,25 @@ class TasksRepository {
 
   Future<List<Task>> getAll() => _dataSource.fetchAll();
 
-  Future<Task> create(String title, {String? notes, String? dueDate}) =>
-      _dataSource.create(title, notes: notes, dueDate: dueDate);
+  Future<Task> create(String title,
+          {String? notes, String? dueDate, int? ownerId}) =>
+      _dataSource.create(title,
+          notes: notes, dueDate: dueDate, ownerId: ownerId);
 
   Future<Task> update(String id,
-          {String? title, String? notes, String? dueDate, String? status}) =>
+          {String? title,
+          String? notes,
+          String? dueDate,
+          String? status,
+          int? ownerId,
+          bool includeOwnerId = false}) =>
       _dataSource.update(id,
-          title: title, notes: notes, dueDate: dueDate, status: status);
+          title: title,
+          notes: notes,
+          dueDate: dueDate,
+          status: status,
+          ownerId: ownerId,
+          includeOwnerId: includeOwnerId);
 
   Future<void> delete(String id) => _dataSource.delete(id);
 }

--- a/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/foundation.dart';
 import '../../tasks/models/task.dart';
+import '../../tasks/repositories/tasks_repository.dart';
 import '../models/weekly_plan.dart';
 import '../repositories/weekly_plan_repository.dart';
 
 enum WeeklyPlannerStatus { idle, loading, error }
 
 class WeeklyPlannerController extends ChangeNotifier {
-  WeeklyPlannerController(this._repository)
+  WeeklyPlannerController(this._repository, this._tasksRepository)
       : _currentWeekLabel = _todayWeekLabel();
 
   final WeeklyPlanRepository _repository;
+  final TasksRepository _tasksRepository;
 
   WeeklyPlan? _plan;
   WeeklyPlannerStatus _status = WeeklyPlannerStatus.idle;
@@ -116,7 +118,9 @@ class WeeklyPlannerController extends ChangeNotifier {
       {String? notes,
       String? dueDate,
       String? scheduledDate,
-      int? scheduledOrder}) async {
+      int? scheduledOrder,
+      int? ownerId,
+      bool ownerChanged = false}) async {
     try {
       await _repository.updateTask(task.id,
           notes: notes,
@@ -124,6 +128,13 @@ class WeeklyPlannerController extends ChangeNotifier {
           scheduledDate: scheduledDate,
           scheduledOrder: scheduledOrder,
           sourceType: task.sourceType);
+      if (ownerChanged) {
+        await _tasksRepository.update(
+          task.id,
+          ownerId: ownerId,
+          includeOwnerId: true,
+        );
+      }
       await load();
     } catch (e) {
       _errorMessage = e.toString();
@@ -150,9 +161,9 @@ class WeeklyPlannerController extends ChangeNotifier {
     }
   }
 
-  Future<void> createTask(String title, {String? dueDate}) async {
+  Future<void> createTask(String title, {String? dueDate, int? ownerId}) async {
     try {
-      await _repository.createTask(title, dueDate: dueDate);
+      await _tasksRepository.create(title, dueDate: dueDate, ownerId: ownerId);
       await load();
     } catch (e) {
       _errorMessage = e.toString();

--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -4,10 +4,15 @@ import 'package:provider/provider.dart';
 import '../../../app/core/formatters/date_formatters.dart';
 import '../../../app/core/tasks/task_visual_style.dart';
 import '../../../app/core/widgets/error_banner.dart';
+import '../../../app/core/workspace/workspace_controller.dart';
+import '../../../app/core/workspace/workspace_models.dart';
 import '../../../app/theme/rhythm_tokens.dart';
+import '../../../shared/widgets/collaborators_row.dart';
+import '../../../shared/widgets/workspace_member_picker.dart';
 import '../../tasks/models/task.dart';
 import '../controllers/weekly_planner_controller.dart';
 import '../models/weekly_plan.dart';
+import '../../tasks/data/collaborators_data_source.dart';
 
 const _kCanvas = RhythmTokens.background;
 const _kCanvasAccent = RhythmTokens.backgroundAccent;
@@ -37,6 +42,7 @@ class _WeeklyPlannerViewState extends State<WeeklyPlannerView> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<WeeklyPlannerController>().load();
+      context.read<WorkspaceController>().loadMembers();
     });
   }
 
@@ -659,48 +665,67 @@ class _BacklogPane extends StatelessWidget {
 
   Future<void> _showAddBacklogTaskDialog(BuildContext context) async {
     final ctrl = TextEditingController();
+    final workspaceMembers = context.read<WorkspaceController>().members;
+    int? ownerId;
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: _kSurface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(RhythmTokens.radiusL),
-        ),
-        title: const Text('Add unscheduled task'),
-        content: TextField(
-          controller: ctrl,
-          autofocus: true,
-          decoration: InputDecoration(
-            hintText: 'Task title',
-            filled: true,
-            fillColor: _kSurfaceMuted,
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
-              borderSide: const BorderSide(color: _kBorder),
-            ),
-            enabledBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
-              borderSide: const BorderSide(color: _kBorder),
-            ),
-            focusedBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
-              borderSide: const BorderSide(color: _kPrimary),
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setState) => AlertDialog(
+          backgroundColor: _kSurface,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(RhythmTokens.radiusL),
+          ),
+          title: const Text('Add unscheduled task'),
+          content: SizedBox(
+            width: 380,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextField(
+                  controller: ctrl,
+                  autofocus: true,
+                  decoration: InputDecoration(
+                    hintText: 'Task title',
+                    filled: true,
+                    fillColor: _kSurfaceMuted,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+                      borderSide: const BorderSide(color: _kBorder),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+                      borderSide: const BorderSide(color: _kBorder),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+                      borderSide: const BorderSide(color: _kPrimary),
+                    ),
+                  ),
+                  onSubmitted: (_) => Navigator.pop(ctx, true),
+                ),
+                const SizedBox(height: 12),
+                _TaskOwnerPickerField(
+                  workspaceMembers: workspaceMembers,
+                  selectedUserId: ownerId,
+                  onChanged: (value) => setState(() => ownerId = value),
+                ),
+              ],
             ),
           ),
-          onSubmitted: (_) => Navigator.pop(ctx, true),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('Cancel')),
+            FilledButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('Add')),
+          ],
         ),
-        actions: [
-          TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Cancel')),
-          FilledButton(
-              onPressed: () => Navigator.pop(ctx, true),
-              child: const Text('Add')),
-        ],
       ),
     );
     if (confirmed == true && ctrl.text.trim().isNotEmpty) {
-      await controller.createTask(ctrl.text.trim());
+      await controller.createTask(ctrl.text.trim(), ownerId: ownerId);
     }
   }
 }
@@ -1005,49 +1030,68 @@ class _DayColumnState extends State<_DayColumn> {
 
   Future<void> _showAddTaskDialog(BuildContext context) async {
     final ctrl = TextEditingController();
+    final workspaceMembers = context.read<WorkspaceController>().members;
+    int? ownerId;
     final confirmed = await showDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: _kSurface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(RhythmTokens.radiusL),
-        ),
-        title: Text('Add task for ${widget.dayName}'),
-        content: TextField(
-          controller: ctrl,
-          autofocus: true,
-          decoration: InputDecoration(
-            hintText: 'Task title',
-            filled: true,
-            fillColor: _kSurfaceMuted,
-            border: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
-              borderSide: const BorderSide(color: _kBorder),
-            ),
-            enabledBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
-              borderSide: const BorderSide(color: _kBorder),
-            ),
-            focusedBorder: OutlineInputBorder(
-              borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
-              borderSide: const BorderSide(color: _kPrimary),
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setState) => AlertDialog(
+          backgroundColor: _kSurface,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(RhythmTokens.radiusL),
+          ),
+          title: Text('Add task for ${widget.dayName}'),
+          content: SizedBox(
+            width: 380,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextField(
+                  controller: ctrl,
+                  autofocus: true,
+                  decoration: InputDecoration(
+                    hintText: 'Task title',
+                    filled: true,
+                    fillColor: _kSurfaceMuted,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+                      borderSide: const BorderSide(color: _kBorder),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+                      borderSide: const BorderSide(color: _kBorder),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+                      borderSide: const BorderSide(color: _kPrimary),
+                    ),
+                  ),
+                  onSubmitted: (_) => Navigator.pop(ctx, true),
+                ),
+                const SizedBox(height: 12),
+                _TaskOwnerPickerField(
+                  workspaceMembers: workspaceMembers,
+                  selectedUserId: ownerId,
+                  onChanged: (value) => setState(() => ownerId = value),
+                ),
+              ],
             ),
           ),
-          onSubmitted: (_) => Navigator.pop(ctx, true),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: const Text('Cancel')),
+            FilledButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: const Text('Add')),
+          ],
         ),
-        actions: [
-          TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Cancel')),
-          FilledButton(
-              onPressed: () => Navigator.pop(ctx, true),
-              child: const Text('Add')),
-        ],
       ),
     );
     if (confirmed == true && ctrl.text.trim().isNotEmpty) {
       await widget.controller
-          .createTask(ctrl.text.trim(), dueDate: widget.date);
+          .createTask(ctrl.text.trim(), dueDate: widget.date, ownerId: ownerId);
     }
   }
 }
@@ -1287,7 +1331,9 @@ class _DetailPaneState extends State<_DetailPane> {
   bool _saving = false;
   String? _dueDate;
   String? _scheduledDate;
+  int? _ownerId;
   bool _datesDirty = false;
+  bool _ownerDirty = false;
 
   @override
   void initState() {
@@ -1305,6 +1351,7 @@ class _DetailPaneState extends State<_DetailPane> {
         oldWidget.task.notes != widget.task.notes ||
         oldWidget.task.dueDate != widget.task.dueDate ||
         oldWidget.task.scheduledDate != widget.task.scheduledDate ||
+        oldWidget.task.ownerId != widget.task.ownerId ||
         oldWidget.task.status != widget.task.status) {
       _syncFromTask();
     }
@@ -1320,8 +1367,10 @@ class _DetailPaneState extends State<_DetailPane> {
     _notesCtrl.text = widget.task.notes ?? '';
     _dueDate = widget.task.dueDate;
     _scheduledDate = widget.task.scheduledDate;
+    _ownerId = widget.task.ownerId;
     _notesDirty = false;
     _datesDirty = false;
+    _ownerDirty = false;
   }
 
   Future<void> _saveDetailChanges() async {
@@ -1335,11 +1384,14 @@ class _DetailPaneState extends State<_DetailPane> {
           : _datesDirty
               ? (_scheduledDate ?? '')
               : null,
+      ownerId: _ownerId,
+      ownerChanged: _ownerDirty,
     );
     setState(() {
       _saving = false;
       _notesDirty = false;
       _datesDirty = false;
+      _ownerDirty = false;
     });
   }
 
@@ -1390,6 +1442,7 @@ class _DetailPaneState extends State<_DetailPane> {
     final isDone = task.status == 'done';
     final isShadowEvent = task.sourceType == 'calendar_shadow_event';
     final timeLabel = _shadowEventLabel(task);
+    final workspaceMembers = context.watch<WorkspaceController>().members;
     return Container(
       decoration: BoxDecoration(
         color: _kSurfaceMuted,
@@ -1484,6 +1537,14 @@ class _DetailPaneState extends State<_DetailPane> {
                           widget.controller.toggleTaskDone(task, isDone),
                     ),
                   const SizedBox(height: 14),
+                  if (!isShadowEvent && task.sourceType != 'project_step') ...[
+                    _editableOwnerRow(context, workspaceMembers),
+                    if (task.ownerId != null) ...[
+                      const SizedBox(height: 10),
+                      _collaboratorsSection(context, task, workspaceMembers),
+                    ],
+                    const SizedBox(height: 14),
+                  ],
                   if (!isShadowEvent)
                     _editableDateRow(
                       context,
@@ -1567,7 +1628,8 @@ class _DetailPaneState extends State<_DetailPane> {
                       maxLines: 8,
                     ),
                   const SizedBox(height: 10),
-                  if (!isShadowEvent && (_notesDirty || _datesDirty))
+                  if (!isShadowEvent &&
+                      (_notesDirty || _datesDirty || _ownerDirty))
                     Row(
                       children: [
                         FilledButton.tonal(
@@ -1590,8 +1652,10 @@ class _DetailPaneState extends State<_DetailPane> {
                                     _notesCtrl.text = widget.task.notes ?? '';
                                     _dueDate = widget.task.dueDate;
                                     _scheduledDate = widget.task.scheduledDate;
+                                    _ownerId = widget.task.ownerId;
                                     _notesDirty = false;
                                     _datesDirty = false;
+                                    _ownerDirty = false;
                                   }),
                           child: const Text('Discard'),
                         ),
@@ -1717,6 +1781,141 @@ class _DetailPaneState extends State<_DetailPane> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _editableOwnerRow(
+    BuildContext context,
+    List<WorkspaceMember> workspaceMembers,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 76,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                'Owner',
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: _kTextSecondary,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: WorkspaceMemberPicker(
+              workspaceMembers: workspaceMembers,
+              selectedUserId: _ownerId,
+              onChanged: (value) {
+                setState(() {
+                  _ownerId = value;
+                  _ownerDirty = _ownerId != widget.task.ownerId;
+                });
+              },
+              label: 'Select owner',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _collaboratorsSection(
+    BuildContext context,
+    Task task,
+    List<WorkspaceMember> workspaceMembers,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 76,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                'Collaborators',
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: _kTextSecondary,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: CollaboratorsRow(
+              collaborators: task.collaborators,
+              ownerId: task.ownerId!,
+              workspaceMembers: workspaceMembers,
+              onAdd: (userId) async {
+                final dataSource = CollaboratorsDataSource();
+                await dataSource.addToTask(task.id, userId);
+                await widget.controller.load();
+              },
+              onRemove: (userId) async {
+                final dataSource = CollaboratorsDataSource();
+                await dataSource.removeFromTask(task.id, userId);
+                await widget.controller.load();
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TaskOwnerPickerField extends StatelessWidget {
+  const _TaskOwnerPickerField({
+    required this.workspaceMembers,
+    required this.selectedUserId,
+    required this.onChanged,
+  });
+
+  final List<WorkspaceMember> workspaceMembers;
+  final int? selectedUserId;
+  final ValueChanged<int?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 76,
+          child: Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Text(
+              'Owner',
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: _kTextSecondary,
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+          ),
+        ),
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            decoration: BoxDecoration(
+              color: _kSurface,
+              borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
+              border: Border.all(color: _kBorder),
+            ),
+            child: WorkspaceMemberPicker(
+              workspaceMembers: workspaceMembers,
+              selectedUserId: selectedUserId,
+              onChanged: onChanged,
+              label: 'Select owner',
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -136,6 +136,7 @@ class RhythmApp extends StatelessWidget {
         ChangeNotifierProvider(
           create: (_) => WeeklyPlannerController(
             WeeklyPlanRepository(WeeklyPlanDataSource(baseUrl: baseUrl)),
+            TasksRepository(TasksLocalDataSource(baseUrl: baseUrl)),
           ),
         ),
         ChangeNotifierProvider(

--- a/apps/desktop_flutter/test/controller_regressions_test.dart
+++ b/apps/desktop_flutter/test/controller_regressions_test.dart
@@ -127,12 +127,11 @@ void main() {
     controller.setPollingEnabled(false);
   });
 
-  test('RhythmsController loads users and forwards workflow steps', () async {
+  test('RhythmsController loads rules and forwards workflow steps', () async {
     final repository = _FakeRhythmsRepository();
     final controller = RhythmsController(repository);
 
     await controller.load();
-    expect(controller.users, hasLength(2));
     expect(controller.rules, hasLength(1));
     expect(controller.rules.first.steps, hasLength(2));
 


### PR DESCRIPTION
## Summary
- add workspace-aware owner and collaborator flows across weekly planner, rhythms, projects, and settings
- wire weekly planner task mutations through the configured task repository and preload workspace members where assignment UI depends on them
- ignore local runtime artifacts and superpowers planning scratch files

## Validation
- flutter test test/controller_regressions_test.dart
- flutter analyze (info-level warnings only)