### PR TITLE
fix: register correct Google Sign-In URL scheme in Info.plist

### DIFF
--- a/apps/desktop_flutter/macos/Runner/Info.plist
+++ b/apps/desktop_flutter/macos/Runner/Info.plist
@@ -27,12 +27,12 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.googleusercontent.apps.999198211175-0avbpkvrkj5krqttb87p9qhekh29baf1</string>
+				<string>com.googleusercontent.apps.99919821175-em7b006pdol702sa5qecv9dhu2km483a</string>
 			</array>
 		</dict>
 	</array>
 	<key>GIDClientID</key>
-	<string>999198211175-0avbpkvrkj5krqttb87p9qhekh29baf1.apps.googleusercontent.com</string>
+	<string>99919821175-em7b006pdol702sa5qecv9dhu2km483a.apps.googleusercontent.com</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
## Summary
- The release build injects client ID `99919821175-em7b006pdol702sa5qecv9dhu2km483a` via `--dart-define=GOOGLE_DESKTOP_CLIENT_ID`
- Info.plist had the URL scheme for a different/old client ID (`999198211175-0avbpkvrkj5krqttb87p9qhekh29baf1`)
- macOS requires `CFBundleURLSchemes` to match the runtime client ID for the OAuth redirect callback to work — without it, Google Sign-In throws `NSInvalidArgumentException`

## Test plan
- [ ] Build and run locally with `--dart-define=GOOGLE_DESKTOP_CLIENT_ID=99919821175-em7b006pdol702sa5qecv9dhu2km483a flutter run -d macos`
- [ ] Tap "Continue with Google" — OAuth browser opens and redirects back without error
- [ ] Sign-in completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)