### PR TITLE
chore: add release checks and PR scope guardrails

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,13 +5,16 @@
 - 
 
 ## Scope boundaries
-- 
+- Intended area (`backend`, `desktop`, `release`, `docs`, or intentional multi-area):
+- Explicitly out of scope:
+- Ran `tools/git/check_pr_scope.sh --expect-area <area>` locally, or explain why this PR is intentionally cross-area:
 
 ## Acceptance criteria checklist
 - [ ] Requirements implemented
 - [ ] Architecture boundaries preserved (thin controllers, service logic)
 - [ ] Docs updated where contracts/behavior changed
 - [ ] Tests updated/added where behavior changed
+- [ ] PR diff reviewed for unrelated files
 
 ## Testing
 - 

--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -150,6 +150,11 @@ jobs:
           echo "=== codesign -dvvv ==="
           codesign -dvvv "$APP" 2>&1 | head -40 || true
 
+      - name: Verify signed desktop OAuth build
+        run: |
+          tools/release/verify_desktop_oauth_build.sh --signed \
+            apps/desktop_flutter/build/macos/Build/Products/Release/Rhythm.app
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/docs/engineering/pull-request-hygiene.md
+++ b/docs/engineering/pull-request-hygiene.md
@@ -1,0 +1,30 @@
+# Pull Request Hygiene
+
+Use this check before opening a PR when the branch is supposed to stay in one lane.
+
+## Scope Check
+
+Run:
+
+```bash
+tools/git/check_pr_scope.sh --expect-area backend
+```
+
+Replace `backend` with one of:
+
+- `backend`
+- `desktop`
+- `release`
+- `docs`
+
+The command compares `HEAD` against the merge-base with `origin/main` when available, or `main` otherwise. It prints changed files by area and fails when the branch includes files outside the expected area.
+
+## Intentional Multi-Area PRs
+
+If a PR truly needs to cross areas, state that explicitly in the PR body and use:
+
+```bash
+tools/git/check_pr_scope.sh --allow-multi-area
+```
+
+That keeps broad changes intentional instead of accidental branch spillover.

--- a/docs/release/macos_distribution.md
+++ b/docs/release/macos_distribution.md
@@ -71,9 +71,25 @@ base64 -i DeveloperIDApplication.p12 | pbcopy
 5. Wait for the workflow to:
    - run analyze and tests
    - build the macOS app
+   - verify the unsigned app still uses the desktop PKCE flow and does not contain stale native Google/AppAuth markers
    - package `.zip` and `.dmg`
    - sign/notarize if Apple secrets are configured
+   - dump the final signed entitlements and re-verify the signed app carries the expected runtime and entitlement shape
    - publish a GitHub release
+
+## Release Diagnostics
+
+The workflow now runs [`tools/release/verify_desktop_oauth_build.sh`](/Users/ajhochhalter/Documents/Rhythm/tools/release/verify_desktop_oauth_build.sh) twice:
+
+- before signing, to catch accidental regressions in the desktop OAuth build output
+- after signing, to confirm the final `.app` still has the expected network entitlements and does not pick up stale keychain or Google Sign-In entitlements
+
+You can run the same check locally against a built app bundle:
+
+```bash
+tools/release/verify_desktop_oauth_build.sh apps/desktop_flutter/build/macos/Build/Products/Release/Rhythm.app
+tools/release/verify_desktop_oauth_build.sh --signed apps/desktop_flutter/build/macos/Build/Products/Release/Rhythm.app
+```
 
 ## Facilities V1 Beta Notes
 

--- a/tools/git/check_pr_scope.sh
+++ b/tools/git/check_pr_scope.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+BASE_REF="${BASE_REF:-}"
+EXPECT_AREA=""
+ALLOW_MULTI_AREA=0
+
+usage() {
+  cat <<'EOF'
+Usage: tools/git/check_pr_scope.sh [--base <ref>] [--expect-area <area>] [--allow-multi-area]
+
+Areas:
+  backend   apps/api_server plus backend-focused docs/tests
+  desktop   apps/desktop_flutter plus desktop-focused docs/tests
+  release   .github/workflows, tools/release, macOS packaging/signing files, release docs
+  docs      docs-only changes
+
+The command prints the changed files relative to the merge-base with the base ref.
+When --expect-area is provided, it fails if files outside that area are present.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      BASE_REF="${2:-}"
+      shift 2
+      ;;
+    --expect-area)
+      EXPECT_AREA="${2:-}"
+      shift 2
+      ;;
+    --allow-multi-area)
+      ALLOW_MULTI_AREA=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+resolve_default_base() {
+  if [[ -n "${BASE_REF}" ]]; then
+    printf '%s\n' "${BASE_REF}"
+    return
+  fi
+
+  if git show-ref --verify --quiet refs/remotes/origin/main; then
+    printf '%s\n' "origin/main"
+    return
+  fi
+
+  if git show-ref --verify --quiet refs/heads/main; then
+    printf '%s\n' "main"
+    return
+  fi
+
+  echo "Unable to find a default base ref. Pass --base <ref>." >&2
+  exit 1
+}
+
+matches_area() {
+  local area="$1"
+  local path="$2"
+
+  case "${area}" in
+    backend)
+      [[ "${path}" == apps/api_server/* ]] && return 0
+      [[ "${path}" == docs/engineering/api-contracts.md ]] && return 0
+      [[ "${path}" == docs/engineering/mvc-guidelines.md ]] && return 0
+      [[ "${path}" == docs/engineering/data-model.md ]] && return 0
+      [[ "${path}" == docs/engineering/architecture.md ]] && return 0
+      [[ "${path}" == docs/release/hosted_deployment_synology_cloudflare.md ]] && return 0
+      ;;
+    desktop)
+      [[ "${path}" == apps/desktop_flutter/* ]] && return 0
+      [[ "${path}" == docs/release/macos_distribution.md ]] && return 0
+      [[ "${path}" == docs/plans/google-oauth-* ]] && return 0
+      [[ "${path}" == docs/product/facilities-v1.md ]] && return 0
+      ;;
+    release)
+      [[ "${path}" == .github/workflows/* ]] && return 0
+      [[ "${path}" == tools/release/* ]] && return 0
+      [[ "${path}" == apps/desktop_flutter/macos/* ]] && return 0
+      [[ "${path}" == docs/release/* ]] && return 0
+      [[ "${path}" == docs/plans/google-oauth-* ]] && return 0
+      ;;
+    docs)
+      [[ "${path}" == docs/* ]] && return 0
+      ;;
+    *)
+      echo "Unknown area '${area}'. Expected backend, desktop, release, or docs." >&2
+      exit 1
+      ;;
+  esac
+
+  [[ "${path}" == .github/PULL_REQUEST_TEMPLATE.md ]] && return 0
+  [[ "${path}" == tools/git/check_pr_scope.sh ]] && return 0
+
+  return 1
+}
+
+classify_path() {
+  local path="$1"
+  case "${path}" in
+    apps/api_server/*) printf 'backend\n' ;;
+    apps/desktop_flutter/*) printf 'desktop\n' ;;
+    .github/workflows/*|tools/release/*) printf 'release\n' ;;
+    docs/*) printf 'docs\n' ;;
+    tools/*) printf 'tools\n' ;;
+    .github/*) printf 'github\n' ;;
+    *) printf 'other\n' ;;
+  esac
+}
+
+BASE_REF="$(resolve_default_base)"
+MERGE_BASE="$(git merge-base HEAD "${BASE_REF}")"
+CHANGED_FILES=()
+while IFS= read -r path; do
+  CHANGED_FILES+=("${path}")
+done < <(git diff --name-only "${MERGE_BASE}"...HEAD)
+
+if [[ "${#CHANGED_FILES[@]}" -eq 0 ]]; then
+  echo "No changes detected relative to ${BASE_REF}."
+  exit 0
+fi
+
+backend_count=0
+desktop_count=0
+release_count=0
+docs_count=0
+tools_count=0
+github_count=0
+other_count=0
+
+for path in "${CHANGED_FILES[@]}"; do
+  area="$(classify_path "${path}")"
+  case "${area}" in
+    backend) backend_count=$((backend_count + 1)) ;;
+    desktop) desktop_count=$((desktop_count + 1)) ;;
+    release) release_count=$((release_count + 1)) ;;
+    docs) docs_count=$((docs_count + 1)) ;;
+    tools) tools_count=$((tools_count + 1)) ;;
+    github) github_count=$((github_count + 1)) ;;
+    other) other_count=$((other_count + 1)) ;;
+  esac
+done
+
+echo "PR scope check against ${BASE_REF}"
+echo "Merge base: ${MERGE_BASE}"
+echo "Changed files: ${#CHANGED_FILES[@]}"
+echo
+[[ "${backend_count}" -gt 0 ]] && echo "  backend: ${backend_count}"
+[[ "${desktop_count}" -gt 0 ]] && echo "  desktop: ${desktop_count}"
+[[ "${release_count}" -gt 0 ]] && echo "  release: ${release_count}"
+[[ "${docs_count}" -gt 0 ]] && echo "  docs: ${docs_count}"
+[[ "${tools_count}" -gt 0 ]] && echo "  tools: ${tools_count}"
+[[ "${github_count}" -gt 0 ]] && echo "  github: ${github_count}"
+[[ "${other_count}" -gt 0 ]] && echo "  other: ${other_count}"
+
+echo
+printf '%s\n' "${CHANGED_FILES[@]}"
+
+if [[ -n "${EXPECT_AREA}" ]]; then
+  violations=()
+  for path in "${CHANGED_FILES[@]}"; do
+    if ! matches_area "${EXPECT_AREA}" "${path}"; then
+      violations+=("${path}")
+    fi
+  done
+
+  if [[ "${#violations[@]}" -gt 0 ]]; then
+    echo
+    echo "Scope check failed for expected area '${EXPECT_AREA}'." >&2
+    printf '%s\n' "${violations[@]}" >&2
+    exit 1
+  fi
+fi
+
+active_areas=0
+[[ "${backend_count}" -gt 0 ]] && active_areas=$((active_areas + 1))
+[[ "${desktop_count}" -gt 0 ]] && active_areas=$((active_areas + 1))
+[[ "${release_count}" -gt 0 ]] && active_areas=$((active_areas + 1))
+[[ "${docs_count}" -gt 0 ]] && active_areas=$((active_areas + 1))
+[[ "${tools_count}" -gt 0 ]] && active_areas=$((active_areas + 1))
+[[ "${github_count}" -gt 0 ]] && active_areas=$((active_areas + 1))
+[[ "${other_count}" -gt 0 ]] && active_areas=$((active_areas + 1))
+
+if [[ "${active_areas}" -gt 3 && "${ALLOW_MULTI_AREA}" -ne 1 ]]; then
+  echo
+  echo "Scope check warning: this branch spans ${active_areas} areas." >&2
+  echo "Re-run with --allow-multi-area if the breadth is intentional." >&2
+  exit 1
+fi
+
+echo
+echo "PR scope check passed."

--- a/tools/release/verify_desktop_oauth_build.sh
+++ b/tools/release/verify_desktop_oauth_build.sh
@@ -1,7 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_PATH="${1:-apps/desktop_flutter/build/macos/Build/Products/Release/Rhythm.app}"
+MODE="unsigned"
+APP_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --signed)
+      MODE="signed"
+      shift
+      ;;
+    --unsigned)
+      MODE="unsigned"
+      shift
+      ;;
+    *)
+      APP_PATH="$1"
+      shift
+      ;;
+  esac
+done
+
+APP_PATH="${APP_PATH:-apps/desktop_flutter/build/macos/Build/Products/Release/Rhythm.app}"
 
 if [[ ! -d "${APP_PATH}" ]]; then
   echo "Missing macOS app bundle: ${APP_PATH}" >&2
@@ -10,14 +30,21 @@ fi
 
 APP_BINARY="${APP_PATH}/Contents/Frameworks/App.framework/Versions/A/App"
 INFO_PLIST="${APP_PATH}/Contents/Info.plist"
+RUNNER_BINARY="${APP_PATH}/Contents/MacOS/Rhythm"
 
 if [[ ! -f "${APP_BINARY}" ]]; then
   echo "Missing Flutter App.framework binary: ${APP_BINARY}" >&2
   exit 1
 fi
 
+if [[ ! -f "${RUNNER_BINARY}" ]]; then
+  echo "Missing macOS runner binary: ${RUNNER_BINARY}" >&2
+  exit 1
+fi
+
 APP_STRINGS="$(mktemp -t rhythm-desktop-oauth-strings)"
-trap 'rm -f "${APP_STRINGS}"' EXIT
+ENTITLEMENTS_XML="$(mktemp -t rhythm-desktop-entitlements)"
+trap 'rm -f "${APP_STRINGS}" "${ENTITLEMENTS_XML}"' EXIT
 
 strings "${APP_BINARY}" > "${APP_STRINGS}"
 
@@ -52,6 +79,57 @@ reject_string "client_secret"
 if plutil -p "${INFO_PLIST}" | grep -Eq "GIDClient|GIDSignIn|GoogleSignIn|org.openid.appauth"; then
   echo "Desktop OAuth verification failed: Info.plist still contains native Google/AppAuth configuration." >&2
   exit 1
+fi
+
+print_diagnostics() {
+  local bundle_id
+  bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "${INFO_PLIST}" 2>/dev/null || echo '<missing>')"
+  echo "Desktop OAuth verification mode: ${MODE}"
+  echo "Bundle identifier: ${bundle_id}"
+  echo "Runner binary: ${RUNNER_BINARY}"
+  echo "Embedded Flutter binary: ${APP_BINARY}"
+}
+
+require_codesign_detail() {
+  local needle="$1"
+  if ! codesign -dvvv "${APP_PATH}" 2>&1 | grep -Fq "${needle}"; then
+    echo "Desktop OAuth verification failed: expected codesign detail '${needle}'." >&2
+    exit 1
+  fi
+}
+
+require_entitlement_key() {
+  local needle="$1"
+  if ! grep -Fq "<key>${needle}</key>" "${ENTITLEMENTS_XML}"; then
+    echo "Desktop OAuth verification failed: missing entitlement '${needle}'." >&2
+    exit 1
+  fi
+}
+
+reject_entitlement_key() {
+  local needle="$1"
+  if grep -Fq "<key>${needle}</key>" "${ENTITLEMENTS_XML}"; then
+    echo "Desktop OAuth verification failed: unexpected entitlement '${needle}' present." >&2
+    exit 1
+  fi
+}
+
+print_diagnostics
+
+if [[ "${MODE}" == "signed" ]]; then
+  if ! codesign --display --entitlements - --xml "${APP_PATH}" > "${ENTITLEMENTS_XML}" 2>/dev/null; then
+    echo "Desktop OAuth verification failed: could not read signed entitlements." >&2
+    exit 1
+  fi
+
+  require_codesign_detail "Authority="
+  require_codesign_detail "TeamIdentifier="
+  require_codesign_detail "Runtime Version="
+
+  require_entitlement_key "com.apple.security.network.client"
+  require_entitlement_key "com.apple.security.network.server"
+  reject_entitlement_key "keychain-access-groups"
+  reject_entitlement_key "com.apple.security.keychain-access-groups"
 fi
 
 echo "Desktop OAuth build verification passed."


### PR DESCRIPTION
## Summary
- strengthen desktop release verification by checking both unsigned and signed macOS app bundles
- add a lightweight PR scope checker plus documentation for using it before opening focused PRs
- update the PR template to call out intended scope, out-of-scope items, and local diff review

## Why this change
This is intentionally separate from the broader `ui-overhaul` work. The goal is to land the workflow/tooling guardrails on their own so future branches and fresh checkouts inherit them.

## Scope boundaries
- Intended area: intentional multi-area workflow/tooling/docs change
- Explicitly out of scope: the larger UI overhaul and unrelated product behavior changes
- Ran `tools/git/check_pr_scope.sh --allow-multi-area` locally because this PR spans workflow, docs, tooling, and PR-template updates by design

## Acceptance criteria checklist
- [x] Requirements implemented
- [x] Architecture boundaries preserved (thin controllers, service logic)
- [x] Docs updated where contracts/behavior changed
- [x] Tests updated/added where behavior changed
- [x] PR diff reviewed for unrelated files

## Testing
- `bash -n tools/git/check_pr_scope.sh`
- `bash -n tools/release/verify_desktop_oauth_build.sh`
- `tools/git/check_pr_scope.sh --allow-multi-area`
- `tools/release/verify_desktop_oauth_build.sh /Users/ajhochhalter/Documents/Rhythm/apps/desktop_flutter/build/macos/Build/Products/Release/Rhythm.app`
