### PR TITLE
Fix desktop OAuth flow dropping user avatar

### DIFF
--- a/apps/api_server/src/controllers/auth_controller.ts
+++ b/apps/api_server/src/controllers/auth_controller.ts
@@ -151,6 +151,7 @@ export class AuthController {
         googleSub: profile.sub,
         email: profile.email,
         name: profile.name ?? profile.email,
+        photoUrl: profile.picture ?? null,
       });
 
       await googleOAuth.storeDesktopIntegration(session.user.id, tokens, profile);

--- a/apps/api_server/src/repositories/users_repository.ts
+++ b/apps/api_server/src/repositories/users_repository.ts
@@ -223,7 +223,7 @@ export class UsersRepository {
         name: data.name,
         email: data.email,
         googleSub: data.googleSub,
-        photoUrl: data.photoUrl ?? null,
+        photoUrl: data.photoUrl ?? existingBySub.photoUrl,
       });
     }
 
@@ -233,7 +233,7 @@ export class UsersRepository {
         name: data.name,
         email: data.email,
         googleSub: data.googleSub,
-        photoUrl: data.photoUrl ?? null,
+        photoUrl: data.photoUrl ?? existingByEmail.photoUrl,
       });
     }
 

--- a/apps/api_server/src/services/google_oauth_service.ts
+++ b/apps/api_server/src/services/google_oauth_service.ts
@@ -29,6 +29,7 @@ interface GoogleUserInfo {
   sub: string;
   email?: string;
   name?: string;
+  picture?: string;
 }
 
 export class GoogleOAuthService {


### PR DESCRIPTION
## Summary
- Adds picture to GoogleUserInfo in google_oauth_service.ts so it is captured from Google's userinfo endpoint
- Passes photoUrl: profile.picture ?? null in auth_controller.ts googleDesktopExchange so the avatar reaches loginWithGoogleProfile
- Preserves existing photo_url in users_repository.ts upsertGoogleUserAsync when Google returns no picture, instead of overwriting with null

## Root cause
The /auth/google/desktop-exchange path fetched Google userinfo but never mapped picture through to Rhythm's user record. Every desktop login nulled out the avatar.

## Test plan
- [ ] Log in via desktop Google OAuth with a Google account that has a profile photo
- [ ] Confirm session.user.photoUrl is populated in the response
- [ ] Log in again to confirm existing photo is not wiped when Google omits the field

Generated with Claude Code