### PR TITLE
fix: add missing sequential column to Postgres recurring_task_rules

### DIFF
--- a/apps/api_server/src/database/postgres_bootstrap.ts
+++ b/apps/api_server/src/database/postgres_bootstrap.ts
@@ -43,6 +43,7 @@ export async function runPostgresBootstrap(pool: Pool): Promise<void> {
       month INTEGER,
       steps_json TEXT NOT NULL DEFAULT '[]',
       enabled BOOLEAN NOT NULL DEFAULT TRUE,
+      sequential BOOLEAN NOT NULL DEFAULT FALSE,
       owner_id INTEGER REFERENCES users(id),
       created_at TEXT NOT NULL DEFAULT (${UTC_TEXT_NOW})
     );
@@ -303,6 +304,7 @@ export async function runPostgresBootstrap(pool: Pool): Promise<void> {
 
     ALTER TABLE recurring_task_rules ADD COLUMN IF NOT EXISTS steps_json TEXT NOT NULL DEFAULT '[]';
     ALTER TABLE recurring_task_rules ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT TRUE;
+    ALTER TABLE recurring_task_rules ADD COLUMN IF NOT EXISTS sequential BOOLEAN NOT NULL DEFAULT FALSE;
     ALTER TABLE recurring_task_rules ADD COLUMN IF NOT EXISTS owner_id INTEGER REFERENCES users(id);
 
     ALTER TABLE project_templates ADD COLUMN IF NOT EXISTS owner_id INTEGER REFERENCES users(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary

- The `sequential` column on `recurring_task_rules` was only added in the SQLite migration path (`migrations.ts`) but was never included in `postgres_bootstrap.ts`
- Every `POST /recurring-rules` on the production Postgres server failed with a column-not-found error → 500 "Internal server error"
- UPDATE (`PATCH /recurring-rules/:id`) would also fail for the same reason

## Changes

- Added `sequential BOOLEAN NOT NULL DEFAULT FALSE` to the `CREATE TABLE recurring_task_rules` definition in `postgres_bootstrap.ts` (for fresh Postgres installs)
- Added `ALTER TABLE recurring_task_rules ADD COLUMN IF NOT EXISTS sequential BOOLEAN NOT NULL DEFAULT FALSE` to the idempotent migrations block (for existing Postgres databases — will run on next server restart)

## Test plan

- [ ] Restart the production API server (triggers the `ADD COLUMN IF NOT EXISTS` migration)
- [ ] Create a new rhythm in the Flutter app — should succeed without error
- [ ] Confirm the rhythm appears in the list with `sequential` defaulting to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)