### PR TITLE
docs: finish MCP distribution and CI

### DIFF
--- a/.github/workflows/mcp_server_ci.yml
+++ b/.github/workflows/mcp_server_ci.yml
@@ -1,25 +1,44 @@
 name: MCP Server CI
 
 on:
+  push:
+    branches: ['**']
+    paths:
+      - 'apps/mcp_server/**'
+      - '.github/workflows/mcp_server_ci.yml'
   pull_request:
     paths:
       - 'apps/mcp_server/**'
       - '.github/workflows/mcp_server_ci.yml'
 
 jobs:
-  mcp-checks:
+  build:
+    name: Type-check and build
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: apps/mcp_server
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: apps/mcp_server/package-lock.json
-      - run: npm install --workspaces=false --ignore-scripts
-      - run: npm run build
-      - name: Verify binary is executable
-        run: node dist/index.js --help 2>&1 | true
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify binary shebang
+        run: |
+          head -1 dist/index.js | grep -q '#!/usr/bin/env node' && echo "✓ Shebang present" || (echo "✗ Missing shebang in dist/index.js" && exit 1)

--- a/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
+++ b/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
@@ -664,7 +664,9 @@ class _ClaudeIntegrationSectionState
               ),
               const SizedBox(height: 6),
               const Text(
-                'Use this token to connect Claude Desktop or Claude Code to your Rhythm workspace via the @ajhochy/rhythm-mcp-server package.',
+                'Use this token to connect Claude Desktop or Claude Code to '
+                'your Rhythm workspace via the @ajhochy/rhythm-mcp-server '
+                'package.',
                 style: TextStyle(
                   fontSize: 13,
                   color: RhythmTokens.textSecondary,

--- a/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
+++ b/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
@@ -664,7 +664,7 @@ class _ClaudeIntegrationSectionState
               ),
               const SizedBox(height: 6),
               const Text(
-                'Use this token to connect Claude Desktop or Claude Code to your Rhythm workspace via the @rhythm/mcp-server package.',
+                'Use this token to connect Claude Desktop or Claude Code to your Rhythm workspace via the @ajhochy/rhythm-mcp-server package.',
                 style: TextStyle(
                   fontSize: 13,
                   color: RhythmTokens.textSecondary,
@@ -779,7 +779,7 @@ class _ClaudeIntegrationSectionState
                     '  "mcpServers": {\n'
                     '    "rhythm": {\n'
                     '      "command": "npx",\n'
-                    '      "args": ["-y", "@rhythm/mcp-server"],\n'
+                    '      "args": ["-y", "@ajhochy/rhythm-mcp-server"],\n'
                     '      "env": {\n'
                     '        "RHYTHM_API_URL": "${serverConfig.url}",\n'
                     '        "RHYTHM_API_TOKEN": "${_tokenVisible ? token : "••••••••"}"\n'

--- a/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
+++ b/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
@@ -610,8 +610,7 @@ class _ClaudeIntegrationSection extends StatefulWidget {
       _ClaudeIntegrationSectionState();
 }
 
-class _ClaudeIntegrationSectionState
-    extends State<_ClaudeIntegrationSection> {
+class _ClaudeIntegrationSectionState extends State<_ClaudeIntegrationSection> {
   bool _tokenVisible = false;
   bool _copied = false;
 
@@ -701,21 +700,18 @@ class _ClaudeIntegrationSectionState
               ] else ...[
                 // Token display row
                 Container(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 12, vertical: 10),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
                   decoration: BoxDecoration(
                     color: RhythmTokens.surfaceMuted,
-                    borderRadius:
-                        BorderRadius.circular(RhythmTokens.radiusS),
+                    borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
                     border: Border.all(color: RhythmTokens.border),
                   ),
                   child: Row(
                     children: [
                       Expanded(
                         child: Text(
-                          _tokenVisible
-                              ? token
-                              : '•' * 40,
+                          _tokenVisible ? token : '•' * 40,
                           style: const TextStyle(
                             fontFamily: 'monospace',
                             fontSize: 12,
@@ -773,8 +769,7 @@ class _ClaudeIntegrationSectionState
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
                     color: const Color(0xFF1E293B),
-                    borderRadius:
-                        BorderRadius.circular(RhythmTokens.radiusS),
+                    borderRadius: BorderRadius.circular(RhythmTokens.radiusS),
                   ),
                   child: SelectableText(
                     '{\n'

--- a/apps/mcp_server/README.md
+++ b/apps/mcp_server/README.md
@@ -32,7 +32,7 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
   "mcpServers": {
     "rhythm": {
       "command": "npx",
-      "args": ["-y", "@rhythm/mcp-server"],
+      "args": ["-y", "@ajhochy/rhythm-mcp-server"],
       "env": {
         "RHYTHM_API_URL": "https://api.vcrc.com",
         "RHYTHM_API_TOKEN": "paste-your-session-token-here"
@@ -53,7 +53,7 @@ Add to `~/.claude/settings.json` (global) or `.claude/settings.json` (per-projec
   "mcpServers": {
     "rhythm": {
       "command": "npx",
-      "args": ["-y", "@rhythm/mcp-server"],
+      "args": ["-y", "@ajhochy/rhythm-mcp-server"],
       "env": {
         "RHYTHM_API_URL": "https://api.vcrc.com",
         "RHYTHM_API_TOKEN": "paste-your-session-token-here"

--- a/apps/mcp_server/README.md
+++ b/apps/mcp_server/README.md
@@ -1,0 +1,107 @@
+# Rhythm MCP Server
+
+Rhythm MCP Server lets you manage tasks, projects, rhythms, messages, and facilities in Rhythm directly from Claude.
+
+## Prerequisites
+
+- Node.js 18 or later
+- A Rhythm account at [api.vcrc.com](https://api.vcrc.com)
+- Claude Desktop, Claude Code, or any MCP-compatible client
+
+## Get your API token
+
+Open Rhythm → **Settings → Claude Integration** and copy your session token.
+
+Alternatively, obtain one via the API:
+
+```bash
+curl -X POST https://api.vcrc.com/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "you@example.com", "password": "yourpassword"}'
+# Response: { "sessionToken": "abc123...", "user": { ... } }
+```
+
+Copy the `sessionToken` value.
+
+## Claude Desktop setup
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS):
+
+```json
+{
+  "mcpServers": {
+    "rhythm": {
+      "command": "npx",
+      "args": ["-y", "@rhythm/mcp-server"],
+      "env": {
+        "RHYTHM_API_URL": "https://api.vcrc.com",
+        "RHYTHM_API_TOKEN": "paste-your-session-token-here"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving.
+
+## Claude Code setup
+
+Add to `~/.claude/settings.json` (global) or `.claude/settings.json` (per-project):
+
+```json
+{
+  "mcpServers": {
+    "rhythm": {
+      "command": "npx",
+      "args": ["-y", "@rhythm/mcp-server"],
+      "env": {
+        "RHYTHM_API_URL": "https://api.vcrc.com",
+        "RHYTHM_API_TOKEN": "paste-your-session-token-here"
+      }
+    }
+  }
+}
+```
+
+## Verify it's working
+
+In Claude, ask: *"Call rhythm_ping to check the connection."*
+
+Expected response: Rhythm API status and the email address your token authenticates as.
+
+## Available tools
+
+| Tool | Description |
+|------|-------------|
+| `rhythm_ping` | Verify connectivity and confirm your token is valid |
+| `rhythm_get_dashboard` | Summary snapshot of tasks, projects, rhythms, and threads — start here |
+| `rhythm_list_tasks` | List tasks with optional status/date/search filters |
+| `rhythm_create_task` | Create a task |
+| `rhythm_update_task` | Update task fields (title, notes, due date, status) |
+| `rhythm_complete_task` | Mark a task as done |
+| `rhythm_delete_task` | Permanently delete a task |
+| `rhythm_list_rhythms` | List recurring rules |
+| `rhythm_create_rhythm` | Create a recurring rule |
+| `rhythm_update_rhythm` | Update or enable/disable a rhythm |
+| `rhythm_delete_rhythm` | Delete a rhythm |
+| `rhythm_list_project_templates` | List project templates |
+| `rhythm_create_project_template` | Create a project template |
+| `rhythm_add_project_step` | Add a step to a template |
+| `rhythm_create_project_instance` | Instantiate a template as an active project |
+| `rhythm_list_project_instances` | List active projects with step progress |
+| `rhythm_update_project_step` | Mark a project step done or add notes |
+| `rhythm_list_message_threads` | List message threads |
+| `rhythm_create_message_thread` | Create a message thread |
+| `rhythm_send_message` | Send a message to a thread |
+| `rhythm_list_facilities` | List facilities |
+| `rhythm_create_reservation` | Reserve a facility for a time window |
+
+## Troubleshooting
+
+**`RHYTHM_API_TOKEN environment variable is not set`** — The token is missing from your MCP config. Double-check the `env` block in your settings file.
+
+**401 errors** — Token expired or invalid. Re-fetch a token from Rhythm Settings or re-run the login curl command.
+
+**Can't reach API** — Confirm `RHYTHM_API_URL` is set to `https://api.vcrc.com`.
+
+**`npx` fails** — Ensure Node.js 18+ is installed: `node --version`.

--- a/apps/mcp_server/package-lock.json
+++ b/apps/mcp_server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@rhythm/mcp-server",
+  "name": "@ajhochy/rhythm-mcp-server",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@rhythm/mcp-server",
+      "name": "@ajhochy/rhythm-mcp-server",
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/apps/mcp_server/package.json
+++ b/apps/mcp_server/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json --noCheck",
+    "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",

--- a/apps/mcp_server/package.json
+++ b/apps/mcp_server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rhythm/mcp-server",
+  "name": "@ajhochy/rhythm-mcp-server",
   "version": "0.1.0",
   "description": "MCP server for Rhythm — manage tasks, projects, and rhythms via Claude",
   "type": "commonjs",


### PR DESCRIPTION
## Summary

Completes the remaining code and documentation work for MCP Milestone 8.

- add the `apps/mcp_server/README.md` setup guide for Claude Desktop and Claude Code
- align `apps/mcp_server/package.json` with publishable npm package metadata and standard build/prepare scripts
- switch the published package/install snippets to `@ajhochy/rhythm-mcp-server`
- finalize `.github/workflows/mcp_server_ci.yml` so MCP changes run Node 20 install, type-check, build, and shebang verification on push and PR

## Validation

- `apps/mcp_server/src/index.ts` still starts with the required `#!/usr/bin/env node` shebang
- GitHub Actions `Type-check and build` is passing on this PR
- package is now published at https://www.npmjs.com/package/@ajhochy/rhythm-mcp-server

Closes #222
Closes #223
Closes #224
Closes #192
