### PR TITLE
fix: use correct keychain access group for Google Sign-In

### DIFF
--- a/apps/desktop_flutter/macos/Runner/DebugProfile.entitlements
+++ b/apps/desktop_flutter/macos/Runner/DebugProfile.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)org.visaliacrc.rhythm</string>
+		<string>$(AppIdentifierPrefix)com.google.GIDSignIn</string>
 	</array>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>

--- a/apps/desktop_flutter/macos/Runner/Release.entitlements
+++ b/apps/desktop_flutter/macos/Runner/Release.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)org.visaliacrc.rhythm</string>
+		<string>$(AppIdentifierPrefix)com.google.GIDSignIn</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>


### PR DESCRIPTION
## Summary
The keychain access group must be `$(AppIdentifierPrefix)com.google.GIDSignIn` — the group the SDK hardcodes internally. PR #240 used the app bundle ID instead, which is why the keychain error persisted.

## Root cause
`GULKeychainUtils` sets `kSecUseDataProtectionKeychain = YES` on all keychain operations. The Data Protection keychain requires a `keychain-access-groups` entitlement, and the SDK writes to the `com.google.GIDSignIn` group specifically. Without that exact group in the entitlement the write fails.

## Test plan
- [ ] Merge and trigger release build
- [ ] Confirm Google Sign-In completes successfully

Generated with Claude Code