### PR TITLE
fix: cast expires_at to timestamptz for Postgres session lookup

### DIFF
--- a/apps/api_server/src/repositories/sessions_repository.ts
+++ b/apps/api_server/src/repositories/sessions_repository.ts
@@ -74,7 +74,7 @@ export class SessionsRepository {
       const result = await getPostgresPool().query<SessionRow>(
         `SELECT * FROM sessions
          WHERE token = $1
-           AND (expires_at IS NULL OR expires_at > NOW())`,
+           AND (expires_at IS NULL OR expires_at::timestamptz > NOW())`,
         [token],
       );
       const row = result.rows[0];


### PR DESCRIPTION
## Summary
- `sessions_repository` was comparing `expires_at` (stored as `TEXT`) against `NOW()` (`timestamptz`) in the Postgres query
- Postgres rejects the `text > timestamptz` comparison without an explicit cast — SQLite handled it silently
- This caused every authenticated request against the hosted API to return `INTERNAL_ERROR`

## Fix
Added `::timestamptz` cast in the `findByTokenAsync` Postgres query:
```sql
AND (expires_at IS NULL OR expires_at::timestamptz > NOW())
```

## Test plan
- [ ] Push triggers new Docker image build via `api_deploy_synology` workflow
- [ ] Pull new image on Synology and restart containers
- [ ] Sign in on the desktop app against `api.vcrcapps.com` — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)