### PR TITLE
Fix data leak: scope all data reads to owner_id and explicit collabor…

### DIFF
--- a/apps/api_server/src/__tests__/auth_and_messaging.test.ts
+++ b/apps/api_server/src/__tests__/auth_and_messaging.test.ts
@@ -63,7 +63,7 @@ describe('Auth and ownership flows', () => {
     ).toBe(session.user.id);
   });
 
-  it('filters tasks to the current owner plus legacy shared records', () => {
+  it('filters tasks to the current owner only', () => {
     const alice = usersRepo.create({ name: 'Alice', email: 'alice@example.com' });
     const bob = usersRepo.create({ name: 'Bob', email: 'bob@example.com' });
 
@@ -72,12 +72,12 @@ describe('Auth and ownership flows', () => {
     tasksRepo.create({ title: 'Bob private task', ownerId: bob.id });
 
     const visibleToAlice = tasksRepo.findAll(alice.id).map((task) => task.title);
-    expect(visibleToAlice).toContain('Shared task');
+    expect(visibleToAlice).not.toContain('Shared task');
     expect(visibleToAlice).toContain('Alice private task');
     expect(visibleToAlice).not.toContain('Bob private task');
   });
 
-  it('filters project templates and instances to the current owner plus legacy shared records', () => {
+  it('filters project templates and instances to the current owner only', () => {
     const alice = usersRepo.create({ name: 'Alice', email: 'alice@example.com' });
     const bob = usersRepo.create({ name: 'Bob', email: 'bob@example.com' });
 
@@ -116,14 +116,14 @@ describe('Auth and ownership flows', () => {
     const visibleTemplatesToAlice = projectTemplatesRepo
       .findAll(alice.id)
       .map((template) => template.name);
-    expect(visibleTemplatesToAlice).toContain('Shared Template');
+    expect(visibleTemplatesToAlice).not.toContain('Shared Template');
     expect(visibleTemplatesToAlice).toContain('Alice Template');
     expect(visibleTemplatesToAlice).not.toContain('Bob Template');
 
     const visibleInstancesToAlice = projectInstancesRepo
       .findAll(alice.id)
       .map((instance) => instance.name);
-    expect(visibleInstancesToAlice).toContain('Shared Instance');
+    expect(visibleInstancesToAlice).not.toContain('Shared Instance');
     expect(visibleInstancesToAlice).toContain('Alice Instance');
     expect(visibleInstancesToAlice).not.toContain('Bob Instance');
   });

--- a/apps/api_server/src/__tests__/tasks_permissions.test.ts
+++ b/apps/api_server/src/__tests__/tasks_permissions.test.ts
@@ -1,0 +1,143 @@
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { createApp } from '../app';
+import { runMigrations } from '../database/migrations';
+import { setDb } from '../database/db';
+import { SessionsRepository } from '../repositories/sessions_repository';
+import { TasksRepository } from '../repositories/tasks_repository';
+import { UsersRepository } from '../repositories/users_repository';
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+  runMigrations(db);
+  return db;
+}
+
+async function readJson(response: Response) {
+  const text = await response.text();
+  return text ? JSON.parse(text) : null;
+}
+
+describe('Tasks permissions', () => {
+  let usersRepo: UsersRepository;
+  let sessionsRepo: SessionsRepository;
+  let tasksRepo: TasksRepository;
+  let baseUrl: string;
+  let closeServer: () => Promise<void>;
+
+  beforeEach(async () => {
+    setDb(makeDb());
+    usersRepo = new UsersRepository();
+    sessionsRepo = new SessionsRepository();
+    tasksRepo = new TasksRepository();
+
+    const server = createApp().listen(0);
+    await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+    closeServer = () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+  });
+
+  afterEach(async () => {
+    await closeServer();
+  });
+
+  async function authHeaderFor(userId: number) {
+    const session = await sessionsRepo.createAsync(userId);
+    return { Authorization: `Bearer ${session.token}` };
+  }
+
+  it('does not expose another user tasks or legacy unowned tasks', async () => {
+    const owner = usersRepo.create({ name: 'Owner', email: 'owner@example.com' });
+    const other = usersRepo.create({ name: 'Other', email: 'other@example.com' });
+    const ownerHeaders = await authHeaderFor(owner.id);
+    const otherHeaders = await authHeaderFor(other.id);
+
+    const createResponse = await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: {
+        ...ownerHeaders,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ title: 'Owner private task' }),
+    });
+    expect(createResponse.status).toBe(201);
+    const ownerTask = await readJson(createResponse) as { id: string };
+
+    tasksRepo.create({ title: 'Legacy unowned task' });
+
+    const ownerListResponse = await fetch(`${baseUrl}/tasks`, {
+      headers: ownerHeaders,
+    });
+    expect(ownerListResponse.status).toBe(200);
+    const ownerTasks = await readJson(ownerListResponse) as Array<{ title: string }>;
+    expect(ownerTasks.map((task) => task.title)).toEqual(['Owner private task']);
+
+    const otherListResponse = await fetch(`${baseUrl}/tasks`, {
+      headers: otherHeaders,
+    });
+    expect(otherListResponse.status).toBe(200);
+    expect(await readJson(otherListResponse)).toEqual([]);
+
+    const otherDetailResponse = await fetch(`${baseUrl}/tasks/${ownerTask.id}`, {
+      headers: otherHeaders,
+    });
+    expect(otherDetailResponse.status).toBe(404);
+  });
+
+  it('prevents non-owners from adding themselves as task collaborators', async () => {
+    const owner = usersRepo.create({ name: 'Owner', email: 'task-owner@example.com' });
+    const other = usersRepo.create({ name: 'Other', email: 'task-other@example.com' });
+    const ownerHeaders = await authHeaderFor(owner.id);
+    const otherHeaders = await authHeaderFor(other.id);
+
+    const createResponse = await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: {
+        ...ownerHeaders,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ title: 'Collaborator guarded task' }),
+    });
+    const task = await readJson(createResponse) as { id: string };
+
+    const selfAddResponse = await fetch(`${baseUrl}/tasks/${task.id}/collaborators`, {
+      method: 'POST',
+      headers: {
+        ...otherHeaders,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ userId: other.id }),
+    });
+    expect(selfAddResponse.status).toBe(404);
+
+    const stillHiddenResponse = await fetch(`${baseUrl}/tasks`, {
+      headers: otherHeaders,
+    });
+    expect(await readJson(stillHiddenResponse)).toEqual([]);
+
+    const ownerAddResponse = await fetch(`${baseUrl}/tasks/${task.id}/collaborators`, {
+      method: 'POST',
+      headers: {
+        ...ownerHeaders,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ userId: other.id }),
+    });
+    expect(ownerAddResponse.status).toBe(201);
+
+    const collaboratorListResponse = await fetch(`${baseUrl}/tasks`, {
+      headers: otherHeaders,
+    });
+    const collaboratorTasks = await readJson(collaboratorListResponse) as Array<{ id: string }>;
+    expect(collaboratorTasks.map((visibleTask) => visibleTask.id)).toEqual([task.id]);
+  });
+});

--- a/apps/api_server/src/controllers/tasks_controller.ts
+++ b/apps/api_server/src/controllers/tasks_controller.ts
@@ -106,7 +106,12 @@ export class TasksController {
 
   async remove(req: Request, res: Response, next: NextFunction) {
     try {
-      await repo.deleteAsync(req.params.id, req.auth?.user.id);
+      const actorId = req.auth?.user.id;
+      const task = await repo.findByIdAsync(req.params.id, actorId);
+      if (actorId == null || task.ownerId !== actorId) {
+        throw AppError.forbidden('Only the task owner can delete this task');
+      }
+      await repo.deleteAsync(req.params.id, actorId);
       res.status(204).send();
     } catch (err) {
       next(err);
@@ -115,6 +120,7 @@ export class TasksController {
 
   async getCollaborators(req: Request, res: Response, next: NextFunction) {
     try {
+      await repo.findByIdAsync(req.params.id, req.auth?.user.id);
       res.json(await repo.listCollaboratorsAsync(req.params.id));
     } catch (err) {
       next(err);
@@ -127,10 +133,13 @@ export class TasksController {
       if (!userId || typeof userId !== 'number') {
         throw AppError.badRequest('userId is required and must be a number');
       }
-      await repo.addCollaboratorAsync(req.params.id, userId);
       const actorId = req.auth?.user.id;
+      const task = await repo.findByIdAsync(req.params.id, actorId);
+      if (actorId == null || task.ownerId !== actorId) {
+        throw AppError.forbidden('Only the task owner can add collaborators');
+      }
+      await repo.addCollaboratorAsync(req.params.id, userId);
       if (actorId != null) {
-        const task = await repo.findByIdAsync(req.params.id, actorId);
         await notifService.notifyCollaboratorAddedAsync(
           'task',
           req.params.id,
@@ -150,6 +159,11 @@ export class TasksController {
       const collaboratorUserId = Number(req.params.userId);
       if (isNaN(collaboratorUserId)) {
         throw AppError.badRequest('Invalid userId');
+      }
+      const actorId = req.auth?.user.id;
+      const task = await repo.findByIdAsync(req.params.id, actorId);
+      if (actorId == null || task.ownerId !== actorId) {
+        throw AppError.forbidden('Only the task owner can remove collaborators');
       }
       await repo.removeCollaboratorAsync(req.params.id, collaboratorUserId);
       res.status(204).send();

--- a/apps/api_server/src/repositories/automation_rules_repository.ts
+++ b/apps/api_server/src/repositories/automation_rules_repository.ts
@@ -61,7 +61,7 @@ export class AutomationRulesRepository {
         userId != null
           ? await getPostgresPool().query<AutomationRuleRow>(
               `SELECT * FROM automation_rules
-               WHERE owner_id = $1 OR owner_id IS NULL
+               WHERE owner_id = $1
                ORDER BY created_at ASC`,
               [userId],
             )
@@ -78,7 +78,7 @@ export class AutomationRulesRepository {
       ? getDb()
           .prepare(
             `SELECT * FROM automation_rules
-             WHERE owner_id = ? OR owner_id IS NULL
+             WHERE owner_id = ?
              ORDER BY created_at ASC`,
           )
           .all(userId)
@@ -120,7 +120,7 @@ export class AutomationRulesRepository {
         userId != null
           ? await getPostgresPool().query<AutomationRuleRow>(
               `SELECT * FROM automation_rules
-               WHERE id = $1 AND (owner_id = $2 OR owner_id IS NULL)`,
+               WHERE id = $1 AND owner_id = $2`,
               [id, userId],
             )
           : await getPostgresPool().query<AutomationRuleRow>(
@@ -139,7 +139,7 @@ export class AutomationRulesRepository {
       ? getDb()
           .prepare(
             `SELECT * FROM automation_rules
-             WHERE id = ? AND (owner_id = ? OR owner_id IS NULL)`,
+             WHERE id = ? AND owner_id = ?`,
           )
           .get(id, userId)
       : getDb()

--- a/apps/api_server/src/repositories/project_instances_repository.ts
+++ b/apps/api_server/src/repositories/project_instances_repository.ts
@@ -239,7 +239,7 @@ export class ProjectInstancesRepository {
       ? getDb()
           .prepare(
             `SELECT * FROM project_instances
-             WHERE owner_id = ? OR owner_id IS NULL
+             WHERE owner_id = ?
              ORDER BY created_at DESC`,
           )
           .all(userId)
@@ -255,7 +255,7 @@ export class ProjectInstancesRepository {
         userId != null
           ? await getPostgresPool().query<InstanceRow>(
               `SELECT * FROM project_instances
-               WHERE owner_id = $1 OR owner_id IS NULL
+               WHERE owner_id = $1
                ORDER BY created_at DESC`,
               [userId],
             )
@@ -276,7 +276,7 @@ export class ProjectInstancesRepository {
       ? getDb()
           .prepare(
             `SELECT * FROM project_instances
-             WHERE template_id = ? AND (owner_id = ? OR owner_id IS NULL)
+             WHERE template_id = ? AND owner_id = ?
              ORDER BY anchor_date DESC`,
           )
           .all(templateId, userId)
@@ -297,7 +297,7 @@ export class ProjectInstancesRepository {
         userId != null
           ? await getPostgresPool().query<InstanceRow>(
               `SELECT * FROM project_instances
-               WHERE template_id = $1 AND (owner_id = $2 OR owner_id IS NULL)
+               WHERE template_id = $1 AND owner_id = $2
                ORDER BY anchor_date DESC`,
               [templateId, userId],
             )
@@ -319,7 +319,7 @@ export class ProjectInstancesRepository {
       ? getDb()
           .prepare(
             `SELECT * FROM project_instances
-             WHERE id = ? AND (owner_id = ? OR owner_id IS NULL)`,
+             WHERE id = ? AND owner_id = ?`,
           )
           .get(id, userId)
       : getDb()
@@ -335,7 +335,7 @@ export class ProjectInstancesRepository {
         userId != null
           ? await getPostgresPool().query<InstanceRow>(
               `SELECT * FROM project_instances
-               WHERE id = $1 AND (owner_id = $2 OR owner_id IS NULL)`,
+               WHERE id = $1 AND owner_id = $2`,
               [id, userId],
             )
           : await getPostgresPool().query<InstanceRow>(
@@ -362,7 +362,7 @@ export class ProjectInstancesRepository {
              WHERE template_id = ?
                AND anchor_date = ?
                AND COALESCE(name, '') = COALESCE(?, '')
-               AND (owner_id = ? OR owner_id IS NULL)`,
+               AND owner_id = ?`,
           )
           .get(templateId, anchorDate, name ?? null, userId)
       : getDb()
@@ -389,7 +389,7 @@ export class ProjectInstancesRepository {
                WHERE template_id = $1
                  AND anchor_date = $2
                  AND COALESCE(name, '') = COALESCE($3, '')
-                 AND (owner_id = $4 OR owner_id IS NULL)`,
+                 AND owner_id = $4`,
               [templateId, anchorDate, name ?? null, userId],
             )
           : await getPostgresPool().query<InstanceRow>(
@@ -497,7 +497,7 @@ export class ProjectInstancesRepository {
              FROM project_instance_steps pis
              JOIN project_instances pi ON pi.id = pis.instance_id
              LEFT JOIN users u ON u.id = pis.assignee_id
-             WHERE pis.id = ? AND (pi.owner_id = ? OR pi.owner_id IS NULL)`,
+             WHERE pis.id = ? AND pi.owner_id = ?`,
           )
           .get(stepId, userId)
       : getDb()
@@ -549,7 +549,7 @@ export class ProjectInstancesRepository {
                FROM project_instance_steps pis
                JOIN project_instances pi ON pi.id = pis.instance_id
                LEFT JOIN users u ON u.id = pis.assignee_id
-               WHERE pis.id = $1 AND (pi.owner_id = $2 OR pi.owner_id IS NULL)`,
+               WHERE pis.id = $1 AND pi.owner_id = $2`,
               [stepId, userId],
             )
           : await getPostgresPool().query<InstanceStepRow>(
@@ -593,7 +593,7 @@ export class ProjectInstancesRepository {
     if (userId != null) {
       getDb()
         .prepare(
-          'DELETE FROM project_instances WHERE template_id = ? AND (owner_id = ? OR owner_id IS NULL)',
+          'DELETE FROM project_instances WHERE template_id = ? AND owner_id = ?',
         )
         .run(templateId, userId);
       return;
@@ -605,7 +605,7 @@ export class ProjectInstancesRepository {
     if (env.dbClient === 'postgres') {
       if (userId != null) {
         await getPostgresPool().query(
-          'DELETE FROM project_instances WHERE template_id = $1 AND (owner_id = $2 OR owner_id IS NULL)',
+          'DELETE FROM project_instances WHERE template_id = $1 AND owner_id = $2',
           [templateId, userId],
         );
         return;
@@ -624,7 +624,7 @@ export class ProjectInstancesRepository {
     const result = (userId != null
       ? getDb()
           .prepare(
-            'DELETE FROM project_instances WHERE id = ? AND (owner_id = ? OR owner_id IS NULL)',
+            'DELETE FROM project_instances WHERE id = ? AND owner_id = ?',
           )
           .run(instanceId, userId)
       : getDb().prepare('DELETE FROM project_instances WHERE id = ?').run(instanceId));
@@ -637,7 +637,7 @@ export class ProjectInstancesRepository {
       const result =
         userId != null
           ? await getPostgresPool().query(
-              'DELETE FROM project_instances WHERE id = $1 AND (owner_id = $2 OR owner_id IS NULL)',
+              'DELETE FROM project_instances WHERE id = $1 AND owner_id = $2',
               [instanceId, userId],
             )
           : await getPostgresPool().query(

--- a/apps/api_server/src/repositories/project_templates_repository.ts
+++ b/apps/api_server/src/repositories/project_templates_repository.ts
@@ -90,7 +90,7 @@ export class ProjectTemplatesRepository {
         userId != null
           ? await getPostgresPool().query<TemplateRow>(
               `SELECT * FROM project_templates
-               WHERE owner_id = $1 OR owner_id IS NULL
+               WHERE owner_id = $1
                ORDER BY created_at ASC`,
               [userId],
             )
@@ -111,7 +111,7 @@ export class ProjectTemplatesRepository {
       ? getDb()
           .prepare(
             `SELECT * FROM project_templates
-             WHERE owner_id = ? OR owner_id IS NULL
+             WHERE owner_id = ?
              ORDER BY created_at ASC`,
           )
           .all(userId)
@@ -127,7 +127,7 @@ export class ProjectTemplatesRepository {
         userId != null
           ? await getPostgresPool().query<TemplateRow>(
               `SELECT * FROM project_templates
-               WHERE id = $1 AND (owner_id = $2 OR owner_id IS NULL)`,
+               WHERE id = $1 AND owner_id = $2`,
               [id, userId],
             )
           : await getPostgresPool().query<TemplateRow>(
@@ -146,7 +146,7 @@ export class ProjectTemplatesRepository {
       ? getDb()
           .prepare(
             `SELECT * FROM project_templates
-             WHERE id = ? AND (owner_id = ? OR owner_id IS NULL)`,
+             WHERE id = ? AND owner_id = ?`,
           )
           .get(id, userId)
       : getDb().prepare('SELECT * FROM project_templates WHERE id = ?').get(id)) as
@@ -256,11 +256,11 @@ export class ProjectTemplatesRepository {
       await this.findByIdAsync(id, userId);
       if (userId != null) {
         await getPostgresPool().query(
-          'DELETE FROM project_instances WHERE template_id = $1 AND (owner_id = $2 OR owner_id IS NULL)',
+          'DELETE FROM project_instances WHERE template_id = $1 AND owner_id = $2',
           [id, userId],
         );
         const result = await getPostgresPool().query(
-          'DELETE FROM project_templates WHERE id = $1 AND (owner_id = $2 OR owner_id IS NULL)',
+          'DELETE FROM project_templates WHERE id = $1 AND owner_id = $2',
           [id, userId],
         );
         if (result.rowCount === 0) throw AppError.notFound('ProjectTemplate');
@@ -359,7 +359,7 @@ export class ProjectTemplatesRepository {
              FROM project_template_steps pts
              JOIN project_templates pt ON pt.id = pts.template_id
              LEFT JOIN users u ON u.id = pts.assignee_id
-             WHERE pts.id = ? AND (pt.owner_id = ? OR pt.owner_id IS NULL)`,
+             WHERE pts.id = ? AND pt.owner_id = ?`,
           )
           .get(stepId, userId)
       : getDb()
@@ -409,7 +409,7 @@ export class ProjectTemplatesRepository {
                FROM project_template_steps pts
                JOIN project_templates pt ON pt.id = pts.template_id
                LEFT JOIN users u ON u.id = pts.assignee_id
-               WHERE pts.id = $1 AND (pt.owner_id = $2 OR pt.owner_id IS NULL)`,
+               WHERE pts.id = $1 AND pt.owner_id = $2`,
               [stepId, userId],
             )
           : await getPostgresPool().query<StepRow>(
@@ -453,7 +453,7 @@ export class ProjectTemplatesRepository {
           `SELECT pts.id
            FROM project_template_steps pts
            JOIN project_templates pt ON pt.id = pts.template_id
-           WHERE pts.id = ? AND (pt.owner_id = ? OR pt.owner_id IS NULL)`,
+           WHERE pts.id = ? AND pt.owner_id = ?`,
         )
         .get(stepId, userId) as { id: string } | undefined;
       if (!visible) throw AppError.notFound('ProjectTemplateStep');
@@ -469,7 +469,7 @@ export class ProjectTemplatesRepository {
           `SELECT pts.id
            FROM project_template_steps pts
            JOIN project_templates pt ON pt.id = pts.template_id
-           WHERE pts.id = $1 AND (pt.owner_id = $2 OR pt.owner_id IS NULL)`,
+           WHERE pts.id = $1 AND pt.owner_id = $2`,
           [stepId, userId],
         );
         if (visible.rows.length === 0) {

--- a/apps/api_server/src/repositories/recurring_task_rules_repository.ts
+++ b/apps/api_server/src/repositories/recurring_task_rules_repository.ts
@@ -119,7 +119,6 @@ export class RecurringTaskRulesRepository {
                  ON rc.rhythm_id = recurring_task_rules.id
                 AND rc.user_id = $1
                WHERE recurring_task_rules.owner_id = $1
-                  OR recurring_task_rules.owner_id IS NULL
                   OR rc.user_id IS NOT NULL
                ORDER BY recurring_task_rules.created_at ASC`,
               [userId],
@@ -142,7 +141,6 @@ export class RecurringTaskRulesRepository {
              ON rc.rhythm_id = recurring_task_rules.id
             AND rc.user_id = ?
            WHERE recurring_task_rules.owner_id = ?
-              OR recurring_task_rules.owner_id IS NULL
               OR rc.user_id IS NOT NULL
            ORDER BY recurring_task_rules.created_at ASC`,
         )
@@ -168,7 +166,6 @@ export class RecurringTaskRulesRepository {
                WHERE recurring_task_rules.id = $1
                  AND (
                    recurring_task_rules.owner_id = $2
-                   OR recurring_task_rules.owner_id IS NULL
                    OR rc.user_id IS NOT NULL
                  )`,
               [id, userId],
@@ -196,7 +193,6 @@ export class RecurringTaskRulesRepository {
              WHERE recurring_task_rules.id = ?
                AND (
                  recurring_task_rules.owner_id = ?
-                 OR recurring_task_rules.owner_id IS NULL
                  OR rc.user_id IS NOT NULL
                )`,
           )

--- a/apps/api_server/src/repositories/tasks_repository.ts
+++ b/apps/api_server/src/repositories/tasks_repository.ts
@@ -87,7 +87,7 @@ export class TasksRepository {
                  ON tasks.source_type = 'recurring_rule'
                 AND (tasks.source_id = rr.id OR tasks.source_id LIKE rr.id || ':%')
                LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = $2
-               WHERE tasks.owner_id = $3 OR tasks.owner_id IS NULL OR tc.user_id IS NOT NULL
+               WHERE tasks.owner_id = $3 OR tc.user_id IS NOT NULL
                ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
               [userId, userId, userId],
             )
@@ -120,7 +120,7 @@ export class TasksRepository {
              ON tasks.source_type = 'recurring_rule'
             AND (tasks.source_id = rr.id OR tasks.source_id LIKE rr.id || ':%')
            LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = ?
-           WHERE tasks.owner_id = ? OR tasks.owner_id IS NULL OR tc.user_id IS NOT NULL
+           WHERE tasks.owner_id = ? OR tc.user_id IS NOT NULL
            ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
         )
         .all(userId, userId, userId) as TaskRow[];
@@ -137,7 +137,9 @@ export class TasksRepository {
       const result =
         userId != null
           ? await getPostgresPool().query<TaskRow>(
-              `${TASK_SELECT} WHERE tasks.id = $1 AND (tasks.owner_id = $2 OR tasks.owner_id IS NULL)`,
+              `${TASK_SELECT}
+               LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = $2
+               WHERE tasks.id = $1 AND (tasks.owner_id = $2 OR tc.user_id IS NOT NULL)`,
               [id, userId],
             )
           : await getPostgresPool().query<TaskRow>(
@@ -156,9 +158,11 @@ export class TasksRepository {
     const row = (userId != null
       ? getDb()
           .prepare(
-            `${TASK_SELECT} WHERE tasks.id = ? AND (tasks.owner_id = ? OR tasks.owner_id IS NULL)`,
+            `${TASK_SELECT}
+             LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = ?
+             WHERE tasks.id = ? AND (tasks.owner_id = ? OR tc.user_id IS NOT NULL)`,
           )
-          .get(id, userId)
+          .get(userId, id, userId)
       : getDb().prepare(`${TASK_SELECT} WHERE tasks.id = ?`).get(id)) as
       | TaskRow
       | undefined;
@@ -224,7 +228,8 @@ export class TasksRepository {
         userId != null
           ? await getPostgresPool().query<TaskRow>(
               `${TASK_SELECT}
-               WHERE (tasks.owner_id = $1 OR tasks.owner_id IS NULL)
+               LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = $1
+               WHERE (tasks.owner_id = $1 OR tc.user_id IS NOT NULL)
                  AND (tasks.due_date BETWEEN $2 AND $3 OR tasks.scheduled_date BETWEEN $4 AND $5)
                ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
               [userId, weekStart, weekEnd, weekStart, weekEnd],
@@ -246,11 +251,12 @@ export class TasksRepository {
       const rows = getDb()
           .prepare(
             `${TASK_SELECT}
-          WHERE (tasks.owner_id = ? OR tasks.owner_id IS NULL)
+          LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = ?
+          WHERE (tasks.owner_id = ? OR tc.user_id IS NOT NULL)
              AND (tasks.due_date BETWEEN ? AND ? OR tasks.scheduled_date BETWEEN ? AND ?)
          ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
       )
-        .all(userId, weekStart, weekEnd, weekStart, weekEnd) as TaskRow[];
+        .all(userId, userId, weekStart, weekEnd, weekStart, weekEnd) as TaskRow[];
       return rows.map(rowToTask);
     }
     const rows = getDb()
@@ -275,7 +281,13 @@ export class TasksRepository {
                    OR (tasks.scheduled_date IS NULL AND tasks.due_date < $1)
                    OR tasks.scheduled_date < $2
                  )
-                 AND (tasks.owner_id = $3 OR tasks.owner_id IS NULL)
+                 AND (
+                   tasks.owner_id = $3
+                   OR EXISTS (
+                     SELECT 1 FROM task_collaborators tc
+                     WHERE tc.task_id = tasks.id AND tc.user_id = $3
+                   )
+                 )
                ORDER BY
                  CASE
                    WHEN tasks.scheduled_date IS NOT NULL THEN tasks.scheduled_date
@@ -315,7 +327,13 @@ export class TasksRepository {
                    OR (tasks.scheduled_date IS NULL AND tasks.due_date < ?)
                    OR tasks.scheduled_date < ?
                  )
-                 AND (tasks.owner_id = ? OR tasks.owner_id IS NULL)
+                 AND (
+                   tasks.owner_id = ?
+                   OR EXISTS (
+                     SELECT 1 FROM task_collaborators tc
+                     WHERE tc.task_id = tasks.id AND tc.user_id = ?
+                   )
+                 )
                ORDER BY
                  CASE
                    WHEN tasks.scheduled_date IS NOT NULL THEN tasks.scheduled_date
@@ -323,7 +341,7 @@ export class TasksRepository {
                  END ASC,
                  tasks.created_at ASC`,
             )
-            .all(startOfWeek, startOfWeek, userId) as TaskRow[])
+            .all(startOfWeek, startOfWeek, userId, userId) as TaskRow[])
         : (db
             .prepare(
               `${TASK_SELECT}


### PR DESCRIPTION
…ators

Tasks, automation rules, project templates, project instances, and recurring rules now filter by owner_id when a userId is present. Removed the legacy owner_id IS NULL fallback that exposed unowned rows to all authenticated users. Collaborator joins preserved for tasks and rhythms. Delete and collaborator mutation locked to task owner only.

## Summary
- 

## Why this change
- 

## Scope boundaries
- 

## Acceptance criteria checklist
- [ ] Requirements implemented
- [ ] Architecture boundaries preserved (thin controllers, service logic)
- [ ] Docs updated where contracts/behavior changed
- [ ] Tests updated/added where behavior changed

## Testing
- 
