### PR TITLE
ci: install CocoaPods before macOS xcodebuild in Desktop CI

### DIFF
--- a/.github/workflows/desktop_ci.yml
+++ b/.github/workflows/desktop_ci.yml
@@ -27,6 +27,9 @@ jobs:
         run: >
           flutter build macos --debug --config-only
           --dart-define=GOOGLE_DESKTOP_CLIENT_ID="$GOOGLE_DESKTOP_CLIENT_ID"
+      - name: Install CocoaPods dependencies
+        working-directory: apps/desktop_flutter/macos
+        run: pod install
       - name: Build macOS debug app
         working-directory: apps/desktop_flutter/macos
         run: >


### PR DESCRIPTION
### Motivation
- The manual `xcodebuild` invocation in the Desktop CI can fail when CocoaPods state is not prepared in a clean checkout because the Xcode project runs a `[CP] Check Pods Manifest.lock` script that requires `pod install` to have been run.

### Description
- Added an `Install CocoaPods dependencies` step to `.github/workflows/desktop_ci.yml` that runs `pod install` in `apps/desktop_flutter/macos` immediately before the unsigned `xcodebuild` macOS debug build.

### Testing
- Verified the workflow change with `git diff`, inspected the updated workflow with `sed -n`, and committed the change successfully, but could not run `flutter` or `xcodebuild` locally in this environment because `flutter` and macOS build tools are not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69def21941ec8328895c6026f07d667f)