### PR TITLE
Harden owner-scoped data access

### DIFF
--- a/apps/api_server/src/__tests__/recurrence_service.test.ts
+++ b/apps/api_server/src/__tests__/recurrence_service.test.ts
@@ -6,6 +6,7 @@ import { UsersRepository } from '../repositories/users_repository';
 import { RecurringTaskRulesRepository } from '../repositories/recurring_task_rules_repository';
 import { TasksRepository } from '../repositories/tasks_repository';
 import { RecurrenceService } from '../services/recurrence_service';
+import { runRecurrenceGenerationOnce } from '../jobs/recurrence_generation_job';
 
 function makeDb() {
   const db = new Database(':memory:');
@@ -78,7 +79,9 @@ describe('Recurring rules and recurrence generation', () => {
     await service.generateInstances(stepRule, from, to);
     await service.generateInstances(legacyRule, from, to);
 
-    const generated = tasksRepo.findAll().filter((task) => task.sourceType === 'recurring_rule');
+    const generated = tasksRepo
+      .findAllIncludingLegacy()
+      .filter((task) => task.sourceType === 'recurring_rule');
     expect(generated).toHaveLength(3);
     expect(generated.map((task) => task.title).sort()).toEqual([
       'Lead',
@@ -100,5 +103,83 @@ describe('Recurring rules and recurrence generation', () => {
     expect(
       generated.find((task) => task.title === 'Lead')?.ownerId,
     ).toBe(assigneeId);
+  });
+
+  it('does not generate tasks from null-owned legacy recurring rules', async () => {
+    const legacyRule = rulesRepo.create({
+      title: 'Legacy null-owned rhythm',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      ownerId: null,
+      steps: [
+        { id: 'assigned', title: 'Assigned legacy step', assigneeId },
+      ],
+    });
+
+    const from = new Date('2026-03-23T00:00:00.000Z');
+    const to = new Date('2026-03-23T23:59:59.999Z');
+
+    const created = await service.generateInstances(legacyRule, from, to);
+
+    expect(created).toHaveLength(0);
+    expect(tasksRepo.findAllIncludingLegacy()).toHaveLength(0);
+  });
+
+  it('only returns enabled owned rules for background generation', async () => {
+    const ownedRule = rulesRepo.create({
+      title: 'Owned rhythm',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      ownerId,
+    });
+    rulesRepo.create({
+      title: 'Legacy null-owned rhythm',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      ownerId: null,
+    });
+    rulesRepo.create({
+      title: 'Disabled owned rhythm',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      ownerId,
+      enabled: false,
+    });
+
+    expect(
+      rulesRepo.findEnabledForGeneration().map((rule) => rule.id),
+    ).toEqual([ownedRule.id]);
+    expect(rulesRepo.findAllIncludingLegacy()).toHaveLength(3);
+  });
+
+  it('background recurrence generation skips null-owned legacy rules and generates owned rules', async () => {
+    const ownedRule = rulesRepo.create({
+      title: 'Owned rhythm',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      ownerId,
+    });
+    rulesRepo.create({
+      title: 'Legacy null-owned rhythm',
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      ownerId: null,
+      steps: [
+        { id: 'assigned', title: 'Assigned legacy step', assigneeId },
+      ],
+    });
+
+    const result = await runRecurrenceGenerationOnce(
+      new Date('2026-03-23T00:00:00.000Z'),
+      new Date('2026-03-23T23:59:59.999Z'),
+    );
+
+    const generated = tasksRepo
+      .findAllIncludingLegacy()
+      .filter((task) => task.sourceType === 'recurring_rule');
+    expect(result).toEqual({ ruleCount: 1, createdCount: 1 });
+    expect(generated).toHaveLength(1);
+    expect(generated[0].sourceId).toBe(ownedRule.id);
+    expect(generated[0].ownerId).toBe(ownerId);
   });
 });

--- a/apps/api_server/src/__tests__/weekly_planning_service.test.ts
+++ b/apps/api_server/src/__tests__/weekly_planning_service.test.ts
@@ -10,6 +10,8 @@ import {
 import { TasksRepository } from '../repositories/tasks_repository';
 import { CalendarShadowEventsRepository } from '../repositories/calendar_shadow_events_repository';
 import { UsersRepository } from '../repositories/users_repository';
+import { ProjectTemplatesRepository } from '../repositories/project_templates_repository';
+import { ProjectGenerationService } from '../services/project_generation_service';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -63,6 +65,7 @@ describe('WeeklyPlanningService.assemblePlan', () => {
   let service: WeeklyPlanningService;
   let usersRepo: UsersRepository;
   let ownerId: number;
+  let otherUserId: number;
 
   const WEEK = '2026-W13'; // Mon 2026-03-23 → Sun 2026-03-29
 
@@ -74,10 +77,11 @@ describe('WeeklyPlanningService.assemblePlan', () => {
     service = new WeeklyPlanningService();
     usersRepo = new UsersRepository();
     ownerId = usersRepo.create({ name: 'Alice', email: 'alice@example.com' }).id;
+    otherUserId = usersRepo.create({ name: 'Bob', email: 'bob@example.com' }).id;
   });
 
   it('returns the correct week label and 7 days', async () => {
-    const plan = await service.assemblePlan(WEEK);
+    const plan = await service.assemblePlan(WEEK, ownerId);
     expect(plan.weekLabel).toBe(WEEK);
     expect(plan.weekStart).toBe('2026-03-23');
     expect(plan.days).toHaveLength(7);
@@ -86,16 +90,50 @@ describe('WeeklyPlanningService.assemblePlan', () => {
   });
 
   it('places a task with due_date into the correct day', async () => {
-    tasksRepo.create({ title: 'Mon task', dueDate: '2026-03-23' });
-    const plan = await service.assemblePlan(WEEK);
+    tasksRepo.create({ title: 'Mon task', dueDate: '2026-03-23', ownerId });
+    const plan = await service.assemblePlan(WEEK, ownerId);
     const monday = plan.days.find((d) => d.date === '2026-03-23')!;
     expect(monday.tasks).toHaveLength(1);
     expect(monday.tasks[0].title).toBe('Mon task');
   });
 
+  it('does not expose another user project steps in the weekly plan', async () => {
+    const templatesRepo = new ProjectTemplatesRepository();
+    const generationService = new ProjectGenerationService();
+    const template = templatesRepo.create({
+      name: 'Owner project',
+      anchorType: 'date',
+      ownerId,
+    });
+    templatesRepo.addStep(
+      template.id,
+      {
+        title: 'Owner-only project step',
+        offsetDays: 0,
+        sortOrder: 0,
+      },
+      ownerId,
+    );
+    generationService.generate(template.id, '2026-03-23', 'Private launch', ownerId);
+
+    const ownerPlan = await service.assemblePlan(WEEK, ownerId);
+    const otherPlan = await service.assemblePlan(WEEK, otherUserId);
+
+    expect(
+      ownerPlan.days
+        .flatMap((day) => day.tasks)
+        .some((task) => task.title === 'Owner-only project step'),
+    ).toBe(true);
+    expect(
+      otherPlan.days
+        .flatMap((day) => day.tasks)
+        .some((task) => task.title === 'Owner-only project step'),
+    ).toBe(false);
+  });
+
   it('places a task with scheduled_date (overriding due_date) into the correct day', async () => {
-    tasksRepo.create({ title: 'Scheduled task', dueDate: '2026-03-24', scheduledDate: '2026-03-25' });
-    const plan = await service.assemblePlan(WEEK);
+    tasksRepo.create({ title: 'Scheduled task', dueDate: '2026-03-24', scheduledDate: '2026-03-25', ownerId });
+    const plan = await service.assemblePlan(WEEK, ownerId);
     const tue = plan.days.find((d) => d.date === '2026-03-24')!;
     const wed = plan.days.find((d) => d.date === '2026-03-25')!;
     expect(tue.tasks).toHaveLength(0);
@@ -104,16 +142,16 @@ describe('WeeklyPlanningService.assemblePlan', () => {
   });
 
   it('excludes tasks outside the week window', async () => {
-    tasksRepo.create({ title: 'Next week task', dueDate: '2026-03-30' });
-    tasksRepo.create({ title: 'Last week task', dueDate: '2026-03-22' });
-    const plan = await service.assemblePlan(WEEK);
+    tasksRepo.create({ title: 'Next week task', dueDate: '2026-03-30', ownerId });
+    tasksRepo.create({ title: 'Last week task', dueDate: '2026-03-22', ownerId });
+    const plan = await service.assemblePlan(WEEK, ownerId);
     const allDayTasks = plan.days.flatMap((d) => d.tasks);
     expect(allDayTasks).toHaveLength(0);
   });
 
   it('puts tasks with no date into the backlog', async () => {
-    tasksRepo.create({ title: 'Backlog task' });
-    const plan = await service.assemblePlan(WEEK);
+    tasksRepo.create({ title: 'Backlog task', ownerId });
+    const plan = await service.assemblePlan(WEEK, ownerId);
     expect(plan.backlog.some((t) => t.title === 'Backlog task')).toBe(true);
     const allDayTasks = plan.days.flatMap((d) => d.tasks);
     expect(allDayTasks).toHaveLength(0);
@@ -124,9 +162,10 @@ describe('WeeklyPlanningService.assemblePlan', () => {
       title: 'Overdue but scheduled',
       dueDate: '2026-03-20',
       scheduledDate: '2026-03-25',
+      ownerId,
     });
 
-    const plan = await service.assemblePlan(WEEK);
+    const plan = await service.assemblePlan(WEEK, ownerId);
     const wed = plan.days.find((d) => d.date === '2026-03-25')!;
 
     expect(wed.tasks.map((task) => task.title)).toContain(
@@ -138,9 +177,9 @@ describe('WeeklyPlanningService.assemblePlan', () => {
   });
 
   it('excludes done tasks from backlog', async () => {
-    const task = tasksRepo.create({ title: 'Done backlog task' });
-    tasksRepo.update(task.id, { status: 'done' });
-    const plan = await service.assemblePlan(WEEK);
+    const task = tasksRepo.create({ title: 'Done backlog task', ownerId });
+    tasksRepo.update(task.id, { status: 'done' }, ownerId);
+    const plan = await service.assemblePlan(WEEK, ownerId);
     expect(plan.backlog.some((t) => t.title === 'Done backlog task')).toBe(false);
   });
 
@@ -168,10 +207,10 @@ describe('WeeklyPlanningService.assemblePlan', () => {
   });
 
   it('handles multiple tasks across different days', async () => {
-    tasksRepo.create({ title: 'Mon', dueDate: '2026-03-23' });
-    tasksRepo.create({ title: 'Wed', dueDate: '2026-03-25' });
-    tasksRepo.create({ title: 'Fri', dueDate: '2026-03-27' });
-    const plan = await service.assemblePlan(WEEK);
+    tasksRepo.create({ title: 'Mon', dueDate: '2026-03-23', ownerId });
+    tasksRepo.create({ title: 'Wed', dueDate: '2026-03-25', ownerId });
+    tasksRepo.create({ title: 'Fri', dueDate: '2026-03-27', ownerId });
+    const plan = await service.assemblePlan(WEEK, ownerId);
     expect(plan.days.find((d) => d.date === '2026-03-23')!.tasks).toHaveLength(1);
     expect(plan.days.find((d) => d.date === '2026-03-25')!.tasks).toHaveLength(1);
     expect(plan.days.find((d) => d.date === '2026-03-27')!.tasks).toHaveLength(1);
@@ -179,7 +218,7 @@ describe('WeeklyPlanningService.assemblePlan', () => {
   });
 
   it('returns empty days and empty backlog for an empty DB', async () => {
-    const plan = await service.assemblePlan(WEEK);
+    const plan = await service.assemblePlan(WEEK, ownerId);
     expect(plan.days.every((d) => d.tasks.length === 0)).toBe(true);
     expect(plan.backlog).toHaveLength(0);
   });

--- a/apps/api_server/src/controllers/project_generation_controller.ts
+++ b/apps/api_server/src/controllers/project_generation_controller.ts
@@ -24,7 +24,7 @@ export class ProjectGenerationController {
         req.params.id,
         anchorDate,
         typeof name === 'string' ? name : null,
-        req.auth?.user.id,
+        req.auth!.user.id,
       );
       res.status(201).json(instance);
     } catch (err) {
@@ -39,11 +39,11 @@ export class ProjectGenerationController {
         res.json(
           await instanceRepo.findByTemplateIdAsync(
             templateId,
-            req.auth?.user.id,
+            req.auth!.user.id,
           ),
         );
       } else {
-        res.json(await instanceRepo.findAllAsync(req.auth?.user.id));
+        res.json(await instanceRepo.findAllAsync(req.auth!.user.id));
       }
     } catch (err) {
       next(err);
@@ -52,7 +52,7 @@ export class ProjectGenerationController {
 
   async updateInstanceStep(req: Request, res: Response, next: NextFunction) {
     try {
-      const actorId = req.auth?.user.id;
+      const actorId = req.auth!.user.id;
       const { stepId } = req.params;
       const { title, dueDate, status, notes, assigneeId } = req.body as Record<string, unknown>;
       const step = await instanceRepo.updateStepAsync(
@@ -78,7 +78,7 @@ export class ProjectGenerationController {
       );
 
       // Notify on step completion
-      if (status === 'done' && actorId != null) {
+      if (status === 'done') {
         const collaborators = await instanceRepo.listCollaboratorsAsync(req.params.id);
         const collaboratorIds = collaborators.map((c) => c.userId);
         const instance = await instanceRepo.findByIdAsync(req.params.id, actorId);
@@ -105,7 +105,7 @@ export class ProjectGenerationController {
 
   async deleteInstance(req: Request, res: Response, next: NextFunction) {
     try {
-      await instanceRepo.deleteAsync(req.params.id, req.auth?.user.id);
+      await instanceRepo.deleteAsync(req.params.id, req.auth!.user.id);
       res.status(204).send();
     } catch (err) {
       next(err);
@@ -114,6 +114,7 @@ export class ProjectGenerationController {
 
   async getCollaborators(req: Request, res: Response, next: NextFunction) {
     try {
+      await instanceRepo.findByIdAsync(req.params.id, req.auth!.user.id);
       res.json(await instanceRepo.listCollaboratorsAsync(req.params.id));
     } catch (err) {
       next(err);
@@ -126,18 +127,19 @@ export class ProjectGenerationController {
       if (!userId || typeof userId !== 'number') {
         throw AppError.badRequest('userId is required and must be a number');
       }
-      await instanceRepo.addCollaboratorAsync(req.params.id, userId);
-      const actorId = req.auth?.user.id;
-      if (actorId != null) {
-        const instance = await instanceRepo.findByIdAsync(req.params.id, actorId);
-        await notifService.notifyCollaboratorAddedAsync(
-          'project',
-          req.params.id,
-          instance.name ?? 'Project',
-          userId,
-          actorId,
-        );
+      const actorId = req.auth!.user.id;
+      const instance = await instanceRepo.findByIdAsync(req.params.id, actorId);
+      if (instance.ownerId !== actorId) {
+        throw AppError.forbidden('Only the project owner can add collaborators');
       }
+      await instanceRepo.addCollaboratorAsync(req.params.id, userId);
+      await notifService.notifyCollaboratorAddedAsync(
+        'project',
+        req.params.id,
+        instance.name ?? 'Project',
+        userId,
+        actorId,
+      );
       res.status(201).json(await instanceRepo.listCollaboratorsAsync(req.params.id));
     } catch (err) {
       next(err);
@@ -149,6 +151,11 @@ export class ProjectGenerationController {
       const collaboratorUserId = Number(req.params.userId);
       if (isNaN(collaboratorUserId)) {
         throw AppError.badRequest('Invalid userId');
+      }
+      const actorId = req.auth!.user.id;
+      const instance = await instanceRepo.findByIdAsync(req.params.id, actorId);
+      if (instance.ownerId !== actorId) {
+        throw AppError.forbidden('Only the project owner can remove collaborators');
       }
       await instanceRepo.removeCollaboratorAsync(req.params.id, collaboratorUserId);
       res.status(204).send();

--- a/apps/api_server/src/controllers/project_templates_controller.ts
+++ b/apps/api_server/src/controllers/project_templates_controller.ts
@@ -7,7 +7,7 @@ const repo = new ProjectTemplatesRepository();
 export class ProjectTemplatesController {
   async getAll(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(await repo.findAllAsync(req.auth?.user.id));
+      res.json(await repo.findAllAsync(req.auth!.user.id));
     } catch (err) {
       next(err);
     }
@@ -15,7 +15,7 @@ export class ProjectTemplatesController {
 
   async getById(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(await repo.findByIdAsync(req.params.id, req.auth?.user.id));
+      res.json(await repo.findByIdAsync(req.params.id, req.auth!.user.id));
     } catch (err) {
       next(err);
     }
@@ -31,7 +31,7 @@ export class ProjectTemplatesController {
         name,
         description: description as string ?? null,
         anchorType: anchorType as string,
-        ownerId: req.auth?.user.id ?? null,
+        ownerId: req.auth!.user.id,
       });
       res.status(201).json(template);
     } catch (err) {
@@ -50,7 +50,7 @@ export class ProjectTemplatesController {
             ? { description: (description as string | null) ?? null }
             : {}),
         },
-        req.auth?.user.id,
+        req.auth!.user.id,
       );
       res.json(template);
     } catch (err) {
@@ -60,7 +60,7 @@ export class ProjectTemplatesController {
 
   async remove(req: Request, res: Response, next: NextFunction) {
     try {
-      await repo.deleteAsync(req.params.id, req.auth?.user.id);
+      await repo.deleteAsync(req.params.id, req.auth!.user.id);
       res.status(204).send();
     } catch (err) {
       next(err);
@@ -86,7 +86,7 @@ export class ProjectTemplatesController {
                 ? assigneeId
                 : undefined,
         },
-        req.auth?.user.id,
+        req.auth!.user.id,
       );
       res.status(201).json(step);
     } catch (err) {
@@ -99,7 +99,7 @@ export class ProjectTemplatesController {
       const step = await repo.updateStepAsync(
         req.params.stepId,
         req.body as Record<string, unknown>,
-        req.auth?.user.id,
+        req.auth!.user.id,
       );
       res.json(step);
     } catch (err) {
@@ -109,7 +109,7 @@ export class ProjectTemplatesController {
 
   async removeStep(req: Request, res: Response, next: NextFunction) {
     try {
-      await repo.deleteStepAsync(req.params.stepId, req.auth?.user.id);
+      await repo.deleteStepAsync(req.params.stepId, req.auth!.user.id);
       res.status(204).send();
     } catch (err) {
       next(err);

--- a/apps/api_server/src/controllers/recurring_rules_controller.ts
+++ b/apps/api_server/src/controllers/recurring_rules_controller.ts
@@ -27,10 +27,11 @@ const VALID_FREQUENCIES = ['weekly', 'monthly', 'annual'] as const;
 export class RecurringRulesController {
   async getAll(req: Request, res: Response, next: NextFunction) {
     try {
+      const userId = req.auth!.user.id;
       res.json(
         await this.decorateRules(
-          await repo.findAllAsync(req.auth?.user.id),
-          req.auth?.user.id,
+          await repo.findAllAsync(userId),
+          userId,
         ),
       );
     } catch (err) {
@@ -40,10 +41,11 @@ export class RecurringRulesController {
 
   async getById(req: Request, res: Response, next: NextFunction) {
     try {
+      const userId = req.auth!.user.id;
       res.json(
         await this.decorateRule(
-          await repo.findByIdAsync(req.params.id, req.auth?.user.id),
-          req.auth?.user.id,
+          await repo.findByIdAsync(req.params.id, userId),
+          userId,
         ),
       );
     } catch (err) {
@@ -66,7 +68,7 @@ export class RecurringRulesController {
         dayOfWeek: dayOfWeek as number ?? null,
         dayOfMonth: dayOfMonth as number ?? null,
         month: month as number ?? null,
-        ownerId: req.auth?.user.id ?? null,
+        ownerId: req.auth!.user.id,
         steps: parseSteps(steps),
         sequential: sequential === true,
       });
@@ -79,7 +81,7 @@ export class RecurringRulesController {
       to.setUTCDate(to.getUTCDate() + weeks * 7);
       await recurrenceService.generateInstances(rule, from, to);
 
-      res.status(201).json(await this.decorateRule(rule, req.auth?.user.id));
+      res.status(201).json(await this.decorateRule(rule, req.auth!.user.id));
     } catch (err) {
       next(err);
     }
@@ -88,7 +90,8 @@ export class RecurringRulesController {
   async update(req: Request, res: Response, next: NextFunction) {
     try {
       const body = req.body as Record<string, unknown>;
-      const rule = await repo.updateAsync(req.params.id, body, req.auth?.user.id);
+      const userId = req.auth!.user.id;
+      const rule = await repo.updateAsync(req.params.id, body, userId);
       await tasksRepo.deleteFutureOpenBySourceIdAsync('recurring_rule', rule.id);
       if (rule.enabled) {
         const weeks = parseInt(process.env.RECURRENCE_LOOKAHEAD_WEEKS ?? '', 10);
@@ -98,7 +101,7 @@ export class RecurringRulesController {
         to.setUTCDate(to.getUTCDate() + lookahead * 7);
         await recurrenceService.generateInstances(rule, from, to);
       }
-      res.json(await this.decorateRule(rule, req.auth?.user.id));
+      res.json(await this.decorateRule(rule, userId));
     } catch (err) {
       next(err);
     }
@@ -106,7 +109,7 @@ export class RecurringRulesController {
 
   async remove(req: Request, res: Response, next: NextFunction) {
     try {
-      await repo.deleteAsync(req.params.id, req.auth?.user.id);
+      await repo.deleteAsync(req.params.id, req.auth!.user.id);
       res.status(204).send();
     } catch (err) {
       next(err);
@@ -115,6 +118,7 @@ export class RecurringRulesController {
 
   async getCollaborators(req: Request, res: Response, next: NextFunction) {
     try {
+      await repo.findByIdAsync(req.params.id, req.auth!.user.id);
       res.json(await repo.listCollaboratorsAsync(req.params.id));
     } catch (err) {
       next(err);
@@ -123,8 +127,8 @@ export class RecurringRulesController {
 
   async addCollaborator(req: Request, res: Response, next: NextFunction) {
     try {
-      const actorId = req.auth?.user.id;
-      const rule = await repo.findByIdAsync(req.params.id);
+      const actorId = req.auth!.user.id;
+      const rule = await repo.findByIdAsync(req.params.id, actorId);
       if (rule.ownerId !== actorId) throw AppError.forbidden('Only the rhythm owner can manage collaborators');
       const { userId } = req.body as Record<string, unknown>;
       if (!userId || typeof userId !== 'number') {
@@ -148,8 +152,9 @@ export class RecurringRulesController {
 
   async removeCollaborator(req: Request, res: Response, next: NextFunction) {
     try {
-      const rule = await repo.findByIdAsync(req.params.id);
-      if (rule.ownerId !== req.auth?.user.id) throw AppError.forbidden('Only the rhythm owner can manage collaborators');
+      const actorId = req.auth!.user.id;
+      const rule = await repo.findByIdAsync(req.params.id, actorId);
+      if (rule.ownerId !== actorId) throw AppError.forbidden('Only the rhythm owner can manage collaborators');
       const collaboratorUserId = Number(req.params.userId);
       if (isNaN(collaboratorUserId)) {
         throw AppError.badRequest('Invalid userId');
@@ -163,16 +168,16 @@ export class RecurringRulesController {
 
   private async decorateRules(
     rules: RecurringTaskRule[],
-    currentUserId?: number,
+    currentUserId: number,
   ) {
     return Promise.all(
       rules.map((rule) => this.decorateRule(rule, currentUserId)),
     );
   }
 
-  private async decorateRule(rule: RecurringTaskRule, currentUserId?: number) {
+  private async decorateRule(rule: RecurringTaskRule, currentUserId: number) {
     const [visibleTasks, users, collaborators] = await Promise.all([
-      tasksRepo.findAllAsync(),
+      tasksRepo.findAllAsync(currentUserId),
       usersRepo.findAllAsync(),
       repo.listCollaboratorsAsync(rule.id),
     ]);

--- a/apps/api_server/src/controllers/tasks_controller.ts
+++ b/apps/api_server/src/controllers/tasks_controller.ts
@@ -12,7 +12,7 @@ const notifService = new NotificationService(new NotificationsRepository());
 export class TasksController {
   async getAll(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(await repo.findAllAsync(req.auth?.user.id));
+      res.json(await repo.findAllAsync(req.auth!.user.id));
     } catch (err) {
       next(err);
     }
@@ -20,7 +20,7 @@ export class TasksController {
 
   async getById(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(await repo.findByIdAsync(req.params.id, req.auth?.user.id));
+      res.json(await repo.findByIdAsync(req.params.id, req.auth!.user.id));
     } catch (err) {
       next(err);
     }
@@ -37,7 +37,7 @@ export class TasksController {
         notes: (notes as string) ?? null,
         dueDate: (dueDate as string) ?? null,
         status: status as 'open' | 'done',
-        ownerId: req.auth?.user.id ?? null,
+        ownerId: req.auth!.user.id,
       });
       res.status(201).json(task);
     } catch (err) {
@@ -47,7 +47,7 @@ export class TasksController {
 
   async update(req: Request, res: Response, next: NextFunction) {
     try {
-      const actorId = req.auth?.user.id;
+      const actorId = req.auth!.user.id;
       const existing = await repo.findByIdAsync(req.params.id, actorId);
       const updated = await repo.updateAsync(
         req.params.id,
@@ -106,9 +106,9 @@ export class TasksController {
 
   async remove(req: Request, res: Response, next: NextFunction) {
     try {
-      const actorId = req.auth?.user.id;
+      const actorId = req.auth!.user.id;
       const task = await repo.findByIdAsync(req.params.id, actorId);
-      if (actorId == null || task.ownerId !== actorId) {
+      if (task.ownerId !== actorId) {
         throw AppError.forbidden('Only the task owner can delete this task');
       }
       await repo.deleteAsync(req.params.id, actorId);
@@ -120,7 +120,7 @@ export class TasksController {
 
   async getCollaborators(req: Request, res: Response, next: NextFunction) {
     try {
-      await repo.findByIdAsync(req.params.id, req.auth?.user.id);
+      await repo.findByIdAsync(req.params.id, req.auth!.user.id);
       res.json(await repo.listCollaboratorsAsync(req.params.id));
     } catch (err) {
       next(err);
@@ -133,21 +133,19 @@ export class TasksController {
       if (!userId || typeof userId !== 'number') {
         throw AppError.badRequest('userId is required and must be a number');
       }
-      const actorId = req.auth?.user.id;
+      const actorId = req.auth!.user.id;
       const task = await repo.findByIdAsync(req.params.id, actorId);
-      if (actorId == null || task.ownerId !== actorId) {
+      if (task.ownerId !== actorId) {
         throw AppError.forbidden('Only the task owner can add collaborators');
       }
       await repo.addCollaboratorAsync(req.params.id, userId);
-      if (actorId != null) {
-        await notifService.notifyCollaboratorAddedAsync(
-          'task',
-          req.params.id,
-          task.title,
-          userId,
-          actorId,
-        );
-      }
+      await notifService.notifyCollaboratorAddedAsync(
+        'task',
+        req.params.id,
+        task.title,
+        userId,
+        actorId,
+      );
       res.status(201).json(await repo.listCollaboratorsAsync(req.params.id));
     } catch (err) {
       next(err);
@@ -160,9 +158,9 @@ export class TasksController {
       if (isNaN(collaboratorUserId)) {
         throw AppError.badRequest('Invalid userId');
       }
-      const actorId = req.auth?.user.id;
+      const actorId = req.auth!.user.id;
       const task = await repo.findByIdAsync(req.params.id, actorId);
-      if (actorId == null || task.ownerId !== actorId) {
+      if (task.ownerId !== actorId) {
         throw AppError.forbidden('Only the task owner can remove collaborators');
       }
       await repo.removeCollaboratorAsync(req.params.id, collaboratorUserId);

--- a/apps/api_server/src/controllers/weekly_plan_controller.ts
+++ b/apps/api_server/src/controllers/weekly_plan_controller.ts
@@ -24,7 +24,8 @@ export class WeeklyPlanController {
           "Invalid week format. Use YYYY-WNN (e.g. 2026-W13).",
         );
       }
-      const plan = await this.service.assemblePlan(weekLabel, req.auth?.user.id);
+      const userId = req.auth!.user.id;
+      const plan = await this.service.assemblePlan(weekLabel, userId);
       const assemblySignal: AutomationSignal = {
         id: `rhythm:plan_assembly:${weekLabel}`,
         provider: "rhythm",
@@ -74,7 +75,7 @@ export class WeeklyPlanController {
       const updated = await this.tasksRepo.updateAsync(
         id,
         { scheduledDate, locked },
-        req.auth?.user.id,
+        req.auth!.user.id,
       );
       res.json(updated);
     } catch (err) {

--- a/apps/api_server/src/jobs/recurrence_generation_job.ts
+++ b/apps/api_server/src/jobs/recurrence_generation_job.ts
@@ -15,25 +15,37 @@ function getCronSchedule(): string {
   return process.env.RECURRENCE_CRON_SCHEDULE ?? DEFAULT_CRON_SCHEDULE;
 }
 
+export async function runRecurrenceGenerationOnce(
+  from: Date = new Date(),
+  to?: Date,
+): Promise<{ ruleCount: number; createdCount: number }> {
+  const rules =
+    await new RecurringTaskRulesRepository().findEnabledForGenerationAsync();
+  if (rules.length === 0) return { ruleCount: 0, createdCount: 0 };
+
+  const service = new RecurrenceService();
+  const end = to ?? new Date(from);
+  if (to == null) {
+    end.setUTCDate(end.getUTCDate() + getLookaheadWeeks() * 7);
+  }
+
+  let total = 0;
+  for (const rule of rules) {
+    const created = await service.generateInstances(rule, from, end);
+    total += created.length;
+  }
+
+  return { ruleCount: rules.length, createdCount: total };
+}
+
 async function runGeneration(): Promise<void> {
   try {
-    const rules = (await new RecurringTaskRulesRepository().findAllAsync()).filter(
-      (r) => r.enabled,
+    const result = await runRecurrenceGenerationOnce();
+    if (result.ruleCount === 0) return;
+
+    logger.info(
+      `RecurrenceGenerationJob: created ${result.createdCount} task(s) for ${result.ruleCount} rule(s)`,
     );
-    if (rules.length === 0) return;
-
-    const service = new RecurrenceService();
-    const from = new Date();
-    const to = new Date();
-    to.setUTCDate(to.getUTCDate() + getLookaheadWeeks() * 7);
-
-    let total = 0;
-    for (const rule of rules) {
-      const created = await service.generateInstances(rule, from, to);
-      total += created.length;
-    }
-
-    logger.info(`RecurrenceGenerationJob: created ${total} task(s) for ${rules.length} rule(s)`);
   } catch (err) {
     logger.error(`RecurrenceGenerationJob error: ${String(err)}`);
   }

--- a/apps/api_server/src/repositories/project_instances_repository.ts
+++ b/apps/api_server/src/repositories/project_instances_repository.ts
@@ -62,6 +62,8 @@ function stepRowToPlannerTask(row: {
   notes: string | null;
   instance_id: string;
   instance_name: string | null;
+  owner_id: number | null;
+  is_shared?: number | boolean | null;
 }): Task {
   return {
     id: row.id,
@@ -75,7 +77,8 @@ function stepRowToPlannerTask(row: {
     sourceType: 'project_step',
     sourceId: row.instance_id,
     sourceName: row.instance_name ?? null,
-    ownerId: null,
+    ownerId: row.owner_id,
+    isShared: Boolean(row.is_shared),
     createdAt: '',
     updatedAt: '',
   };
@@ -89,6 +92,8 @@ interface PlannerStepRow {
   notes: string | null;
   instance_id: string;
   instance_name: string | null;
+  owner_id: number | null;
+  is_shared?: number | boolean | null;
 }
 
 export class ProjectInstancesRepository {
@@ -128,64 +133,83 @@ export class ProjectInstancesRepository {
   async findPlannerStepsDueInRangeAsync(
     startDate: string,
     endDate: string,
+    userId: number,
   ): Promise<Task[]> {
     const query = `SELECT pis.id, pis.title, pis.due_date, pis.status, pis.notes, pis.instance_id,
-                          pi.name as instance_name
+                          pi.name as instance_name, pi.owner_id,
+                          CASE WHEN pi.owner_id != $3 THEN 1 ELSE 0 END AS is_shared
                    FROM project_instance_steps pis
                    JOIN project_instances pi ON pi.id = pis.instance_id
-                   WHERE pis.due_date BETWEEN $1 AND $2 AND pis.due_date IS NOT NULL AND pis.due_date != ''
+                   LEFT JOIN project_collaborators pc
+                     ON pc.project_instance_id = pi.id AND pc.user_id = $3
+                   WHERE pis.due_date BETWEEN $1 AND $2
+                     AND pis.due_date IS NOT NULL
+                     AND pis.due_date != ''
+                     AND (pi.owner_id = $3 OR pc.user_id IS NOT NULL)
                    ORDER BY pis.due_date ASC`;
 
     if (env.dbClient === 'postgres') {
       const result = await getPostgresPool().query<PlannerStepRow>(query, [
         startDate,
         endDate,
+        userId,
       ]);
       return result.rows.map(stepRowToPlannerTask);
     }
 
     const rows = getDb()
-      .prepare(query.replace(/\$1/g, '?').replace(/\$2/g, '?'))
-      .all(startDate, endDate) as PlannerStepRow[];
+      .prepare(query.replace(/\$1/g, '?').replace(/\$2/g, '?').replace(/\$3/g, '?'))
+      .all(userId, userId, startDate, endDate, userId) as PlannerStepRow[];
     return rows.map(stepRowToPlannerTask);
   }
 
-  async findPlannerOpenStepsWithoutDueDateAsync(): Promise<Task[]> {
+  async findPlannerOpenStepsWithoutDueDateAsync(userId: number): Promise<Task[]> {
     const query = `SELECT pis.id, pis.title, pis.due_date, pis.status, pis.notes, pis.instance_id,
-                          pi.name as instance_name
+                          pi.name as instance_name, pi.owner_id,
+                          CASE WHEN pi.owner_id != $1 THEN 1 ELSE 0 END AS is_shared
                    FROM project_instance_steps pis
                    JOIN project_instances pi ON pi.id = pis.instance_id
-                   WHERE pis.status = 'open' AND (pis.due_date IS NULL OR pis.due_date = '')
+                   LEFT JOIN project_collaborators pc
+                     ON pc.project_instance_id = pi.id AND pc.user_id = $1
+                   WHERE pis.status = 'open'
+                     AND (pis.due_date IS NULL OR pis.due_date = '')
+                     AND (pi.owner_id = $1 OR pc.user_id IS NOT NULL)
                    ORDER BY pi.created_at ASC, pis.title ASC`;
 
     if (env.dbClient === 'postgres') {
-      const result = await getPostgresPool().query<PlannerStepRow>(query);
-      return result.rows.map(stepRowToPlannerTask);
-    }
-
-    const rows = getDb().prepare(query).all() as PlannerStepRow[];
-    return rows.map(stepRowToPlannerTask);
-  }
-
-  async findPlannerOpenStepsBeforeDateAsync(date: string): Promise<Task[]> {
-    const query = `SELECT pis.id, pis.title, pis.due_date, pis.status, pis.notes, pis.instance_id,
-                          pi.name as instance_name
-                   FROM project_instance_steps pis
-                   JOIN project_instances pi ON pi.id = pis.instance_id
-                   WHERE pis.status = 'open'
-                     AND pis.due_date IS NOT NULL
-                     AND pis.due_date != ''
-                     AND pis.due_date < $1
-                   ORDER BY pis.due_date ASC, pi.created_at ASC`;
-
-    if (env.dbClient === 'postgres') {
-      const result = await getPostgresPool().query<PlannerStepRow>(query, [date]);
+      const result = await getPostgresPool().query<PlannerStepRow>(query, [userId]);
       return result.rows.map(stepRowToPlannerTask);
     }
 
     const rows = getDb()
       .prepare(query.replace(/\$1/g, '?'))
-      .all(date) as PlannerStepRow[];
+      .all(userId, userId, userId) as PlannerStepRow[];
+    return rows.map(stepRowToPlannerTask);
+  }
+
+  async findPlannerOpenStepsBeforeDateAsync(date: string, userId: number): Promise<Task[]> {
+    const query = `SELECT pis.id, pis.title, pis.due_date, pis.status, pis.notes, pis.instance_id,
+                          pi.name as instance_name, pi.owner_id,
+                          CASE WHEN pi.owner_id != $2 THEN 1 ELSE 0 END AS is_shared
+                   FROM project_instance_steps pis
+                   JOIN project_instances pi ON pi.id = pis.instance_id
+                   LEFT JOIN project_collaborators pc
+                     ON pc.project_instance_id = pi.id AND pc.user_id = $2
+                   WHERE pis.status = 'open'
+                     AND pis.due_date IS NOT NULL
+                     AND pis.due_date != ''
+                     AND pis.due_date < $1
+                     AND (pi.owner_id = $2 OR pc.user_id IS NOT NULL)
+                   ORDER BY pis.due_date ASC, pi.created_at ASC`;
+
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<PlannerStepRow>(query, [date, userId]);
+      return result.rows.map(stepRowToPlannerTask);
+    }
+
+    const rows = getDb()
+      .prepare(query.replace(/\$1/g, '?').replace(/\$2/g, '?'))
+      .all(userId, userId, date, userId) as PlannerStepRow[];
     return rows.map(stepRowToPlannerTask);
   }
 
@@ -234,34 +258,25 @@ export class ProjectInstancesRepository {
       .run(row.remaining === 0 ? 'done' : 'active', instanceId);
   }
 
-  findAll(userId?: number): ProjectInstance[] {
-    const rows = (userId != null
-      ? getDb()
-          .prepare(
-            `SELECT * FROM project_instances
-             WHERE owner_id = ?
-             ORDER BY created_at DESC`,
-          )
-          .all(userId)
-      : getDb()
-          .prepare('SELECT * FROM project_instances ORDER BY created_at DESC')
-          .all()) as InstanceRow[];
+  findAll(userId: number): ProjectInstance[] {
+    const rows = getDb()
+      .prepare(
+        `SELECT * FROM project_instances
+         WHERE owner_id = ?
+         ORDER BY created_at DESC`,
+      )
+      .all(userId) as InstanceRow[];
     return rows.map((row) => rowToInstance(row, this.getSteps(row.id)));
   }
 
-  async findAllAsync(userId?: number): Promise<ProjectInstance[]> {
+  async findAllAsync(userId: number): Promise<ProjectInstance[]> {
     if (env.dbClient === 'postgres') {
-      const result =
-        userId != null
-          ? await getPostgresPool().query<InstanceRow>(
-              `SELECT * FROM project_instances
-               WHERE owner_id = $1
-               ORDER BY created_at DESC`,
-              [userId],
-            )
-          : await getPostgresPool().query<InstanceRow>(
-              'SELECT * FROM project_instances ORDER BY created_at DESC',
-            );
+      const result = await getPostgresPool().query<InstanceRow>(
+        `SELECT * FROM project_instances
+         WHERE owner_id = $1
+         ORDER BY created_at DESC`,
+        [userId],
+      );
       return Promise.all(
         result.rows.map(async (row) =>
           rowToInstance(row, await this.getStepsAsync(row.id)),
@@ -271,40 +286,49 @@ export class ProjectInstancesRepository {
     return this.findAll(userId);
   }
 
-  findByTemplateId(templateId: string, userId?: number): ProjectInstance[] {
-    const rows = (userId != null
-      ? getDb()
-          .prepare(
-            `SELECT * FROM project_instances
-             WHERE template_id = ? AND owner_id = ?
-             ORDER BY anchor_date DESC`,
-          )
-          .all(templateId, userId)
-      : getDb()
-          .prepare(
-            'SELECT * FROM project_instances WHERE template_id = ? ORDER BY anchor_date DESC',
-          )
-          .all(templateId)) as InstanceRow[];
+  findAllIncludingLegacy(): ProjectInstance[] {
+    const rows = getDb()
+      .prepare('SELECT * FROM project_instances ORDER BY created_at DESC')
+      .all() as InstanceRow[];
+    return rows.map((row) => rowToInstance(row, this.getSteps(row.id)));
+  }
+
+  async findAllIncludingLegacyAsync(): Promise<ProjectInstance[]> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<InstanceRow>(
+        'SELECT * FROM project_instances ORDER BY created_at DESC',
+      );
+      return Promise.all(
+        result.rows.map(async (row) =>
+          rowToInstance(row, await this.getStepsAsync(row.id)),
+        ),
+      );
+    }
+    return this.findAllIncludingLegacy();
+  }
+
+  findByTemplateId(templateId: string, userId: number): ProjectInstance[] {
+    const rows = getDb()
+      .prepare(
+        `SELECT * FROM project_instances
+         WHERE template_id = ? AND owner_id = ?
+         ORDER BY anchor_date DESC`,
+      )
+      .all(templateId, userId) as InstanceRow[];
     return rows.map((row) => rowToInstance(row, this.getSteps(row.id)));
   }
 
   async findByTemplateIdAsync(
     templateId: string,
-    userId?: number,
+    userId: number,
   ): Promise<ProjectInstance[]> {
     if (env.dbClient === 'postgres') {
-      const result =
-        userId != null
-          ? await getPostgresPool().query<InstanceRow>(
-              `SELECT * FROM project_instances
-               WHERE template_id = $1 AND owner_id = $2
-               ORDER BY anchor_date DESC`,
-              [templateId, userId],
-            )
-          : await getPostgresPool().query<InstanceRow>(
-              'SELECT * FROM project_instances WHERE template_id = $1 ORDER BY anchor_date DESC',
-              [templateId],
-            );
+      const result = await getPostgresPool().query<InstanceRow>(
+        `SELECT * FROM project_instances
+         WHERE template_id = $1 AND owner_id = $2
+         ORDER BY anchor_date DESC`,
+        [templateId, userId],
+      );
       return Promise.all(
         result.rows.map(async (row) =>
           rowToInstance(row, await this.getStepsAsync(row.id)),
@@ -314,34 +338,50 @@ export class ProjectInstancesRepository {
     return this.findByTemplateId(templateId, userId);
   }
 
-  findById(id: string, userId?: number): ProjectInstance {
-    const row = (userId != null
-      ? getDb()
-          .prepare(
-            `SELECT * FROM project_instances
-             WHERE id = ? AND owner_id = ?`,
-          )
-          .get(id, userId)
-      : getDb()
-          .prepare('SELECT * FROM project_instances WHERE id = ?')
-          .get(id)) as InstanceRow | undefined;
+  findByTemplateIdIncludingLegacy(templateId: string): ProjectInstance[] {
+    const rows = getDb()
+      .prepare(
+        'SELECT * FROM project_instances WHERE template_id = ? ORDER BY anchor_date DESC',
+      )
+      .all(templateId) as InstanceRow[];
+    return rows.map((row) => rowToInstance(row, this.getSteps(row.id)));
+  }
+
+  async findByTemplateIdIncludingLegacyAsync(
+    templateId: string,
+  ): Promise<ProjectInstance[]> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<InstanceRow>(
+        'SELECT * FROM project_instances WHERE template_id = $1 ORDER BY anchor_date DESC',
+        [templateId],
+      );
+      return Promise.all(
+        result.rows.map(async (row) =>
+          rowToInstance(row, await this.getStepsAsync(row.id)),
+        ),
+      );
+    }
+    return this.findByTemplateIdIncludingLegacy(templateId);
+  }
+
+  findById(id: string, userId: number): ProjectInstance {
+    const row = getDb()
+      .prepare(
+        `SELECT * FROM project_instances
+         WHERE id = ? AND owner_id = ?`,
+      )
+      .get(id, userId) as InstanceRow | undefined;
     if (!row) throw AppError.notFound('ProjectInstance');
     return rowToInstance(row, this.getSteps(id));
   }
 
-  async findByIdAsync(id: string, userId?: number): Promise<ProjectInstance> {
+  async findByIdAsync(id: string, userId: number): Promise<ProjectInstance> {
     if (env.dbClient === 'postgres') {
-      const result =
-        userId != null
-          ? await getPostgresPool().query<InstanceRow>(
-              `SELECT * FROM project_instances
-               WHERE id = $1 AND owner_id = $2`,
-              [id, userId],
-            )
-          : await getPostgresPool().query<InstanceRow>(
-              'SELECT * FROM project_instances WHERE id = $1',
-              [id],
-            );
+      const result = await getPostgresPool().query<InstanceRow>(
+        `SELECT * FROM project_instances
+         WHERE id = $1 AND owner_id = $2`,
+        [id, userId],
+      );
       const row = result.rows[0];
       if (!row) throw AppError.notFound('ProjectInstance');
       return rowToInstance(row, await this.getStepsAsync(id));
@@ -349,28 +389,42 @@ export class ProjectInstancesRepository {
     return this.findById(id, userId);
   }
 
+  findByIdIncludingLegacy(id: string): ProjectInstance {
+    const row = getDb()
+      .prepare('SELECT * FROM project_instances WHERE id = ?')
+      .get(id) as InstanceRow | undefined;
+    if (!row) throw AppError.notFound('ProjectInstance');
+    return rowToInstance(row, this.getSteps(id));
+  }
+
+  async findByIdIncludingLegacyAsync(id: string): Promise<ProjectInstance> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<InstanceRow>(
+        'SELECT * FROM project_instances WHERE id = $1',
+        [id],
+      );
+      const row = result.rows[0];
+      if (!row) throw AppError.notFound('ProjectInstance');
+      return rowToInstance(row, await this.getStepsAsync(id));
+    }
+    return this.findByIdIncludingLegacy(id);
+  }
+
   findByTemplateAndAnchor(
     templateId: string,
     anchorDate: string,
-    name?: string | null,
-    userId?: number | null,
+    name: string | null,
+    userId: number,
   ): ProjectInstance | null {
-    const row = (userId != null
-      ? getDb()
-          .prepare(
-            `SELECT * FROM project_instances
-             WHERE template_id = ?
-               AND anchor_date = ?
-               AND COALESCE(name, '') = COALESCE(?, '')
-               AND owner_id = ?`,
-          )
-          .get(templateId, anchorDate, name ?? null, userId)
-      : getDb()
-          .prepare(
-            `SELECT * FROM project_instances
-             WHERE template_id = ? AND anchor_date = ? AND COALESCE(name, '') = COALESCE(?, '')`,
-          )
-          .get(templateId, anchorDate, name ?? null)) as InstanceRow | undefined;
+    const row = getDb()
+      .prepare(
+        `SELECT * FROM project_instances
+         WHERE template_id = ?
+           AND anchor_date = ?
+           AND COALESCE(name, '') = COALESCE(?, '')
+           AND owner_id = ?`,
+      )
+      .get(templateId, anchorDate, name ?? null, userId) as InstanceRow | undefined;
     if (!row) return null;
     return rowToInstance(row, this.getSteps(row.id));
   }
@@ -378,30 +432,38 @@ export class ProjectInstancesRepository {
   async findByTemplateAndAnchorAsync(
     templateId: string,
     anchorDate: string,
-    name?: string | null,
-    userId?: number | null,
+    name: string | null,
+    userId: number,
   ): Promise<ProjectInstance | null> {
     if (env.dbClient === 'postgres') {
-      const result =
-        userId != null
-          ? await getPostgresPool().query<InstanceRow>(
-              `SELECT * FROM project_instances
-               WHERE template_id = $1
-                 AND anchor_date = $2
-                 AND COALESCE(name, '') = COALESCE($3, '')
-                 AND owner_id = $4`,
-              [templateId, anchorDate, name ?? null, userId],
-            )
-          : await getPostgresPool().query<InstanceRow>(
-              `SELECT * FROM project_instances
-               WHERE template_id = $1 AND anchor_date = $2 AND COALESCE(name, '') = COALESCE($3, '')`,
-              [templateId, anchorDate, name ?? null],
-            );
+      const result = await getPostgresPool().query<InstanceRow>(
+        `SELECT * FROM project_instances
+         WHERE template_id = $1
+           AND anchor_date = $2
+           AND COALESCE(name, '') = COALESCE($3, '')
+           AND owner_id = $4`,
+        [templateId, anchorDate, name ?? null, userId],
+      );
       const row = result.rows[0];
       if (!row) return null;
       return rowToInstance(row, await this.getStepsAsync(row.id));
     }
     return this.findByTemplateAndAnchor(templateId, anchorDate, name, userId);
+  }
+
+  findByTemplateAndAnchorIncludingLegacy(
+    templateId: string,
+    anchorDate: string,
+    name?: string | null,
+  ): ProjectInstance | null {
+    const row = getDb()
+      .prepare(
+        `SELECT * FROM project_instances
+         WHERE template_id = ? AND anchor_date = ? AND COALESCE(name, '') = COALESCE(?, '')`,
+      )
+      .get(templateId, anchorDate, name ?? null) as InstanceRow | undefined;
+    if (!row) return null;
+    return rowToInstance(row, this.getSteps(row.id));
   }
 
   createWithSteps(
@@ -446,7 +508,7 @@ export class ProjectInstancesRepository {
       }
     })();
 
-    return this.findById(instanceId);
+    return this.findByIdIncludingLegacy(instanceId);
   }
 
   async createWithStepsAsync(
@@ -480,7 +542,7 @@ export class ProjectInstancesRepository {
           ],
         );
       }
-      return this.findByIdAsync(instanceId);
+      return this.findByIdIncludingLegacyAsync(instanceId);
     }
     return this.createWithSteps(templateId, anchorDate, name, ownerId, steps);
   }
@@ -619,31 +681,23 @@ export class ProjectInstancesRepository {
     this.deleteByTemplateId(templateId, userId);
   }
 
-  delete(instanceId: string, userId?: number): void {
+  delete(instanceId: string, userId: number): void {
     this.findById(instanceId, userId);
-    const result = (userId != null
-      ? getDb()
-          .prepare(
-            'DELETE FROM project_instances WHERE id = ? AND owner_id = ?',
-          )
-          .run(instanceId, userId)
-      : getDb().prepare('DELETE FROM project_instances WHERE id = ?').run(instanceId));
+    const result = getDb()
+      .prepare(
+        'DELETE FROM project_instances WHERE id = ? AND owner_id = ?',
+      )
+      .run(instanceId, userId);
     if (result.changes === 0) throw AppError.notFound('ProjectInstance');
   }
 
-  async deleteAsync(instanceId: string, userId?: number): Promise<void> {
+  async deleteAsync(instanceId: string, userId: number): Promise<void> {
     if (env.dbClient === 'postgres') {
       await this.findByIdAsync(instanceId, userId);
-      const result =
-        userId != null
-          ? await getPostgresPool().query(
-              'DELETE FROM project_instances WHERE id = $1 AND owner_id = $2',
-              [instanceId, userId],
-            )
-          : await getPostgresPool().query(
-              'DELETE FROM project_instances WHERE id = $1',
-              [instanceId],
-            );
+      const result = await getPostgresPool().query(
+        'DELETE FROM project_instances WHERE id = $1 AND owner_id = $2',
+        [instanceId, userId],
+      );
       if (result.rowCount === 0) throw AppError.notFound('ProjectInstance');
       return;
     }

--- a/apps/api_server/src/repositories/project_templates_repository.ts
+++ b/apps/api_server/src/repositories/project_templates_repository.ts
@@ -84,19 +84,14 @@ export class ProjectTemplatesRepository {
     return rows.map(rowToStep);
   }
 
-  async findAllAsync(userId?: number): Promise<ProjectTemplate[]> {
+  async findAllAsync(userId: number): Promise<ProjectTemplate[]> {
     if (env.dbClient === 'postgres') {
-      const result =
-        userId != null
-          ? await getPostgresPool().query<TemplateRow>(
-              `SELECT * FROM project_templates
-               WHERE owner_id = $1
-               ORDER BY created_at ASC`,
-              [userId],
-            )
-          : await getPostgresPool().query<TemplateRow>(
-              'SELECT * FROM project_templates ORDER BY created_at ASC',
-            );
+      const result = await getPostgresPool().query<TemplateRow>(
+        `SELECT * FROM project_templates
+         WHERE owner_id = $1
+         ORDER BY created_at ASC`,
+        [userId],
+      );
       return Promise.all(
         result.rows.map(async (row) =>
           rowToTemplate(row, await this.getStepsAsync(row.id)),
@@ -106,34 +101,45 @@ export class ProjectTemplatesRepository {
     return this.findAll(userId);
   }
 
-  findAll(userId?: number): ProjectTemplate[] {
-    const rows = (userId != null
-      ? getDb()
-          .prepare(
-            `SELECT * FROM project_templates
-             WHERE owner_id = ?
-             ORDER BY created_at ASC`,
-          )
-          .all(userId)
-      : getDb()
-          .prepare('SELECT * FROM project_templates ORDER BY created_at ASC')
-          .all()) as TemplateRow[];
+  findAll(userId: number): ProjectTemplate[] {
+    const rows = getDb()
+      .prepare(
+        `SELECT * FROM project_templates
+         WHERE owner_id = ?
+         ORDER BY created_at ASC`,
+      )
+      .all(userId) as TemplateRow[];
     return rows.map((row) => rowToTemplate(row, this.getSteps(row.id)));
   }
 
-  async findByIdAsync(id: string, userId?: number): Promise<ProjectTemplate> {
+  async findAllIncludingLegacyAsync(): Promise<ProjectTemplate[]> {
     if (env.dbClient === 'postgres') {
-      const result =
-        userId != null
-          ? await getPostgresPool().query<TemplateRow>(
-              `SELECT * FROM project_templates
-               WHERE id = $1 AND owner_id = $2`,
-              [id, userId],
-            )
-          : await getPostgresPool().query<TemplateRow>(
-              'SELECT * FROM project_templates WHERE id = $1',
-              [id],
-            );
+      const result = await getPostgresPool().query<TemplateRow>(
+        'SELECT * FROM project_templates ORDER BY created_at ASC',
+      );
+      return Promise.all(
+        result.rows.map(async (row) =>
+          rowToTemplate(row, await this.getStepsAsync(row.id)),
+        ),
+      );
+    }
+    return this.findAllIncludingLegacy();
+  }
+
+  findAllIncludingLegacy(): ProjectTemplate[] {
+    const rows = getDb()
+      .prepare('SELECT * FROM project_templates ORDER BY created_at ASC')
+      .all() as TemplateRow[];
+    return rows.map((row) => rowToTemplate(row, this.getSteps(row.id)));
+  }
+
+  async findByIdAsync(id: string, userId: number): Promise<ProjectTemplate> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<TemplateRow>(
+        `SELECT * FROM project_templates
+         WHERE id = $1 AND owner_id = $2`,
+        [id, userId],
+      );
       const row = result.rows[0];
       if (!row) throw AppError.notFound('ProjectTemplate');
       return rowToTemplate(row, await this.getStepsAsync(id));
@@ -141,24 +147,41 @@ export class ProjectTemplatesRepository {
     return this.findById(id, userId);
   }
 
-  findById(id: string, userId?: number): ProjectTemplate {
-    const row = (userId != null
-      ? getDb()
-          .prepare(
-            `SELECT * FROM project_templates
-             WHERE id = ? AND owner_id = ?`,
-          )
-          .get(id, userId)
-      : getDb().prepare('SELECT * FROM project_templates WHERE id = ?').get(id)) as
-      | TemplateRow
-      | undefined;
+  findById(id: string, userId: number): ProjectTemplate {
+    const row = getDb()
+      .prepare(
+        `SELECT * FROM project_templates
+         WHERE id = ? AND owner_id = ?`,
+      )
+      .get(id, userId) as TemplateRow | undefined;
+    if (!row) throw AppError.notFound('ProjectTemplate');
+    return rowToTemplate(row, this.getSteps(id));
+  }
+
+  async findByIdIncludingLegacyAsync(id: string): Promise<ProjectTemplate> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<TemplateRow>(
+        'SELECT * FROM project_templates WHERE id = $1',
+        [id],
+      );
+      const row = result.rows[0];
+      if (!row) throw AppError.notFound('ProjectTemplate');
+      return rowToTemplate(row, await this.getStepsAsync(id));
+    }
+    return this.findByIdIncludingLegacy(id);
+  }
+
+  findByIdIncludingLegacy(id: string): ProjectTemplate {
+    const row = getDb()
+      .prepare('SELECT * FROM project_templates WHERE id = ?')
+      .get(id) as TemplateRow | undefined;
     if (!row) throw AppError.notFound('ProjectTemplate');
     return rowToTemplate(row, this.getSteps(id));
   }
 
   async findByNameInsensitiveAsync(
     name: string,
-    userId?: number,
+    userId: number,
   ): Promise<ProjectTemplate | null> {
     const normalized = name.trim().toLowerCase();
     const rows = await this.findAllAsync(userId);
@@ -168,7 +191,7 @@ export class ProjectTemplatesRepository {
     return match ?? null;
   }
 
-  findByNameInsensitive(name: string, userId?: number): ProjectTemplate | null {
+  findByNameInsensitive(name: string, userId: number): ProjectTemplate | null {
     const normalized = name.trim().toLowerCase();
     const rows = this.findAll(userId);
     const match = rows.find(
@@ -193,7 +216,7 @@ export class ProjectTemplatesRepository {
           now,
         ],
       );
-      return this.findByIdAsync(id);
+      return this.findByIdIncludingLegacyAsync(id);
     }
     return this.create(data);
   }
@@ -214,7 +237,7 @@ export class ProjectTemplatesRepository {
         data.ownerId ?? null,
         now,
       );
-    return this.findById(id);
+    return this.findByIdIncludingLegacy(id);
   }
 
   async updateAsync(
@@ -223,7 +246,10 @@ export class ProjectTemplatesRepository {
     userId?: number,
   ): Promise<ProjectTemplate> {
     if (env.dbClient === 'postgres') {
-      const existing = await this.findByIdAsync(id, userId);
+      const existing =
+        userId != null
+          ? await this.findByIdAsync(id, userId)
+          : await this.findByIdIncludingLegacyAsync(id);
       await getPostgresPool().query(
         `UPDATE project_templates SET name = $1, description = $2, owner_id = $3 WHERE id = $4`,
         [
@@ -233,13 +259,18 @@ export class ProjectTemplatesRepository {
           id,
         ],
       );
-      return this.findByIdAsync(id, userId);
+      return userId != null
+        ? this.findByIdAsync(id, userId)
+        : this.findByIdIncludingLegacyAsync(id);
     }
     return this.update(id, data, userId);
   }
 
   update(id: string, data: UpdateProjectTemplateDto, userId?: number): ProjectTemplate {
-    const existing = this.findById(id, userId);
+    const existing =
+      userId != null
+        ? this.findById(id, userId)
+        : this.findByIdIncludingLegacy(id);
     getDb()
       .prepare(`UPDATE project_templates SET name = ?, description = ?, owner_id = ? WHERE id = ?`)
       .run(
@@ -248,12 +279,18 @@ export class ProjectTemplatesRepository {
         data.ownerId !== undefined ? data.ownerId : existing.ownerId,
         id,
       );
-    return this.findById(id, userId);
+    return userId != null
+      ? this.findById(id, userId)
+      : this.findByIdIncludingLegacy(id);
   }
 
   async deleteAsync(id: string, userId?: number): Promise<void> {
     if (env.dbClient === 'postgres') {
-      await this.findByIdAsync(id, userId);
+      if (userId != null) {
+        await this.findByIdAsync(id, userId);
+      } else {
+        await this.findByIdIncludingLegacyAsync(id);
+      }
       if (userId != null) {
         await getPostgresPool().query(
           'DELETE FROM project_instances WHERE template_id = $1 AND owner_id = $2',
@@ -281,7 +318,11 @@ export class ProjectTemplatesRepository {
   }
 
   delete(id: string, userId?: number): void {
-    this.findById(id, userId);
+    if (userId != null) {
+      this.findById(id, userId);
+    } else {
+      this.findByIdIncludingLegacy(id);
+    }
     const db = getDb();
     db.transaction(() => {
       db.prepare('DELETE FROM project_instances WHERE template_id = ?').run(id);
@@ -296,7 +337,11 @@ export class ProjectTemplatesRepository {
     userId?: number,
   ): Promise<ProjectTemplateStep> {
     if (env.dbClient === 'postgres') {
-      await this.findByIdAsync(templateId, userId);
+      if (userId != null) {
+        await this.findByIdAsync(templateId, userId);
+      } else {
+        await this.findByIdIncludingLegacyAsync(templateId);
+      }
       const id = uuidv4();
       await getPostgresPool().query(
         `INSERT INTO project_template_steps (id, template_id, title, offset_days, offset_description, sort_order, assignee_id)
@@ -324,7 +369,11 @@ export class ProjectTemplatesRepository {
   }
 
   addStep(templateId: string, data: CreateStepDto, userId?: number): ProjectTemplateStep {
-    this.findById(templateId, userId); // ensures template exists
+    if (userId != null) {
+      this.findById(templateId, userId);
+    } else {
+      this.findByIdIncludingLegacy(templateId);
+    }
     const id = uuidv4();
     getDb()
       .prepare(

--- a/apps/api_server/src/repositories/recurring_task_rules_repository.ts
+++ b/apps/api_server/src/repositories/recurring_task_rules_repository.ts
@@ -108,45 +108,78 @@ function serializeSteps(steps?: RecurringTaskRuleStep[]): string {
 }
 
 export class RecurringTaskRulesRepository {
-  async findAllAsync(userId?: number): Promise<RecurringTaskRule[]> {
+  async findAllAsync(userId: number): Promise<RecurringTaskRule[]> {
     if (env.dbClient === 'postgres') {
-      const result =
-        userId != null
-          ? await getPostgresPool().query<RuleRow>(
-              `SELECT recurring_task_rules.*
-               FROM recurring_task_rules
-               LEFT JOIN rhythm_collaborators rc
-                 ON rc.rhythm_id = recurring_task_rules.id
-                AND rc.user_id = $1
-               WHERE recurring_task_rules.owner_id = $1
-                  OR rc.user_id IS NOT NULL
-               ORDER BY recurring_task_rules.created_at ASC`,
-              [userId],
-            )
-          : await getPostgresPool().query<RuleRow>(
-              'SELECT * FROM recurring_task_rules ORDER BY created_at ASC',
-            );
+      const result = await getPostgresPool().query<RuleRow>(
+        `SELECT recurring_task_rules.*
+         FROM recurring_task_rules
+         LEFT JOIN rhythm_collaborators rc
+           ON rc.rhythm_id = recurring_task_rules.id
+          AND rc.user_id = $1
+         WHERE recurring_task_rules.owner_id = $1
+            OR rc.user_id IS NOT NULL
+         ORDER BY recurring_task_rules.created_at ASC`,
+        [userId],
+      );
       return result.rows.map(rowToRule);
     }
     return this.findAll(userId);
   }
 
-  findAll(userId?: number): RecurringTaskRule[] {
-    if (userId != null) {
-      const rows = getDb()
-        .prepare(
-          `SELECT recurring_task_rules.*
-           FROM recurring_task_rules
-           LEFT JOIN rhythm_collaborators rc
-             ON rc.rhythm_id = recurring_task_rules.id
-            AND rc.user_id = ?
-           WHERE recurring_task_rules.owner_id = ?
-              OR rc.user_id IS NOT NULL
-           ORDER BY recurring_task_rules.created_at ASC`,
-        )
-        .all(userId, userId) as RuleRow[];
-      return rows.map(rowToRule);
+  findAll(userId: number): RecurringTaskRule[] {
+    const rows = getDb()
+      .prepare(
+        `SELECT recurring_task_rules.*
+         FROM recurring_task_rules
+         LEFT JOIN rhythm_collaborators rc
+           ON rc.rhythm_id = recurring_task_rules.id
+          AND rc.user_id = ?
+         WHERE recurring_task_rules.owner_id = ?
+            OR rc.user_id IS NOT NULL
+         ORDER BY recurring_task_rules.created_at ASC`,
+      )
+      .all(userId, userId) as RuleRow[];
+    return rows.map(rowToRule);
+  }
+
+  async findEnabledForGenerationAsync(): Promise<RecurringTaskRule[]> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<RuleRow>(
+        `SELECT *
+         FROM recurring_task_rules
+         WHERE owner_id IS NOT NULL
+           AND enabled = TRUE
+         ORDER BY created_at ASC`,
+      );
+      return result.rows.map(rowToRule);
     }
+    return this.findEnabledForGeneration();
+  }
+
+  findEnabledForGeneration(): RecurringTaskRule[] {
+    const rows = getDb()
+      .prepare(
+        `SELECT *
+         FROM recurring_task_rules
+         WHERE owner_id IS NOT NULL
+           AND enabled = 1
+         ORDER BY created_at ASC`,
+      )
+      .all() as RuleRow[];
+    return rows.map(rowToRule);
+  }
+
+  async findAllIncludingLegacyAsync(): Promise<RecurringTaskRule[]> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<RuleRow>(
+        'SELECT * FROM recurring_task_rules ORDER BY created_at ASC',
+      );
+      return result.rows.map(rowToRule);
+    }
+    return this.findAllIncludingLegacy();
+  }
+
+  findAllIncludingLegacy(): RecurringTaskRule[] {
     const rows = getDb()
       .prepare('SELECT * FROM recurring_task_rules ORDER BY created_at ASC')
       .all() as RuleRow[];

--- a/apps/api_server/src/repositories/tasks_repository.ts
+++ b/apps/api_server/src/repositories/tasks_repository.ts
@@ -67,85 +67,88 @@ const TASK_SELECT = `
 `;
 
 export class TasksRepository {
-  async findAllAsync(userId?: number): Promise<Task[]> {
+  async findAllAsync(userId: number): Promise<Task[]> {
     if (env.dbClient === 'postgres') {
-      const result =
-        userId != null
-          ? await getPostgresPool().query<TaskRow>(
-              `SELECT tasks.*,
-                CASE
-                  WHEN tasks.source_type = 'project_step' THEN COALESCE(pi.name, pt.name)
-                  WHEN tasks.source_type = 'recurring_rule' THEN rr.title
-                  ELSE NULL
-                END AS source_name,
-                CASE WHEN tasks.owner_id != $1 THEN 1 ELSE 0 END AS is_shared
-               FROM tasks
-               LEFT JOIN project_instances pi
-                 ON tasks.source_type = 'project_step' AND tasks.source_id = pi.id
-               LEFT JOIN project_templates pt ON pi.template_id = pt.id
-               LEFT JOIN recurring_task_rules rr
-                 ON tasks.source_type = 'recurring_rule'
-                AND (tasks.source_id = rr.id OR tasks.source_id LIKE rr.id || ':%')
-               LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = $2
-               WHERE tasks.owner_id = $3 OR tc.user_id IS NOT NULL
-               ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
-              [userId, userId, userId],
-            )
-          : await getPostgresPool().query<TaskRow>(
-              `${TASK_SELECT}
-               ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
-            );
+      const result = await getPostgresPool().query<TaskRow>(
+        `SELECT tasks.*,
+          CASE
+            WHEN tasks.source_type = 'project_step' THEN COALESCE(pi.name, pt.name)
+            WHEN tasks.source_type = 'recurring_rule' THEN rr.title
+            ELSE NULL
+          END AS source_name,
+          CASE WHEN tasks.owner_id != $1 THEN 1 ELSE 0 END AS is_shared
+         FROM tasks
+         LEFT JOIN project_instances pi
+           ON tasks.source_type = 'project_step' AND tasks.source_id = pi.id
+         LEFT JOIN project_templates pt ON pi.template_id = pt.id
+         LEFT JOIN recurring_task_rules rr
+           ON tasks.source_type = 'recurring_rule'
+          AND (tasks.source_id = rr.id OR tasks.source_id LIKE rr.id || ':%')
+         LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = $2
+         WHERE tasks.owner_id = $3 OR tc.user_id IS NOT NULL
+         ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
+        [userId, userId, userId],
+      );
       return result.rows.map(rowToTask);
     }
 
     return this.findAll(userId);
   }
 
-  findAll(userId?: number): Task[] {
-    if (userId != null) {
-      const rows = getDb()
-        .prepare(
-          `SELECT tasks.*,
-            CASE
-              WHEN tasks.source_type = 'project_step' THEN COALESCE(pi.name, pt.name)
-              WHEN tasks.source_type = 'recurring_rule' THEN rr.title
-              ELSE NULL
-            END AS source_name,
-            CASE WHEN tasks.owner_id != ? THEN 1 ELSE 0 END AS is_shared
-           FROM tasks
-           LEFT JOIN project_instances pi
-             ON tasks.source_type = 'project_step' AND tasks.source_id = pi.id
-           LEFT JOIN project_templates pt ON pi.template_id = pt.id
-           LEFT JOIN recurring_task_rules rr
-             ON tasks.source_type = 'recurring_rule'
-            AND (tasks.source_id = rr.id OR tasks.source_id LIKE rr.id || ':%')
-           LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = ?
-           WHERE tasks.owner_id = ? OR tc.user_id IS NOT NULL
-           ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
-        )
-        .all(userId, userId, userId) as TaskRow[];
-      return rows.map(rowToTask);
-    }
+  findAll(userId: number): Task[] {
     const rows = getDb()
-      .prepare(`${TASK_SELECT} ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`)
+      .prepare(
+        `SELECT tasks.*,
+          CASE
+            WHEN tasks.source_type = 'project_step' THEN COALESCE(pi.name, pt.name)
+            WHEN tasks.source_type = 'recurring_rule' THEN rr.title
+            ELSE NULL
+          END AS source_name,
+          CASE WHEN tasks.owner_id != ? THEN 1 ELSE 0 END AS is_shared
+         FROM tasks
+         LEFT JOIN project_instances pi
+           ON tasks.source_type = 'project_step' AND tasks.source_id = pi.id
+         LEFT JOIN project_templates pt ON pi.template_id = pt.id
+         LEFT JOIN recurring_task_rules rr
+           ON tasks.source_type = 'recurring_rule'
+          AND (tasks.source_id = rr.id OR tasks.source_id LIKE rr.id || ':%')
+         LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = ?
+         WHERE tasks.owner_id = ? OR tc.user_id IS NOT NULL
+         ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
+      )
+      .all(userId, userId, userId) as TaskRow[];
+    return rows.map(rowToTask);
+  }
+
+  async findAllIncludingLegacyAsync(): Promise<Task[]> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<TaskRow>(
+        `${TASK_SELECT}
+         ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
+      );
+      return result.rows.map(rowToTask);
+    }
+    return this.findAllIncludingLegacy();
+  }
+
+  findAllIncludingLegacy(): Task[] {
+    const rows = getDb()
+      .prepare(
+        `${TASK_SELECT}
+         ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
+      )
       .all() as TaskRow[];
     return rows.map(rowToTask);
   }
 
-  async findByIdAsync(id: string, userId?: number): Promise<Task> {
+  async findByIdAsync(id: string, userId: number): Promise<Task> {
     if (env.dbClient === 'postgres') {
-      const result =
-        userId != null
-          ? await getPostgresPool().query<TaskRow>(
-              `${TASK_SELECT}
-               LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = $2
-               WHERE tasks.id = $1 AND (tasks.owner_id = $2 OR tc.user_id IS NOT NULL)`,
-              [id, userId],
-            )
-          : await getPostgresPool().query<TaskRow>(
-              `${TASK_SELECT} WHERE tasks.id = $1`,
-              [id],
-            );
+      const result = await getPostgresPool().query<TaskRow>(
+        `${TASK_SELECT}
+         LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = $2
+         WHERE tasks.id = $1 AND (tasks.owner_id = $2 OR tc.user_id IS NOT NULL)`,
+        [id, userId],
+      );
       const row = result.rows[0];
       if (!row) throw AppError.notFound('Task');
       return rowToTask(row);
@@ -154,18 +157,35 @@ export class TasksRepository {
     return this.findById(id, userId);
   }
 
-  findById(id: string, userId?: number): Task {
-    const row = (userId != null
-      ? getDb()
-          .prepare(
-            `${TASK_SELECT}
-             LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = ?
-             WHERE tasks.id = ? AND (tasks.owner_id = ? OR tc.user_id IS NOT NULL)`,
-          )
-          .get(userId, id, userId)
-      : getDb().prepare(`${TASK_SELECT} WHERE tasks.id = ?`).get(id)) as
-      | TaskRow
-      | undefined;
+  findById(id: string, userId: number): Task {
+    const row = getDb()
+      .prepare(
+        `${TASK_SELECT}
+         LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = ?
+         WHERE tasks.id = ? AND (tasks.owner_id = ? OR tc.user_id IS NOT NULL)`,
+      )
+      .get(userId, id, userId) as TaskRow | undefined;
+    if (!row) throw AppError.notFound('Task');
+    return rowToTask(row);
+  }
+
+  async findByIdIncludingLegacyAsync(id: string): Promise<Task> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<TaskRow>(
+        `${TASK_SELECT} WHERE tasks.id = $1`,
+        [id],
+      );
+      const row = result.rows[0];
+      if (!row) throw AppError.notFound('Task');
+      return rowToTask(row);
+    }
+    return this.findByIdIncludingLegacy(id);
+  }
+
+  findByIdIncludingLegacy(id: string): Task {
+    const row = getDb()
+      .prepare(`${TASK_SELECT} WHERE tasks.id = ?`)
+      .get(id) as TaskRow | undefined;
     if (!row) throw AppError.notFound('Task');
     return rowToTask(row);
   }
@@ -221,43 +241,48 @@ export class TasksRepository {
   async findByWeekAsync(
     weekStart: string,
     weekEnd: string,
-    userId?: number,
+    userId: number,
   ): Promise<Task[]> {
     if (env.dbClient === 'postgres') {
-      const result =
-        userId != null
-          ? await getPostgresPool().query<TaskRow>(
-              `${TASK_SELECT}
-               LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = $1
-               WHERE (tasks.owner_id = $1 OR tc.user_id IS NOT NULL)
-                 AND (tasks.due_date BETWEEN $2 AND $3 OR tasks.scheduled_date BETWEEN $4 AND $5)
-               ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
-              [userId, weekStart, weekEnd, weekStart, weekEnd],
-            )
-          : await getPostgresPool().query<TaskRow>(
-              `${TASK_SELECT}
-               WHERE (tasks.due_date BETWEEN $1 AND $2 OR tasks.scheduled_date BETWEEN $3 AND $4)
-               ORDER BY tasks.due_date ASC, tasks.created_at ASC`,
-              [weekStart, weekEnd, weekStart, weekEnd],
-            );
+      const result = await getPostgresPool().query<TaskRow>(
+        `${TASK_SELECT}
+         LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = $1
+         WHERE (tasks.owner_id = $1 OR tc.user_id IS NOT NULL)
+           AND (tasks.due_date BETWEEN $2 AND $3 OR tasks.scheduled_date BETWEEN $4 AND $5)
+         ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
+        [userId, weekStart, weekEnd, weekStart, weekEnd],
+      );
       return result.rows.map(rowToTask);
     }
 
     return this.findByWeek(weekStart, weekEnd, userId);
   }
 
-  findByWeek(weekStart: string, weekEnd: string, userId?: number): Task[] {
-    if (userId != null) {
-      const rows = getDb()
-          .prepare(
-            `${TASK_SELECT}
-          LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = ?
-          WHERE (tasks.owner_id = ? OR tc.user_id IS NOT NULL)
-             AND (tasks.due_date BETWEEN ? AND ? OR tasks.scheduled_date BETWEEN ? AND ?)
-         ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
-      )
-        .all(userId, userId, weekStart, weekEnd, weekStart, weekEnd) as TaskRow[];
-      return rows.map(rowToTask);
+  findByWeek(weekStart: string, weekEnd: string, userId: number): Task[] {
+    const rows = getDb()
+        .prepare(
+          `${TASK_SELECT}
+        LEFT JOIN task_collaborators tc ON tc.task_id = tasks.id AND tc.user_id = ?
+        WHERE (tasks.owner_id = ? OR tc.user_id IS NOT NULL)
+           AND (tasks.due_date BETWEEN ? AND ? OR tasks.scheduled_date BETWEEN ? AND ?)
+       ORDER BY tasks.due_date ASC, tasks.scheduled_order ASC, tasks.created_at ASC`,
+    )
+      .all(userId, userId, weekStart, weekEnd, weekStart, weekEnd) as TaskRow[];
+    return rows.map(rowToTask);
+  }
+
+  async findByWeekIncludingLegacyAsync(
+    weekStart: string,
+    weekEnd: string,
+  ): Promise<Task[]> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<TaskRow>(
+        `${TASK_SELECT}
+         WHERE (tasks.due_date BETWEEN $1 AND $2 OR tasks.scheduled_date BETWEEN $3 AND $4)
+         ORDER BY tasks.due_date ASC, tasks.created_at ASC`,
+        [weekStart, weekEnd, weekStart, weekEnd],
+      );
+      return result.rows.map(rowToTask);
     }
     const rows = getDb()
       .prepare(
@@ -269,96 +294,100 @@ export class TasksRepository {
     return rows.map(rowToTask);
   }
 
-  async findBacklogAsync(startOfWeek: string, userId?: number): Promise<Task[]> {
+  async findBacklogAsync(startOfWeek: string, userId: number): Promise<Task[]> {
     if (env.dbClient === 'postgres') {
-      const result =
-        userId != null
-          ? await getPostgresPool().query<TaskRow>(
-              `${TASK_SELECT}
-               WHERE tasks.status = 'open'
-                 AND (
-                   (tasks.due_date IS NULL AND tasks.scheduled_date IS NULL)
-                   OR (tasks.scheduled_date IS NULL AND tasks.due_date < $1)
-                   OR tasks.scheduled_date < $2
-                 )
-                 AND (
-                   tasks.owner_id = $3
-                   OR EXISTS (
-                     SELECT 1 FROM task_collaborators tc
-                     WHERE tc.task_id = tasks.id AND tc.user_id = $3
-                   )
-                 )
-               ORDER BY
-                 CASE
-                   WHEN tasks.scheduled_date IS NOT NULL THEN tasks.scheduled_date
-                   ELSE tasks.due_date
-                 END ASC,
-                 tasks.created_at ASC`,
-              [startOfWeek, startOfWeek, userId],
-            )
-          : await getPostgresPool().query<TaskRow>(
-              `${TASK_SELECT}
-               WHERE tasks.status = 'open'
-                 AND (
-                   (tasks.due_date IS NULL AND tasks.scheduled_date IS NULL)
-                   OR (tasks.scheduled_date IS NULL AND tasks.due_date < $1)
-                   OR tasks.scheduled_date < $2
-                 )
-               ORDER BY
-                 CASE
-                   WHEN tasks.scheduled_date IS NOT NULL THEN tasks.scheduled_date
-                   ELSE tasks.due_date
-                 END ASC,
-                 tasks.created_at ASC`,
-              [startOfWeek, startOfWeek],
-            );
+      const result = await getPostgresPool().query<TaskRow>(
+        `${TASK_SELECT}
+         WHERE tasks.status = 'open'
+           AND (
+             (tasks.due_date IS NULL AND tasks.scheduled_date IS NULL)
+             OR (tasks.scheduled_date IS NULL AND tasks.due_date < $1)
+             OR tasks.scheduled_date < $2
+           )
+           AND (
+             tasks.owner_id = $3
+             OR EXISTS (
+               SELECT 1 FROM task_collaborators tc
+               WHERE tc.task_id = tasks.id AND tc.user_id = $3
+             )
+           )
+         ORDER BY
+           CASE
+             WHEN tasks.scheduled_date IS NOT NULL THEN tasks.scheduled_date
+             ELSE tasks.due_date
+           END ASC,
+           tasks.created_at ASC`,
+        [startOfWeek, startOfWeek, userId],
+      );
       return result.rows.map(rowToTask);
     }
 
     const db = getDb();
-    const rows =
-      userId != null
-        ? (db
-            .prepare(
-              `${TASK_SELECT}
-               WHERE tasks.status = 'open'
-                 AND (
-                   (tasks.due_date IS NULL AND tasks.scheduled_date IS NULL)
-                   OR (tasks.scheduled_date IS NULL AND tasks.due_date < ?)
-                   OR tasks.scheduled_date < ?
-                 )
-                 AND (
-                   tasks.owner_id = ?
-                   OR EXISTS (
-                     SELECT 1 FROM task_collaborators tc
-                     WHERE tc.task_id = tasks.id AND tc.user_id = ?
-                   )
-                 )
-               ORDER BY
-                 CASE
-                   WHEN tasks.scheduled_date IS NOT NULL THEN tasks.scheduled_date
-                   ELSE tasks.due_date
-                 END ASC,
-                 tasks.created_at ASC`,
-            )
-            .all(startOfWeek, startOfWeek, userId, userId) as TaskRow[])
-        : (db
-            .prepare(
-              `${TASK_SELECT}
-               WHERE tasks.status = 'open'
-                 AND (
-                   (tasks.due_date IS NULL AND tasks.scheduled_date IS NULL)
-                   OR (tasks.scheduled_date IS NULL AND tasks.due_date < ?)
-                   OR tasks.scheduled_date < ?
-                 )
-               ORDER BY
-                 CASE
-                   WHEN tasks.scheduled_date IS NOT NULL THEN tasks.scheduled_date
-                   ELSE tasks.due_date
-                 END ASC,
-                 tasks.created_at ASC`,
-            )
-            .all(startOfWeek, startOfWeek) as TaskRow[]);
+    const rows = db
+      .prepare(
+        `${TASK_SELECT}
+         WHERE tasks.status = 'open'
+           AND (
+             (tasks.due_date IS NULL AND tasks.scheduled_date IS NULL)
+             OR (tasks.scheduled_date IS NULL AND tasks.due_date < ?)
+             OR tasks.scheduled_date < ?
+           )
+           AND (
+             tasks.owner_id = ?
+             OR EXISTS (
+               SELECT 1 FROM task_collaborators tc
+               WHERE tc.task_id = tasks.id AND tc.user_id = ?
+             )
+           )
+         ORDER BY
+           CASE
+             WHEN tasks.scheduled_date IS NOT NULL THEN tasks.scheduled_date
+             ELSE tasks.due_date
+           END ASC,
+           tasks.created_at ASC`,
+      )
+      .all(startOfWeek, startOfWeek, userId, userId) as TaskRow[];
+    return rows.map(rowToTask);
+  }
+
+  async findBacklogIncludingLegacyAsync(startOfWeek: string): Promise<Task[]> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<TaskRow>(
+        `${TASK_SELECT}
+         WHERE tasks.status = 'open'
+           AND (
+             (tasks.due_date IS NULL AND tasks.scheduled_date IS NULL)
+             OR (tasks.scheduled_date IS NULL AND tasks.due_date < $1)
+             OR tasks.scheduled_date < $2
+           )
+         ORDER BY
+           CASE
+             WHEN tasks.scheduled_date IS NOT NULL THEN tasks.scheduled_date
+             ELSE tasks.due_date
+           END ASC,
+           tasks.created_at ASC`,
+        [startOfWeek, startOfWeek],
+      );
+      return result.rows.map(rowToTask);
+    }
+
+    const rows = getDb()
+      .prepare(
+        `${TASK_SELECT}
+         WHERE tasks.status = 'open'
+           AND (
+             (tasks.due_date IS NULL AND tasks.scheduled_date IS NULL)
+             OR (tasks.scheduled_date IS NULL AND tasks.due_date < ?)
+             OR tasks.scheduled_date < ?
+           )
+         ORDER BY
+           CASE
+             WHEN tasks.scheduled_date IS NOT NULL THEN tasks.scheduled_date
+             ELSE tasks.due_date
+           END ASC,
+           tasks.created_at ASC`,
+      )
+      .all(startOfWeek, startOfWeek) as TaskRow[];
     return rows.map(rowToTask);
   }
 
@@ -388,7 +417,7 @@ export class TasksRepository {
           now,
         ],
       );
-      return this.findByIdAsync(id);
+      return this.findByIdIncludingLegacyAsync(id);
     }
 
     return this.create(data);
@@ -420,7 +449,7 @@ export class TasksRepository {
         now,
         now,
       );
-    return this.findById(id);
+    return this.findByIdIncludingLegacy(id);
   }
 
   async upsertExternalTaskAsync(data: CreateTaskDto): Promise<Task> {
@@ -612,7 +641,10 @@ export class TasksRepository {
 
   async updateAsync(id: string, data: UpdateTaskDto, userId?: number): Promise<Task> {
     if (env.dbClient === 'postgres') {
-      const existing = await this.findByIdAsync(id, userId);
+      const existing =
+        userId != null
+          ? await this.findByIdAsync(id, userId)
+          : await this.findByIdIncludingLegacyAsync(id);
       const now = new Date().toISOString();
       const nextNotes = data.notes === '' ? null : data.notes;
       const nextDueDate = data.dueDate === '' ? null : data.dueDate;
@@ -649,14 +681,19 @@ export class TasksRepository {
           id,
         ],
       );
-      return this.findByIdAsync(id, userId);
+      return userId != null
+        ? this.findByIdAsync(id, userId)
+        : this.findByIdIncludingLegacyAsync(id);
     }
 
     return this.update(id, data, userId);
   }
 
   update(id: string, data: UpdateTaskDto, userId?: number): Task {
-    const existing = this.findById(id, userId);
+    const existing =
+      userId != null
+        ? this.findById(id, userId)
+        : this.findByIdIncludingLegacy(id);
     const now = new Date().toISOString();
     const nextNotes = data.notes === '' ? null : data.notes;
     const nextDueDate = data.dueDate === '' ? null : data.dueDate;
@@ -687,12 +724,18 @@ export class TasksRepository {
         now,
         id,
       );
-    return this.findById(id, userId);
+    return userId != null
+      ? this.findById(id, userId)
+      : this.findByIdIncludingLegacy(id);
   }
 
   async deleteAsync(id: string, userId?: number): Promise<void> {
     if (env.dbClient === 'postgres') {
-      await this.findByIdAsync(id, userId);
+      if (userId != null) {
+        await this.findByIdAsync(id, userId);
+      } else {
+        await this.findByIdIncludingLegacyAsync(id);
+      }
       const result = await getPostgresPool().query(
         'DELETE FROM tasks WHERE id = $1',
         [id],
@@ -705,7 +748,11 @@ export class TasksRepository {
   }
 
   delete(id: string, userId?: number): void {
-    this.findById(id, userId);
+    if (userId != null) {
+      this.findById(id, userId);
+    } else {
+      this.findByIdIncludingLegacy(id);
+    }
     const result = getDb().prepare('DELETE FROM tasks WHERE id = ?').run(id);
     if (result.changes === 0) throw AppError.notFound('Task');
   }

--- a/apps/api_server/src/services/automation_engine_service.test.ts
+++ b/apps/api_server/src/services/automation_engine_service.test.ts
@@ -236,6 +236,7 @@ describe("Automation overhaul backend", () => {
     const template = templatesRepo.create({
       name: "Special Service",
       anchorType: "date",
+      ownerId: owner.id,
     });
     templatesRepo.addStep(template.id, {
       title: "Confirm volunteers",
@@ -254,6 +255,7 @@ describe("Automation overhaul backend", () => {
         projectNameTemplate: "{{title}} Project",
       },
       sourceAccountId: pcoAccount.id,
+      ownerId: owner.id,
     });
 
     const signal: AutomationSignal = {
@@ -281,7 +283,7 @@ describe("Automation overhaul backend", () => {
     expect(result.matchedRules).toBe(1);
     expect(result.executedActions).toBe(1);
 
-    const instances = instancesRepo.findByTemplateId(template.id);
+    const instances = instancesRepo.findByTemplateId(template.id, owner.id);
     expect(instances).toHaveLength(1);
     expect(instances[0]?.name).toBe("Good Friday Service Project");
     expect(instances[0]?.anchorDate).toBe("2026-04-03");

--- a/apps/api_server/src/services/automation_engine_service.ts
+++ b/apps/api_server/src/services/automation_engine_service.ts
@@ -433,18 +433,19 @@ export class AutomationEngineService {
     rule: AutomationRule,
     signal: AutomationSignal,
   ): Promise<boolean> {
+    if (rule.ownerId == null) return false;
     const config = rule.actionConfig ?? {};
     const templateId = asString(config.templateId);
     const templateName = asString(config.templateName);
     const template = templateId
       ? await this.templatesRepo.findByIdAsync(
           templateId,
-          rule.ownerId ?? undefined,
+          rule.ownerId,
         )
       : templateName
         ? await this.templatesRepo.findByNameInsensitiveAsync(
             templateName,
-            rule.ownerId ?? undefined,
+            rule.ownerId,
           )
         : null;
     if (template == null) return false;
@@ -463,7 +464,7 @@ export class AutomationEngineService {
       template.id,
       anchorDate,
       projectName,
-      rule.ownerId ?? undefined,
+      rule.ownerId,
     );
     return true;
   }

--- a/apps/api_server/src/services/project_generation_service.ts
+++ b/apps/api_server/src/services/project_generation_service.ts
@@ -14,8 +14,8 @@ export class ProjectGenerationService {
   generate(
     templateId: string,
     anchorDate: string,
-    name?: string | null,
-    userId?: number,
+    name: string | null,
+    userId: number,
   ): ProjectInstance {
     const normalizedName = name?.trim() || null;
     const existing = this.instanceRepo.findByTemplateAndAnchor(
@@ -52,8 +52,8 @@ export class ProjectGenerationService {
   async generateAsync(
     templateId: string,
     anchorDate: string,
-    name?: string | null,
-    userId?: number,
+    name: string | null,
+    userId: number,
   ): Promise<ProjectInstance> {
     const normalizedName = name?.trim() || null;
     const existing = await this.instanceRepo.findByTemplateAndAnchorAsync(

--- a/apps/api_server/src/services/recurrence_service.ts
+++ b/apps/api_server/src/services/recurrence_service.ts
@@ -14,6 +14,8 @@ export class RecurrenceService {
     from: Date,
     to: Date,
   ): Promise<Task[]> {
+    if (rule.ownerId == null) return [];
+
     const dates = this.computeDates(rule, from, to);
     const created: Task[] = [];
     const hasWorkflowSteps = rule.steps.length > 0;

--- a/apps/api_server/src/services/rhythm_signal_generator_service.test.ts
+++ b/apps/api_server/src/services/rhythm_signal_generator_service.test.ts
@@ -4,6 +4,7 @@ import { setDb } from '../database/db';
 import { runMigrations } from '../database/migrations';
 import { ProjectTemplatesRepository } from '../repositories/project_templates_repository';
 import { TasksRepository } from '../repositories/tasks_repository';
+import { UsersRepository } from '../repositories/users_repository';
 import { ProjectGenerationService } from './project_generation_service';
 import { RhythmSignalGeneratorService } from './rhythm_signal_generator_service';
 
@@ -53,8 +54,16 @@ describe('RhythmSignalGeneratorService', () => {
     const templatesRepo = new ProjectTemplatesRepository();
     const genService = new ProjectGenerationService();
     const generator = new RhythmSignalGeneratorService();
+    const owner = new UsersRepository().create({
+      name: 'Owner',
+      email: 'owner@example.com',
+    });
 
-    const template = templatesRepo.create({ name: 'Easter', anchorType: 'date' });
+    const template = templatesRepo.create({
+      name: 'Easter',
+      anchorType: 'date',
+      ownerId: owner.id,
+    });
     templatesRepo.addStep(template.id, {
       title: 'Print bulletins',
       offsetDays: -3,
@@ -65,7 +74,7 @@ describe('RhythmSignalGeneratorService', () => {
       offsetDays: 30,
       sortOrder: 1,
     });
-    genService.generate(template.id, '2026-04-04', 'Easter 2026');
+    genService.generate(template.id, '2026-04-04', 'Easter 2026', owner.id);
 
     const signals = generator.generateProjectStepDueSignals(7);
 

--- a/apps/api_server/src/services/weekly_planning_service.ts
+++ b/apps/api_server/src/services/weekly_planning_service.ts
@@ -53,7 +53,7 @@ export class WeeklyPlanningService {
   private readonly tasksRepo = new TasksRepository();
   private readonly projectInstancesRepo = new ProjectInstancesRepository();
 
-  async assemblePlan(weekLabel: string, userId?: number): Promise<WeeklyPlan> {
+  async assemblePlan(weekLabel: string, userId: number): Promise<WeeklyPlan> {
     const weekStart = parseWeekLabel(weekLabel);
     const weekEnd = new Date(weekStart);
     weekEnd.setUTCDate(weekStart.getUTCDate() + 6);
@@ -82,6 +82,7 @@ export class WeeklyPlanningService {
     const dueProjectSteps = await this.projectInstancesRepo.findPlannerStepsDueInRangeAsync(
       startStr,
       endStr,
+      userId,
     );
 
     for (const task of dueProjectSteps) {
@@ -140,11 +141,11 @@ export class WeeklyPlanningService {
     const backlog = await this.tasksRepo.findBacklogAsync(startStr, userId);
 
     backlog.push(
-      ...(await this.projectInstancesRepo.findPlannerOpenStepsWithoutDueDateAsync()),
+      ...(await this.projectInstancesRepo.findPlannerOpenStepsWithoutDueDateAsync(userId)),
     );
 
     backlog.push(
-      ...(await this.projectInstancesRepo.findPlannerOpenStepsBeforeDateAsync(startStr)),
+      ...(await this.projectInstancesRepo.findPlannerOpenStepsBeforeDateAsync(startStr, userId)),
     );
 
     for (const day of days) {


### PR DESCRIPTION
## Summary

- Require explicit user scope for task, project template, project instance, and recurring rule reads — `userId` is now non-optional on `findAll`/`findAllAsync`
- Add `findAllIncludingLegacyAsync()` / `findAllUnscoped()` internal methods so callers can't accidentally omit scope and expose data
- Prevent null-owned recurring rules from generating tasks via `findEnabledForGenerationAsync()`
- Scope weekly project-step planning queries by owner/collaborator
- Tighten collaborator endpoints and automation project generation around owned data
- Replace `req.auth?.user.id` with `req.auth!.user.id` throughout controllers — auth middleware guarantees the user is present

## Why this is safe to merge

Clean cherry-pick of the one new commit from draft PR #257, rebased directly onto `main`. All 99 tests pass.

## Test plan

- [x] `npm test` in `apps/api_server` — 99/99 passing
- [ ] Confirm tasks, rhythms, projects, and templates return only the authenticated user's data
- [ ] Confirm the recurrence job no longer processes null-owner rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)