### PR TITLE
[codex] Preserve Google avatar on login

### DIFF
--- a/apps/api_server/src/__tests__/auth_and_messaging.test.ts
+++ b/apps/api_server/src/__tests__/auth_and_messaging.test.ts
@@ -63,6 +63,29 @@ describe('Auth and ownership flows', () => {
     ).toBe(session.user.id);
   });
 
+  it('keeps an existing Google avatar when a later login omits picture', async () => {
+    const authService = new AuthService(
+      usersRepo,
+      sessionsRepo,
+      {
+        verifyIdToken: async (token: string): Promise<GoogleIdentity> => ({
+          sub: 'google-sub-avatar',
+          email: 'alice@example.com',
+          name: 'Alice',
+          picture:
+            token === 'with-picture'
+              ? 'https://example.com/alice.png'
+              : null,
+        }),
+      } as never,
+    );
+
+    await authService.loginWithGoogleIdToken('with-picture');
+    const session = await authService.loginWithGoogleIdToken('without-picture');
+
+    expect(session.user.photoUrl).toBe('https://example.com/alice.png');
+  });
+
   it('filters tasks to the current owner only', () => {
     const alice = usersRepo.create({ name: 'Alice', email: 'alice@example.com' });
     const bob = usersRepo.create({ name: 'Bob', email: 'bob@example.com' });

--- a/apps/api_server/src/__tests__/google_desktop_exchange.test.ts
+++ b/apps/api_server/src/__tests__/google_desktop_exchange.test.ts
@@ -58,6 +58,7 @@ describe('Google desktop PKCE exchange', () => {
             sub: 'google-sub-xyz',
             email: 'user@example.com',
             name: 'Test User',
+            picture: 'https://example.com/user.png',
           }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         ),
@@ -72,6 +73,7 @@ describe('Google desktop PKCE exchange', () => {
 
     expect(result.tokens.access_token).toBe('access-123');
     expect(result.profile.email).toBe('user@example.com');
+    expect(result.profile.picture).toBe('https://example.com/user.png');
     const tokenCall = fetchMock.mock.calls[0];
     expect(tokenCall[0]).toBe('https://oauth2.googleapis.com/token');
     const body = (tokenCall[1].body as URLSearchParams).toString();
@@ -104,6 +106,7 @@ describe('Google desktop PKCE exchange', () => {
             sub: 'google-sub-1',
             email: 'alice@example.com',
             name: 'Alice',
+            picture: 'https://example.com/alice.png',
           }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         ),
@@ -120,6 +123,7 @@ describe('Google desktop PKCE exchange', () => {
       googleSub: profile.sub,
       email: profile.email!,
       name: profile.name!,
+      photoUrl: profile.picture ?? null,
     });
     await oauth.storeDesktopIntegration(session.user.id, tokens, profile);
 
@@ -132,6 +136,7 @@ describe('Google desktop PKCE exchange', () => {
     expect(cal?.accessToken).toBe('access-456');
     expect(gmail?.accessToken).toBe('access-456');
     expect(cal?.refreshToken).toBe('refresh-456');
+    expect(session.user.photoUrl).toBe('https://example.com/alice.png');
   });
 
   it('surfaces Google token errors as AppError', async () => {

--- a/apps/api_server/src/repositories/users_repository.ts
+++ b/apps/api_server/src/repositories/users_repository.ts
@@ -257,7 +257,7 @@ export class UsersRepository {
         name: data.name,
         email: data.email,
         googleSub: data.googleSub,
-        photoUrl: data.photoUrl ?? null,
+        photoUrl: data.photoUrl ?? existingBySub.photoUrl,
       });
     }
 
@@ -267,7 +267,7 @@ export class UsersRepository {
         name: data.name,
         email: data.email,
         googleSub: data.googleSub,
-        photoUrl: data.photoUrl ?? null,
+        photoUrl: data.photoUrl ?? existingByEmail.photoUrl,
       });
     }
 


### PR DESCRIPTION
## Summary

This fixes the Google avatar regression by keeping an existing Rhythm `photo_url` when a later Google login response does not include a picture. That prevents desktop OAuth or tokeninfo responses without `picture` from clearing an avatar that was already populated.

## Root Cause

The desktop OAuth path now passes Google `picture` through to auth, but the synchronous SQLite Google user upsert still treated a missing photo as an explicit null and overwrote existing avatars. That made avatar persistence brittle whenever Google omitted the picture field.

## Changes

- Preserve existing `photo_url` for Google user upserts when the incoming profile has no `photoUrl`.
- Add desktop OAuth coverage to assert `picture` is retained and passed to `AuthService` as `photoUrl`.
- Add auth coverage for repeated Google logins where the second response omits `picture`.

## Validation

- `npm test -- --run src/__tests__/google_desktop_exchange.test.ts src/__tests__/auth_and_messaging.test.ts`
- `npm test`
- `npm run build`