### PR TITLE
fix: project instance 404, HTML entity decoding, manual task ordering

### DIFF
--- a/apps/api_server/src/controllers/project_generation_controller.ts
+++ b/apps/api_server/src/controllers/project_generation_controller.ts
@@ -32,6 +32,30 @@ export class ProjectGenerationController {
     }
   }
 
+  async createInstance(req: Request, res: Response, next: NextFunction) {
+    try {
+      const { templateId, anchorDate, name } = req.body as Record<string, unknown>;
+      if (!templateId || typeof templateId !== 'string') {
+        throw AppError.badRequest('templateId is required');
+      }
+      if (!anchorDate || typeof anchorDate !== 'string') {
+        throw AppError.badRequest('anchorDate (YYYY-MM-DD) is required');
+      }
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(anchorDate)) {
+        throw AppError.badRequest('anchorDate must be in YYYY-MM-DD format');
+      }
+      const instance = await service.generateAsync(
+        templateId,
+        anchorDate,
+        typeof name === 'string' ? name : null,
+        req.auth!.user.id,
+      );
+      res.status(201).json(instance);
+    } catch (err) {
+      next(err);
+    }
+  }
+
   async getAllInstances(req: Request, res: Response, next: NextFunction) {
     try {
       const { templateId } = req.query as Record<string, string>;

--- a/apps/api_server/src/routes/project_instances_routes.ts
+++ b/apps/api_server/src/routes/project_instances_routes.ts
@@ -8,6 +8,7 @@ export const projectInstancesRouter = Router();
 projectInstancesRouter.use(requireAuth);
 
 projectInstancesRouter.get('/', controller.getAllInstances.bind(controller));
+projectInstancesRouter.post('/', controller.createInstance.bind(controller));
 projectInstancesRouter.patch('/steps/:stepId', controller.updateInstanceStep.bind(controller));
 projectInstancesRouter.delete('/:id', controller.deleteInstance.bind(controller));
 projectInstancesRouter.get('/:id/collaborators', controller.getCollaborators.bind(controller));

--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -1022,7 +1022,16 @@ class _DayColumnState extends State<_DayColumn> {
                         .where(
                           (t) => t.sourceType != 'calendar_shadow_event',
                         )
-                        .toList();
+                        .toList()
+                      ..sort((a, b) {
+                        final aOrder = a.scheduledOrder ?? 10000000;
+                        final bOrder = b.scheduledOrder ?? 10000000;
+                        final cmp = aOrder.compareTo(bOrder);
+                        if (cmp != 0) return cmp;
+                        return a.title.toLowerCase().compareTo(
+                              b.title.toLowerCase(),
+                            );
+                      });
 
                     final hasContent = allDayEvents.isNotEmpty ||
                         timedEvents.isNotEmpty ||

--- a/apps/mcp_server/src/api_client.ts
+++ b/apps/mcp_server/src/api_client.ts
@@ -73,6 +73,17 @@ export async function apiDelete(
   }
 }
 
+/** Decode HTML entities that the model may inject into tool call arguments (e.g. & → &amp;). */
+export function decodeHtml(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
 /** Convenience: wraps a tool handler so errors always return isError content. */
 export function toolResult(text: string) {
   return { content: [{ type: 'text' as const, text }] };

--- a/apps/mcp_server/src/tools/facilities.ts
+++ b/apps/mcp_server/src/tools/facilities.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { apiGet, apiPost, toolResult, toolError } from '../api_client.js';
+import { apiGet, apiPost, toolResult, toolError, decodeHtml } from '../api_client.js';
 import { registerTool } from './_tool.js';
 
 export function registerFacilityTools(server: McpServer, apiUrl: string, apiToken: string) {
@@ -30,11 +30,11 @@ export function registerFacilityTools(server: McpServer, apiUrl: string, apiToke
     async ({ facility_id, title, requester_name, start_time, end_time, notes }: { facility_id: number; title: string; requester_name: string; start_time: string; end_time: string; notes?: string }) => {
       try {
         const reservation = await apiPost<unknown>(apiUrl, apiToken, `/facilities/${facility_id}/reservations`, {
-          title,
-          requesterName: requester_name,
+          title: decodeHtml(title),
+          requesterName: decodeHtml(requester_name),
           startTime: start_time,
           endTime: end_time,
-          ...(notes !== undefined && { notes }),
+          ...(notes !== undefined && { notes: decodeHtml(notes) }),
         });
         return toolResult(JSON.stringify(reservation, null, 2));
       } catch (err) {

--- a/apps/mcp_server/src/tools/messages.ts
+++ b/apps/mcp_server/src/tools/messages.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { apiGet, apiPost, toolResult, toolError } from '../api_client.js';
+import { apiGet, apiPost, toolResult, toolError, decodeHtml } from '../api_client.js';
 import { registerTool } from './_tool.js';
 
 export function registerMessageTools(server: McpServer, apiUrl: string, apiToken: string) {
@@ -30,7 +30,7 @@ export function registerMessageTools(server: McpServer, apiUrl: string, apiToken
     async ({ title, participant_ids, thread_type }: { title: string; participant_ids?: number[]; thread_type?: string }) => {
       try {
         const thread = await apiPost<unknown>(apiUrl, apiToken, '/message-threads', {
-          title,
+          title: decodeHtml(title),
           ...(participant_ids !== undefined && { participantIds: participant_ids }),
           ...(thread_type !== undefined && { threadType: thread_type }),
         });
@@ -49,7 +49,7 @@ export function registerMessageTools(server: McpServer, apiUrl: string, apiToken
     },
     async ({ thread_id, body }: { thread_id: number; body: string }) => {
       try {
-        const message = await apiPost<unknown>(apiUrl, apiToken, `/message-threads/${thread_id}/messages`, { body });
+        const message = await apiPost<unknown>(apiUrl, apiToken, `/message-threads/${thread_id}/messages`, { body: decodeHtml(body) });
         return toolResult(JSON.stringify(message, null, 2));
       } catch (err) {
         return toolError(err);

--- a/apps/mcp_server/src/tools/projects.ts
+++ b/apps/mcp_server/src/tools/projects.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { apiGet, apiPost, apiPatch, toolResult, toolError } from '../api_client.js';
+import { apiGet, apiPost, apiPatch, toolResult, toolError, decodeHtml } from '../api_client.js';
 import { registerTool } from './_tool.js';
 
 export function registerProjectTools(server: McpServer, apiUrl: string, apiToken: string) {
@@ -26,8 +26,8 @@ export function registerProjectTools(server: McpServer, apiUrl: string, apiToken
     async ({ name, description }: { name: string; description?: string }) => {
       try {
         const template = await apiPost<unknown>(apiUrl, apiToken, '/project-templates', {
-          name,
-          ...(description !== undefined && { description }),
+          name: decodeHtml(name),
+          ...(description !== undefined && { description: decodeHtml(description) }),
         });
         return toolResult(JSON.stringify(template, null, 2));
       } catch (err) {
@@ -48,9 +48,9 @@ export function registerProjectTools(server: McpServer, apiUrl: string, apiToken
     async ({ template_id, title, offset_days, offset_description, sort_order }: { template_id: string; title: string; offset_days: number; offset_description?: string; sort_order?: number }) => {
       try {
         const step = await apiPost<unknown>(apiUrl, apiToken, `/project-templates/${template_id}/steps`, {
-          title,
+          title: decodeHtml(title),
           offsetDays: offset_days,
-          ...(offset_description !== undefined && { offsetDescription: offset_description }),
+          ...(offset_description !== undefined && { offsetDescription: decodeHtml(offset_description) }),
           ...(sort_order !== undefined && { sortOrder: sort_order }),
         });
         return toolResult(JSON.stringify(step, null, 2));
@@ -72,7 +72,7 @@ export function registerProjectTools(server: McpServer, apiUrl: string, apiToken
         const instance = await apiPost<unknown>(apiUrl, apiToken, '/project-instances', {
           templateId: template_id,
           anchorDate: anchor_date,
-          ...(name !== undefined && { name }),
+          ...(name !== undefined && { name: decodeHtml(name) }),
         });
         return toolResult(JSON.stringify(instance, null, 2));
       } catch (err) {

--- a/apps/mcp_server/src/tools/rhythms.ts
+++ b/apps/mcp_server/src/tools/rhythms.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { apiGet, apiPost, apiPatch, apiDelete, toolResult, toolError } from '../api_client.js';
+import { apiGet, apiPost, apiPatch, apiDelete, toolResult, toolError, decodeHtml } from '../api_client.js';
 import { registerTool } from './_tool.js';
 
 export function registerRhythmTools(server: McpServer, apiUrl: string, apiToken: string) {
@@ -32,7 +32,7 @@ export function registerRhythmTools(server: McpServer, apiUrl: string, apiToken:
     async ({ title, frequency, day_of_week, day_of_month, month }: { title: string; frequency: string; day_of_week?: string; day_of_month?: number; month?: number }) => {
       try {
         const rhythm = await apiPost<unknown>(apiUrl, apiToken, '/recurring-rules', {
-          title,
+          title: decodeHtml(title),
           frequency,
           ...(day_of_week !== undefined && { dayOfWeek: day_of_week }),
           ...(day_of_month !== undefined && { dayOfMonth: day_of_month }),
@@ -59,7 +59,7 @@ export function registerRhythmTools(server: McpServer, apiUrl: string, apiToken:
     async ({ id, title, frequency, day_of_week, day_of_month, month, enabled }: { id: string; title?: string; frequency?: string; day_of_week?: string; day_of_month?: number | null; month?: number | null; enabled?: boolean }) => {
       try {
         const body: Record<string, unknown> = {};
-        if (title !== undefined) body.title = title;
+        if (title !== undefined) body.title = decodeHtml(title);
         if (frequency !== undefined) body.frequency = frequency;
         if (day_of_week !== undefined) body.dayOfWeek = day_of_week;
         if (day_of_month !== undefined) body.dayOfMonth = day_of_month;

--- a/apps/mcp_server/src/tools/tasks.ts
+++ b/apps/mcp_server/src/tools/tasks.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { apiGet, apiPost, apiPatch, apiDelete, toolResult, toolError } from '../api_client.js';
+import { apiGet, apiPost, apiPatch, apiDelete, toolResult, toolError, decodeHtml } from '../api_client.js';
 import { registerTool } from './_tool.js';
 
 export function registerTaskTools(server: McpServer, apiUrl: string, apiToken: string) {
@@ -36,8 +36,8 @@ export function registerTaskTools(server: McpServer, apiUrl: string, apiToken: s
     async ({ title, notes, due_date }: { title: string; notes?: string; due_date?: string }) => {
       try {
         const task = await apiPost<unknown>(apiUrl, apiToken, '/tasks', {
-          title,
-          ...(notes !== undefined && { notes }),
+          title: decodeHtml(title),
+          ...(notes !== undefined && { notes: decodeHtml(notes) }),
           ...(due_date !== undefined && { dueDate: due_date }),
         });
         return toolResult(JSON.stringify(task, null, 2));
@@ -59,8 +59,8 @@ export function registerTaskTools(server: McpServer, apiUrl: string, apiToken: s
     async ({ id, title, notes, due_date, status }: { id: string; title?: string; notes?: string; due_date?: string | null; status?: string }) => {
       try {
         const body: Record<string, unknown> = {};
-        if (title !== undefined) body.title = title;
-        if (notes !== undefined) body.notes = notes;
+        if (title !== undefined) body.title = decodeHtml(title);
+        if (notes !== undefined) body.notes = decodeHtml(notes);
         if (due_date !== undefined) body.dueDate = due_date;
         if (status !== undefined) body.status = status;
         const task = await apiPatch<unknown>(apiUrl, apiToken, `/tasks/${id}`, body);


### PR DESCRIPTION
## Summary

- **Project instance 404** — added `POST /project-instances` direct create endpoint (#235)
- **HTML entity decoding** — decode HTML entities in MCP tool string arguments (#234 / d1bba3e)
- **Manual task ordering** — sort Weekly Planner day-column tasks by `scheduledOrder`; the up/down reorder buttons and controller logic were already in place, this makes them visually effective (#237 / 177f9c1)

## Test plan

- [ ] Create a project instance directly via the API and confirm it returns 200 instead of 404
- [ ] Send a tool call with HTML-encoded characters (e.g. `&amp;`, `&lt;`) and confirm they are decoded before reaching the handler
- [ ] In the Weekly Planner, schedule multiple tasks to the same day, use the up/down buttons to reorder them, and confirm the new order persists after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)