### PR TITLE
fix: add keychain-access-groups entitlement for Google Sign-In

### DIFF
--- a/apps/desktop_flutter/macos/Runner/DebugProfile.entitlements
+++ b/apps/desktop_flutter/macos/Runner/DebugProfile.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)org.visaliacrc.rhythm</string>
+	</array>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/apps/desktop_flutter/macos/Runner/Release.entitlements
+++ b/apps/desktop_flutter/macos/Runner/Release.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)org.visaliacrc.rhythm</string>
+	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>com.apple.security.network.server</key>


### PR DESCRIPTION
## Summary
- Adds `com.apple.security.keychain-access-groups` to both `Release.entitlements` and `DebugProfile.entitlements`
- The Google Sign-In SDK (GTMKeychainStore) requires this to store OAuth tokens in the macOS keychain after authentication completes
- Without it, sign-in fails after the Google auth screen with `providerConfigurationError: keychain error`

## Test plan
- [ ] Merge and trigger release build
- [ ] Confirm Google Sign-In completes without keychain error

Generated with Claude Code