### PR TITLE
feat: Weekly Planner task cards wrap titles + intra-column drag reorder

### DIFF
--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -937,17 +937,23 @@ class _DayColumnState extends State<_DayColumn> {
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.stretch,
                               children: [
-                                ...regularTasks.map(
-                                  (task) => Padding(
-                                    padding: const EdgeInsets.only(top: 6),
-                                    child: _TaskTile(
-                                      task: task,
-                                      controller: widget.controller,
-                                      draggable: true,
-                                      compact: true,
+                                for (var i = 0; i < regularTasks.length; i++)
+                                  _TaskReorderTarget(
+                                    task: regularTasks[i],
+                                    previousTask:
+                                        i > 0 ? regularTasks[i - 1] : null,
+                                    columnDate: widget.date,
+                                    controller: widget.controller,
+                                    child: Padding(
+                                      padding: const EdgeInsets.only(top: 6),
+                                      child: _TaskTile(
+                                        task: regularTasks[i],
+                                        controller: widget.controller,
+                                        draggable: true,
+                                        compact: true,
+                                      ),
                                     ),
                                   ),
-                                ),
                                 addButton,
                               ],
                             ),
@@ -1019,8 +1025,6 @@ class _TaskTile extends StatelessWidget {
           ),
           child: Text(
             task.title,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
             style: Theme.of(context)
                 .textTheme
                 .bodySmall
@@ -1052,7 +1056,7 @@ class _TaskTile extends StatelessWidget {
             margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
             padding: EdgeInsets.symmetric(
               horizontal: compact ? 8 : 10,
-              vertical: compact ? 8 : 5,
+              vertical: compact ? 6 : 4,
             ),
             decoration: BoxDecoration(
               color: isSelected || isMultiSelected
@@ -1069,7 +1073,7 @@ class _TaskTile extends StatelessWidget {
                   : const [],
             ),
             child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 if (isShadowEvent)
                   Container(
@@ -1119,8 +1123,6 @@ class _TaskTile extends StatelessWidget {
                         ),
                       Text(
                         task.title,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
                         style: (compact
                                 ? Theme.of(context).textTheme.labelSmall
                                 : Theme.of(context).textTheme.bodySmall)
@@ -1132,29 +1134,12 @@ class _TaskTile extends StatelessWidget {
                               : _plannerTextColor(context, visualStyle),
                           fontSize: compact ? 11 : null,
                           fontWeight: FontWeight.w700,
-                          height: compact ? 1.18 : 1.25,
+                          height: compact ? 1.25 : 1.3,
                         ),
                       ),
                     ],
                   ),
                 ),
-                if (!isShadowEvent && compact) ...[
-                  const SizedBox(width: 6),
-                  Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      _MiniMoveButton(
-                        icon: Icons.keyboard_arrow_up,
-                        onPressed: () => controller.moveTaskEarlier(task),
-                      ),
-                      const SizedBox(height: 4),
-                      _MiniMoveButton(
-                        icon: Icons.keyboard_arrow_down,
-                        onPressed: () => controller.moveTaskLater(task),
-                      ),
-                    ],
-                  ),
-                ],
                 if (isMultiSelected && !compact) ...[
                   const SizedBox(width: 6),
                   Icon(Icons.done_all, size: 14, color: colors.accent),
@@ -1662,28 +1647,83 @@ class _DetailPaneState extends State<_DetailPane> {
 // Shared
 // ---------------------------------------------------------------------------
 
-class _MiniMoveButton extends StatelessWidget {
-  const _MiniMoveButton({required this.icon, required this.onPressed});
+// ---------------------------------------------------------------------------
+// Per-tile drop zone — shows an accent indicator on hover and re-positions
+// the dragged task above this tile by computing a midpoint scheduledOrder
+// between the previous task and this one.
+// ---------------------------------------------------------------------------
 
-  final IconData icon;
-  final VoidCallback onPressed;
+class _TaskReorderTarget extends StatelessWidget {
+  const _TaskReorderTarget({
+    required this.task,
+    required this.previousTask,
+    required this.columnDate,
+    required this.controller,
+    required this.child,
+  });
+
+  final Task task;
+  final Task? previousTask;
+  final String columnDate;
+  final WeeklyPlannerController controller;
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.rhythm;
-    return InkWell(
-      onTap: onPressed,
-      borderRadius: BorderRadius.circular(RhythmRadius.pill),
-      child: Container(
-        width: 18,
-        height: 18,
-        decoration: BoxDecoration(
-          color: colors.surfaceMuted,
-          borderRadius: BorderRadius.circular(RhythmRadius.pill),
-          border: Border.all(color: colors.borderSubtle),
-        ),
-        child: Icon(icon, size: 12, color: colors.textSecondary),
-      ),
+    return DragTarget<Task>(
+      onWillAcceptWithDetails: (details) {
+        final dragged = details.data;
+        if (dragged.id == task.id) return false;
+        if (dragged.id == previousTask?.id) return false;
+        return true;
+      },
+      onAcceptWithDetails: (details) {
+        final dragged = details.data;
+        final targetOrder = task.scheduledOrder ?? 10000000;
+        final previousOrder =
+            previousTask?.scheduledOrder ?? (targetOrder - 10000);
+        final newOrder = ((previousOrder + targetOrder) / 2).round();
+        final isProjectStep = dragged.sourceType == 'project_step';
+        if (isProjectStep) {
+          controller.updateTask(
+            dragged,
+            dueDate: columnDate,
+            scheduledOrder: newOrder,
+          );
+        } else if (dragged.dueDate == null && dragged.scheduledDate == null) {
+          // Coming from backlog — set both dates so it lives on this day.
+          controller.updateTask(
+            dragged,
+            dueDate: columnDate,
+            scheduledDate: columnDate,
+            scheduledOrder: newOrder,
+          );
+        } else {
+          controller.updateTask(
+            dragged,
+            scheduledDate: columnDate,
+            scheduledOrder: newOrder,
+          );
+        }
+      },
+      builder: (context, candidates, _) {
+        final hovering = candidates.isNotEmpty;
+        return Column(
+          children: [
+            AnimatedContainer(
+              duration: const Duration(milliseconds: 100),
+              height: hovering ? 2 : 0,
+              margin: const EdgeInsets.symmetric(horizontal: 8),
+              decoration: BoxDecoration(
+                color: hovering ? colors.accent : Colors.transparent,
+                borderRadius: BorderRadius.circular(RhythmRadius.pill),
+              ),
+            ),
+            child,
+          ],
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- **Title wraps unbounded** in the Weekly Planner task card — no more truncation. Card grows with content; titles never get cut off.
- **Tighter compact padding** (vertical 8 → 6) and the inner row now top-aligns so the checkbox sits next to the first line of multi-line titles instead of floating to the middle.
- **Removed the non-functional up/down move buttons** from compact tiles. The detail pane "Move earlier/later" controls remain.
- **Drag-and-drop reordering within a column** — dropping a task on another tile inserts it above that tile via a midpoint `scheduledOrder`. A thin accent indicator appears above the target on hover. Cross-column drag (the existing column-level drop target) still appends to end. Backlog→position and project_step→position are handled with the same date semantics as the existing `scheduleTask` flow.

## Test plan
- [ ] Open Weekly Planner. Tasks with long titles wrap to multiple lines; checkbox stays at the top of the card.
- [ ] Drag a task within the same day — drop onto another tile and verify the dragged task moves above the target. Drop on empty space below the list and verify it appends to the end.
- [ ] Drag a task from one day column to another day tile — verify it lands at that position with the new `scheduledDate`.
- [ ] Drag a task from the backlog onto a day tile — verify it lands at that position and now lives on that day.
- [ ] Drag the immediately-above tile onto the tile below it — verify it is a no-op (no flicker, no spurious order change).
- [ ] Confirm the up/down chevron buttons are gone from compact cards. Inspector still has Move earlier / Move later buttons that work.
- [ ] Calendar event pills (top events bar) are unaffected; reordering does not apply to them.
