### PR TITLE
ci: inject Google client ID into Info.plist from secret

### DIFF
--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -49,6 +49,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Inject Google client ID into Info.plist
+        working-directory: apps/desktop_flutter/macos/Runner
+        run: |
+          PLIST=Info.plist
+          CLIENT_ID="$GOOGLE_DESKTOP_CLIENT_ID"
+          SCHEME="com.googleusercontent.apps.$(echo "$CLIENT_ID" | sed 's/\.apps\.googleusercontent\.com$//')"
+          /usr/libexec/PlistBuddy -c "Set :GIDClientID $CLIENT_ID" "$PLIST"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleURLTypes:0:CFBundleURLSchemes:0 $SCHEME" "$PLIST"
+
       - uses: subosito/flutter-action@v2
         with:
           channel: stable

--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -104,6 +104,11 @@ jobs:
           ARCHS="arm64 x86_64"
           build
 
+      - name: Verify Google Sign-In config in built app
+        run: |
+          plutil -p apps/desktop_flutter/build/macos/Build/Products/Release/Rhythm.app/Contents/Info.plist \
+            | grep -E "GIDClient|CFBundleURLSchemes|CFBundleURLTypes" || echo "WARNING: no Google Sign-In keys found in built Info.plist"
+
       - name: Bundle API server into app
         if: ${{ inputs.use_embedded_api }}
         working-directory: apps/desktop_flutter


### PR DESCRIPTION
## Summary
- Adds a CI step that overwrites `GIDClientID` and `CFBundleURLSchemes` in `Info.plist` using the `GOOGLE_DESKTOP_CLIENT_ID` secret before each build
- Eliminates the mismatch risk between the hardcoded plist value and the runtime dart-define
- Hardcoded plist values are kept for local dev; CI always overwrites them

## Why this fixes the login error
The Google SDK derives the expected URL scheme from the clientId passed to `GoogleSignIn.instance.initialize()`. If that differs from what is registered in `CFBundleURLSchemes`, it throws NSInvalidArgumentException. Injecting both from the same secret makes them identical by construction.

## Test plan
- [ ] Merge and trigger a release build
- [ ] Verify the Inject Google client ID step succeeds
- [ ] Confirm Google Sign-In works in the resulting build

Generated with Claude Code