### PR TITLE
feat: Claude as Rhythm Workspace Collaborator

### DIFF
--- a/apps/api_server/.env.production.example
+++ b/apps/api_server/.env.production.example
@@ -21,3 +21,6 @@ PCO_REDIRECT_URI=https://api.vcrcapps.com/auth/planning-center/callback
 
 TUNNEL_TOKEN=your-cloudflare-tunnel-token
 SQLITE_MIGRATION_PATH=/data/rhythm.db
+
+RESEND_API_KEY=re_your_actual_key_here
+EMAIL_FROM_ADDRESS=Rhythm <notifications@vcrcapps.com>

--- a/apps/api_server/src/__tests__/auth_and_messaging.test.ts
+++ b/apps/api_server/src/__tests__/auth_and_messaging.test.ts
@@ -1,5 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import Database from 'better-sqlite3';
+import { createApp } from '../app';
 import { runMigrations } from '../database/migrations';
 import { setDb } from '../database/db';
 import { AuthService } from '../services/auth_service';
@@ -10,6 +13,11 @@ import { UsersRepository } from '../repositories/users_repository';
 import { MessagesRepository } from '../repositories/messages_repository';
 import { ProjectInstancesRepository } from '../repositories/project_instances_repository';
 import { ProjectTemplatesRepository } from '../repositories/project_templates_repository';
+
+async function readJson(response: Response) {
+  const text = await response.text();
+  return text ? JSON.parse(text) : null;
+}
 
 function makeDb() {
   const db = new Database(':memory:');
@@ -256,5 +264,81 @@ describe('Auth and ownership flows', () => {
     expect(first.email).toBe('rhythm-bot@rhythm.local');
     expect(first.role).toBe('system');
     expect(second.id).toBe(first.id);
+  });
+});
+
+describe('Message threads task_id API', () => {
+  let usersRepo: UsersRepository;
+  let sessionsRepo: SessionsRepository;
+  let tasksRepo: TasksRepository;
+  let baseUrl: string;
+  let closeServer: () => Promise<void>;
+
+  beforeEach(async () => {
+    setDb(makeDb());
+    usersRepo = new UsersRepository();
+    sessionsRepo = new SessionsRepository();
+    tasksRepo = new TasksRepository();
+
+    const server = createApp().listen(0);
+    await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+    closeServer = () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+  });
+
+  afterEach(async () => {
+    await closeServer();
+  });
+
+  async function authHeaderFor(userId: number) {
+    const session = await sessionsRepo.createAsync(userId);
+    return { Authorization: `Bearer ${session.token}` };
+  }
+
+  it('persists task_id on message_threads when provided', async () => {
+    const owner = usersRepo.create({ name: 'Owner', email: 'owner@x.com' });
+    const claude = usersRepo.create({ name: 'Claude', email: 'claude@x.com' });
+    const task = tasksRepo.create({ title: 'Fix bug', ownerId: owner.id });
+
+    const headers = await authHeaderFor(owner.id);
+    const res = await fetch(`${baseUrl}/message-threads`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        participantIds: [owner.id, claude.id],
+        threadType: 'direct',
+        taskId: task.id,
+      }),
+    });
+    const thread = await readJson(res);
+    expect(res.status).toBe(201);
+    expect(thread.taskId).toBe(task.id);
+  });
+
+  it('GET /message-threads?task_id=X returns only the thread linked to that task', async () => {
+    const owner = usersRepo.create({ name: 'Owner2', email: 'owner2@x.com' });
+    const claude = usersRepo.create({ name: 'Claude2', email: 'claude2@x.com' });
+    const task = tasksRepo.create({ title: 'T', ownerId: owner.id });
+
+    const headers = await authHeaderFor(owner.id);
+    await fetch(`${baseUrl}/message-threads`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ participantIds: [owner.id, claude.id], threadType: 'direct', taskId: task.id }),
+    });
+    await fetch(`${baseUrl}/message-threads`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ participantIds: [owner.id, claude.id], threadType: 'direct', title: 'Unrelated' }),
+    });
+
+    const res = await fetch(`${baseUrl}/message-threads?task_id=${task.id}`, { headers });
+    const threads = await readJson(res);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].taskId).toBe(task.id);
   });
 });

--- a/apps/api_server/src/__tests__/claude_triggers.test.ts
+++ b/apps/api_server/src/__tests__/claude_triggers.test.ts
@@ -89,4 +89,59 @@ describe('Claude triggers endpoints', () => {
     const remaining = getDb().prepare(`SELECT COUNT(*) AS c FROM pending_claude_triggers`).get() as { c: number };
     expect(remaining.c).toBe(0);
   });
+
+  it('writes a pending trigger when Claude is added as a collaborator', async () => {
+    const owner = usersRepo.create({ name: 'O', email: 'o3@x.com' });
+    const task = tasksRepo.create({ title: 'Trigger me', ownerId: owner.id });
+
+    const headers = await authHeaderFor(owner.id);
+    const res = await fetch(`${baseUrl}/tasks/${task.id}/collaborators`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: claudeId }),
+    });
+    expect(res.status).toBe(201);
+
+    const triggers = getDb().prepare(`SELECT * FROM pending_claude_triggers`).all() as any[];
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].task_id).toBe(task.id);
+    expect(triggers[0].triggered_by_user_id).toBe(owner.id);
+  });
+
+  it('does NOT write a trigger when a non-Claude collaborator is added', async () => {
+    const owner = usersRepo.create({ name: 'O', email: 'o4@x.com' });
+    const other = usersRepo.create({ name: 'X', email: 'x@x.com' });
+    const task = tasksRepo.create({ title: 'No trigger', ownerId: owner.id });
+
+    const headers = await authHeaderFor(owner.id);
+    await fetch(`${baseUrl}/tasks/${task.id}/collaborators`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: other.id }),
+    });
+
+    const triggers = getDb().prepare(`SELECT * FROM pending_claude_triggers`).all() as any[];
+    expect(triggers).toHaveLength(0);
+  });
+
+  it('repeated add/remove/add of Claude produces only one trigger row', async () => {
+    const owner = usersRepo.create({ name: 'O', email: 'o5@x.com' });
+    const task = tasksRepo.create({ title: 'Idempotent', ownerId: owner.id });
+    const headers = await authHeaderFor(owner.id);
+
+    await fetch(`${baseUrl}/tasks/${task.id}/collaborators`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: claudeId }),
+    });
+    await fetch(`${baseUrl}/tasks/${task.id}/collaborators/${claudeId}`, { method: 'DELETE', headers });
+    await fetch(`${baseUrl}/tasks/${task.id}/collaborators`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: claudeId }),
+    });
+
+    const triggers = getDb().prepare(`SELECT * FROM pending_claude_triggers WHERE task_id = ?`).all(task.id) as any[];
+    expect(triggers).toHaveLength(1);
+  });
 });

--- a/apps/api_server/src/__tests__/claude_triggers.test.ts
+++ b/apps/api_server/src/__tests__/claude_triggers.test.ts
@@ -1,0 +1,92 @@
+import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { createApp } from '../app';
+import { runMigrations } from '../database/migrations';
+import { setDb, getDb } from '../database/db';
+import { SessionsRepository } from '../repositories/sessions_repository';
+import { TasksRepository } from '../repositories/tasks_repository';
+import { UsersRepository } from '../repositories/users_repository';
+import { env } from '../config/env';
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  return db;
+}
+
+describe('Claude triggers endpoints', () => {
+  let usersRepo: UsersRepository;
+  let sessionsRepo: SessionsRepository;
+  let tasksRepo: TasksRepository;
+  let baseUrl: string;
+  let closeServer: () => Promise<void>;
+  let claudeId: number;
+  let originalClaudeUserId: number | null;
+
+  beforeEach(async () => {
+    setDb(makeDb());
+    usersRepo = new UsersRepository();
+    sessionsRepo = new SessionsRepository();
+    tasksRepo = new TasksRepository();
+
+    const claude = usersRepo.create({ name: 'Claude', email: 'claude@x.com' });
+    claudeId = claude.id;
+    originalClaudeUserId = env.claudeUserId;
+    (env as any).claudeUserId = claudeId;
+
+    const server = createApp().listen(0);
+    await new Promise<void>((r) => server.once('listening', () => r()));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    closeServer = () => new Promise<void>((res, rej) => server.close((e) => e ? rej(e) : res()));
+  });
+
+  afterEach(async () => {
+    (env as any).claudeUserId = originalClaudeUserId;
+    await closeServer();
+  });
+
+  async function authHeaderFor(userId: number) {
+    const session = await sessionsRepo.createAsync(userId);
+    return { Authorization: `Bearer ${session.token}` };
+  }
+
+  it('returns 403 for non-claude users', async () => {
+    const u = usersRepo.create({ name: 'U', email: 'u@x.com' });
+    const headers = await authHeaderFor(u.id);
+    const res = await fetch(`${baseUrl}/claude-triggers`, { headers });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns the queue for claude user', async () => {
+    const owner = usersRepo.create({ name: 'O', email: 'o@x.com' });
+    const task = tasksRepo.create({ title: 'Test task', ownerId: owner.id });
+    getDb().prepare(`INSERT INTO pending_claude_triggers (task_id, triggered_by_user_id) VALUES (?, ?)`)
+      .run(task.id, owner.id);
+
+    const headers = await authHeaderFor(claudeId);
+    const res = await fetch(`${baseUrl}/claude-triggers`, { headers });
+    expect(res.status).toBe(200);
+    const triggers = await res.json() as Array<{ taskId: string; taskTitle: string }>;
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].taskId).toBe(task.id);
+    expect(triggers[0].taskTitle).toBe('Test task');
+  });
+
+  it('deletes a trigger', async () => {
+    const owner = usersRepo.create({ name: 'O', email: 'o2@x.com' });
+    const task = tasksRepo.create({ title: 'T', ownerId: owner.id });
+    getDb().prepare(`INSERT INTO pending_claude_triggers (task_id) VALUES (?)`)
+      .run(task.id);
+    const r = getDb().prepare(`SELECT id FROM pending_claude_triggers WHERE task_id = ?`)
+      .get(task.id) as { id: number };
+
+    const headers = await authHeaderFor(claudeId);
+    const res = await fetch(`${baseUrl}/claude-triggers/${r.id}`, { method: 'DELETE', headers });
+    expect(res.status).toBe(204);
+
+    const remaining = getDb().prepare(`SELECT COUNT(*) AS c FROM pending_claude_triggers`).get() as { c: number };
+    expect(remaining.c).toBe(0);
+  });
+});

--- a/apps/api_server/src/__tests__/tasks_permissions.test.ts
+++ b/apps/api_server/src/__tests__/tasks_permissions.test.ts
@@ -140,4 +140,34 @@ describe('Tasks permissions', () => {
     const collaboratorTasks = await readJson(collaboratorListResponse) as Array<{ id: string }>;
     expect(collaboratorTasks.map((visibleTask) => visibleTask.id)).toEqual([task.id]);
   });
+
+  it('accepts in_progress and waiting_for_reply as valid task statuses', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u@x.com' });
+    const task = tasksRepo.create({ title: 'T', ownerId: user.id });
+    const headers = await authHeaderFor(user.id);
+
+    for (const status of ['in_progress', 'waiting_for_reply', 'done']) {
+      const res = await fetch(`${baseUrl}/tasks/${task.id}`, {
+        method: 'PATCH',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      expect(res.status).toBe(200);
+      const updated = await readJson(res);
+      expect(updated.status).toBe(status);
+    }
+  });
+
+  it('rejects invalid task status values', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u2@x.com' });
+    const task = tasksRepo.create({ title: 'T', ownerId: user.id });
+    const headers = await authHeaderFor(user.id);
+
+    const res = await fetch(`${baseUrl}/tasks/${task.id}`, {
+      method: 'PATCH',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'bogus' }),
+    });
+    expect(res.status).toBe(400);
+  });
 });

--- a/apps/api_server/src/app.ts
+++ b/apps/api_server/src/app.ts
@@ -19,6 +19,7 @@ import { usersRouter } from './routes/users_routes';
 import { weeklyPlanRouter } from './routes/weekly_plan_routes';
 import { workspaceRouter } from './routes/workspace_routes';
 import { notificationsRouter } from './routes/notifications_routes';
+import claudeTriggersRouter from './routes/claude_triggers_routes';
 
 export function createApp() {
   const app = express();
@@ -58,6 +59,7 @@ export function createApp() {
   app.use('/facilities', facilitiesRouter);
   app.use('/workspaces', workspaceRouter);
   app.use('/notifications', notificationsRouter);
+  app.use('/claude-triggers', claudeTriggersRouter);
 
   app.use(errorHandler);
 

--- a/apps/api_server/src/config/env.ts
+++ b/apps/api_server/src/config/env.ts
@@ -65,4 +65,14 @@ export const env = {
       .split(',')
       .map((value) => value.trim().toLowerCase())
       .filter((value) => value.length > 0),
+  claudeUserId: (() => {
+    const raw = process.env.CLAUDE_USER_ID;
+    if (!raw) return null;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed)) {
+      console.warn(`[env] CLAUDE_USER_ID="${raw}" is not a valid integer — treating as null`);
+      return null;
+    }
+    return parsed;
+  })(),
 };

--- a/apps/api_server/src/controllers/claude_triggers_controller.ts
+++ b/apps/api_server/src/controllers/claude_triggers_controller.ts
@@ -1,0 +1,23 @@
+import type { NextFunction, Request, Response } from 'express';
+import { AppError } from '../errors/app_error';
+import { ClaudeTriggersRepository } from '../repositories/claude_triggers_repository';
+
+const repo = new ClaudeTriggersRepository();
+
+export class ClaudeTriggersController {
+  async list(_req: Request, res: Response, next: NextFunction) {
+    try {
+      res.json(await repo.listAllAsync());
+    } catch (err) { next(err); }
+  }
+
+  async remove(req: Request, res: Response, next: NextFunction) {
+    try {
+      const id = Number(req.params.id);
+      if (!Number.isFinite(id)) throw AppError.badRequest('id must be a number');
+      const ok = await repo.deleteAsync(id);
+      if (!ok) throw AppError.notFound('Trigger');
+      res.status(204).end();
+    } catch (err) { next(err); }
+  }
+}

--- a/apps/api_server/src/controllers/messages_controller.ts
+++ b/apps/api_server/src/controllers/messages_controller.ts
@@ -7,7 +7,8 @@ const repo = new MessagesRepository();
 export class MessagesController {
   async getAllThreads(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(await repo.findAllThreadsForUserAsync(req.auth!.user.id));
+      const taskId = typeof req.query['task_id'] === 'string' ? req.query['task_id'] : undefined;
+      res.json(await repo.findAllThreadsForUserAsync(req.auth!.user.id, taskId != null ? { taskId } : undefined));
     } catch (err) {
       next(err);
     }
@@ -19,9 +20,13 @@ export class MessagesController {
         participantIds,
         threadType,
         title,
+        taskId,
       } = req.body as Record<string, unknown>;
       if (!Array.isArray(participantIds) || participantIds.length === 0) {
         throw AppError.badRequest('participantIds is required');
+      }
+      if (taskId !== undefined && taskId !== null && typeof taskId !== 'string') {
+        throw AppError.badRequest('taskId must be a string when provided');
       }
       const thread = await repo.createThreadAsync({
         createdBy: req.auth!.user.id,
@@ -31,6 +36,7 @@ export class MessagesController {
             ? threadType
             : undefined,
         title: typeof title === 'string' && title.trim() ? title.trim() : undefined,
+        taskId: typeof taskId === 'string' ? taskId : null,
       });
       res.status(201).json(thread);
     } catch (err) {

--- a/apps/api_server/src/controllers/tasks_controller.ts
+++ b/apps/api_server/src/controllers/tasks_controller.ts
@@ -4,6 +4,8 @@ import { TasksRepository } from '../repositories/tasks_repository';
 import { NotificationsRepository } from '../repositories/notifications_repository';
 import { NotificationService } from '../services/notification_service';
 import { RecurringTaskRulesRepository } from '../repositories/recurring_task_rules_repository';
+import { ClaudeTriggersRepository } from '../repositories/claude_triggers_repository';
+import { env } from '../config/env';
 
 const VALID_STATUSES = ['open', 'in_progress', 'waiting_for_reply', 'done'] as const;
 type ValidStatus = (typeof VALID_STATUSES)[number];
@@ -11,6 +13,7 @@ type ValidStatus = (typeof VALID_STATUSES)[number];
 const repo = new TasksRepository();
 const rulesRepo = new RecurringTaskRulesRepository();
 const notifService = new NotificationService(new NotificationsRepository());
+const claudeTriggersRepo = new ClaudeTriggersRepository();
 
 export class TasksController {
   async getAll(req: Request, res: Response, next: NextFunction) {
@@ -156,6 +159,9 @@ export class TasksController {
         userId,
         actorId,
       );
+      if (env.claudeUserId != null && userId === env.claudeUserId) {
+        await claudeTriggersRepo.insertAsync(req.params.id, actorId);
+      }
       res.status(201).json(await repo.listCollaboratorsAsync(req.params.id));
     } catch (err) {
       next(err);

--- a/apps/api_server/src/controllers/tasks_controller.ts
+++ b/apps/api_server/src/controllers/tasks_controller.ts
@@ -5,6 +5,9 @@ import { NotificationsRepository } from '../repositories/notifications_repositor
 import { NotificationService } from '../services/notification_service';
 import { RecurringTaskRulesRepository } from '../repositories/recurring_task_rules_repository';
 
+const VALID_STATUSES = ['open', 'in_progress', 'waiting_for_reply', 'done'] as const;
+type ValidStatus = (typeof VALID_STATUSES)[number];
+
 const repo = new TasksRepository();
 const rulesRepo = new RecurringTaskRulesRepository();
 const notifService = new NotificationService(new NotificationsRepository());
@@ -32,11 +35,14 @@ export class TasksController {
       if (!title || typeof title !== 'string') {
         throw AppError.badRequest('title is required');
       }
+      if (status !== undefined && !VALID_STATUSES.includes(status as ValidStatus)) {
+        throw AppError.badRequest(`status must be one of: ${VALID_STATUSES.join(', ')}`);
+      }
       const task = await repo.createAsync({
         title,
         notes: (notes as string) ?? null,
         dueDate: (dueDate as string) ?? null,
-        status: status as 'open' | 'done',
+        status: status as ValidStatus,
         ownerId: req.auth!.user.id,
       });
       res.status(201).json(task);
@@ -48,14 +54,18 @@ export class TasksController {
   async update(req: Request, res: Response, next: NextFunction) {
     try {
       const actorId = req.auth!.user.id;
+      const data = req.body as Record<string, unknown>;
+
+      if (data.status !== undefined && !VALID_STATUSES.includes(data.status as ValidStatus)) {
+        throw AppError.badRequest(`status must be one of: ${VALID_STATUSES.join(', ')}`);
+      }
+
       const existing = await repo.findByIdAsync(req.params.id, actorId);
       const updated = await repo.updateAsync(
         req.params.id,
-        req.body as Record<string, unknown>,
+        data,
         actorId,
       );
-
-      const data = req.body as Record<string, unknown>;
 
       // Notify on assignment
       if (

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -686,6 +686,10 @@ export function runMigrations(db: Database.Database): void {
   if (!threadColsP7.includes('thread_type')) {
     db.exec(`ALTER TABLE message_threads ADD COLUMN thread_type TEXT NOT NULL DEFAULT 'direct'`);
   }
+  if (!threadColsP7.includes('task_id')) {
+    db.exec(`ALTER TABLE message_threads ADD COLUMN task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL`);
+    db.exec(`CREATE INDEX IF NOT EXISTS idx_message_threads_task_id ON message_threads(task_id)`);
+  }
 
   // Phase 8: step assignees + rhythm collaborators
   const templateStepCols = (db.pragma('table_info(project_template_steps)') as { name: string }[]).map((c) => c.name);
@@ -722,4 +726,16 @@ export function runMigrations(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_notifications_recipient
       ON notifications(recipient_user_id, read_at);
   `);
+
+  // Claude collaborator trigger queue
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pending_claude_triggers (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+      triggered_by_user_id INTEGER REFERENCES users(id),
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE(task_id)
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_pending_claude_triggers_created_at ON pending_claude_triggers(created_at)`);
 }

--- a/apps/api_server/src/database/postgres_bootstrap.ts
+++ b/apps/api_server/src/database/postgres_bootstrap.ts
@@ -406,6 +406,8 @@ export async function runPostgresBootstrap(pool: Pool): Promise<void> {
   await pool.query(`ALTER TABLE tasks ADD COLUMN IF NOT EXISTS workspace_id INTEGER REFERENCES workspaces(id)`);
   await pool.query(`ALTER TABLE messages ADD COLUMN IF NOT EXISTS sender_photo_url TEXT`);
   await pool.query(`ALTER TABLE message_threads ADD COLUMN IF NOT EXISTS thread_type TEXT NOT NULL DEFAULT 'direct'`);
+  await pool.query(`ALTER TABLE message_threads ADD COLUMN IF NOT EXISTS task_id TEXT REFERENCES tasks(id) ON DELETE SET NULL`);
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_message_threads_task_id ON message_threads(task_id)`);
 
   // Phase 8: step assignees + rhythm collaborators
   await pool.query(`ALTER TABLE project_template_steps ADD COLUMN IF NOT EXISTS assignee_id INTEGER REFERENCES users(id) ON DELETE SET NULL`);
@@ -436,4 +438,16 @@ export async function runPostgresBootstrap(pool: Pool): Promise<void> {
     CREATE INDEX IF NOT EXISTS idx_notifications_recipient
       ON notifications(recipient_user_id, read_at)
   `);
+
+  // Claude collaborator trigger queue
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS pending_claude_triggers (
+      id SERIAL PRIMARY KEY,
+      task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+      triggered_by_user_id INTEGER REFERENCES users(id),
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE(task_id)
+    )
+  `);
+  await pool.query(`CREATE INDEX IF NOT EXISTS idx_pending_claude_triggers_created_at ON pending_claude_triggers(created_at)`);
 }

--- a/apps/api_server/src/integrations/planning_center/planning_center_service.ts
+++ b/apps/api_server/src/integrations/planning_center/planning_center_service.ts
@@ -557,7 +557,9 @@ export class PlanningCenterService {
             : `${entry.people.length} people`;
       return {
         sourceId: `planning_center:declined:${plan.id}:${entry.ids.join('-')}`,
-        title: `Replace ${entry.positionName} for ${plan.title}`,
+        title: entry.people.length === 1
+          ? `Replace ${entry.people[0]} — ${entry.positionName} for ${plan.title}`
+          : `Replace ${entry.people.length} people — ${entry.positionName} for ${plan.title}`,
         notes:
           `${peopleLabel} declined the ${entry.positionName} invitation` +
           ` in Planning Center for ${plan.serviceTypeName} on ${plan.planDate}.`,
@@ -605,7 +607,7 @@ export class PlanningCenterService {
 
         signals.push({
           sourceId: `planning_center:unconfirmed:${plan.id}:${resource.id}`,
-          title: `Confirm ${positionName} for ${plan.title}`,
+          title: `Confirm ${personName} — ${positionName} for ${plan.title}`,
           notes:
             `${personName} is still unconfirmed for the ${positionName}` +
             ` assignment in Planning Center for ${plan.serviceTypeName} on ${plan.planDate}.`,

--- a/apps/api_server/src/middleware/require_claude_user.ts
+++ b/apps/api_server/src/middleware/require_claude_user.ts
@@ -1,0 +1,11 @@
+import type { NextFunction, Request, Response } from 'express';
+import { env } from '../config/env';
+import { AppError } from '../errors/app_error';
+
+export function requireClaudeUser(req: Request, _res: Response, next: NextFunction) {
+  if (!req.auth) return next(AppError.unauthorized('Auth required'));
+  if (env.claudeUserId == null || req.auth.user.id !== env.claudeUserId) {
+    return next(AppError.forbidden('Reserved for Claude service account'));
+  }
+  next();
+}

--- a/apps/api_server/src/models/dashboard_summary.ts
+++ b/apps/api_server/src/models/dashboard_summary.ts
@@ -28,6 +28,16 @@ export interface DashboardRhythmSummary {
   items: DashboardRhythmItem[];
 }
 
+export interface DashboardProjectStepPreview {
+  id: string;
+  title: string;
+  status: string;
+  dueDate: string | null;
+  notes: string | null;
+  assigneeId: number | null;
+  assigneeName: string | null;
+}
+
 export interface DashboardProjectItem {
   id: string;
   title: string;
@@ -35,6 +45,9 @@ export interface DashboardProjectItem {
   completedCount: number;
   totalCount: number;
   nextDueDate: string | null;
+  onDeckSteps: DashboardProjectStepPreview[];
+  ownerId: number | null;
+  collaboratorNames: string[];
 }
 
 export interface DashboardProjectSummary {

--- a/apps/api_server/src/models/message.ts
+++ b/apps/api_server/src/models/message.ts
@@ -8,6 +8,7 @@ export interface MessageThread {
   id: number;
   title: string;
   threadType: 'direct' | 'group';
+  taskId: string | null;
   createdBy: number | null;
   createdAt: string;
   updatedAt: string;
@@ -31,6 +32,7 @@ export interface CreateThreadDto {
   participantIds: number[];
   threadType?: 'direct' | 'group';
   title?: string;
+  taskId?: string | null;
 }
 
 export interface CreateMessageDto {

--- a/apps/api_server/src/models/task.ts
+++ b/apps/api_server/src/models/task.ts
@@ -4,6 +4,8 @@ export interface TaskCollaborator {
   photoUrl: string | null;
 }
 
+export type TaskStatus = 'open' | 'in_progress' | 'waiting_for_reply' | 'done';
+
 export interface Task {
   id: string;
   title: string;
@@ -12,7 +14,7 @@ export interface Task {
   scheduledDate: string | null;
   scheduledOrder: number | null;
   locked: boolean;
-  status: 'open' | 'done';
+  status: TaskStatus;
   sourceType: string | null;
   sourceId: string | null;
   sourceName: string | null;
@@ -31,7 +33,7 @@ export interface CreateTaskDto {
   title: string;
   notes?: string | null;
   dueDate?: string | null;
-  status?: 'open' | 'done';
+  status?: TaskStatus;
   scheduledDate?: string | null;
   scheduledOrder?: number | null;
   locked?: boolean;
@@ -44,7 +46,7 @@ export interface UpdateTaskDto {
   title?: string;
   notes?: string | null;
   dueDate?: string | null;
-  status?: 'open' | 'done';
+  status?: TaskStatus;
   scheduledDate?: string | null;
   scheduledOrder?: number | null;
   locked?: boolean;

--- a/apps/api_server/src/repositories/claude_triggers_repository.ts
+++ b/apps/api_server/src/repositories/claude_triggers_repository.ts
@@ -1,0 +1,76 @@
+import { env } from '../config/env';
+import { getDb, getPostgresPool } from '../database/db';
+
+export interface PendingClaudeTrigger {
+  id: number;
+  taskId: string;
+  triggeredByUserId: number | null;
+  createdAt: string;
+  taskTitle: string;
+  taskNotes: string | null;
+  taskOwnerId: number | null;
+}
+
+export class ClaudeTriggersRepository {
+  async insertAsync(taskId: string, triggeredByUserId: number | null): Promise<void> {
+    if (env.dbClient === 'postgres') {
+      await getPostgresPool().query(
+        `INSERT INTO pending_claude_triggers (task_id, triggered_by_user_id)
+         VALUES ($1, $2) ON CONFLICT (task_id) DO NOTHING`,
+        [taskId, triggeredByUserId],
+      );
+      return;
+    }
+    getDb()
+      .prepare(
+        `INSERT OR IGNORE INTO pending_claude_triggers (task_id, triggered_by_user_id)
+         VALUES (?, ?)`,
+      )
+      .run(taskId, triggeredByUserId);
+  }
+
+  async listAllAsync(): Promise<PendingClaudeTrigger[]> {
+    const sql = `
+      SELECT pct.id, pct.task_id, pct.triggered_by_user_id, pct.created_at,
+             t.title AS task_title, t.notes AS task_notes, t.owner_id AS task_owner_id
+      FROM pending_claude_triggers pct
+      JOIN tasks t ON t.id = pct.task_id
+      ORDER BY pct.created_at ASC
+    `;
+    if (env.dbClient === 'postgres') {
+      const r = await getPostgresPool().query(sql);
+      return r.rows.map(this.rowToModel);
+    }
+    const rows = getDb().prepare(sql).all() as any[];
+    return rows.map(this.rowToModel);
+  }
+
+  async deleteAsync(id: number): Promise<boolean> {
+    if (env.dbClient === 'postgres') {
+      const r = await getPostgresPool().query(
+        `DELETE FROM pending_claude_triggers WHERE id = $1`,
+        [id],
+      );
+      return (r.rowCount ?? 0) > 0;
+    }
+    const r = getDb()
+      .prepare(`DELETE FROM pending_claude_triggers WHERE id = ?`)
+      .run(id);
+    return r.changes > 0;
+  }
+
+  private rowToModel(row: any): PendingClaudeTrigger {
+    return {
+      id: row.id,
+      taskId: row.task_id,
+      triggeredByUserId: row.triggered_by_user_id,
+      createdAt:
+        typeof row.created_at === 'string'
+          ? row.created_at
+          : row.created_at.toISOString(),
+      taskTitle: row.task_title,
+      taskNotes: row.task_notes,
+      taskOwnerId: row.task_owner_id,
+    };
+  }
+}

--- a/apps/api_server/src/repositories/messages_repository.ts
+++ b/apps/api_server/src/repositories/messages_repository.ts
@@ -14,6 +14,7 @@ interface ThreadRow {
   id: number;
   title: string;
   thread_type: string;
+  task_id: string | null;
   created_by: number | null;
   created_at: string;
   updated_at: string;
@@ -39,6 +40,7 @@ function rowToThread(row: ThreadSummaryRow): MessageThread {
     id: row.id,
     title: row.title,
     threadType: (row.thread_type ?? 'direct') as 'direct' | 'group',
+    taskId: row.task_id ?? null,
     createdBy: row.created_by,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -145,7 +147,10 @@ export class MessagesRepository {
     return row?.id ?? null;
   }
 
-  findAllThreadsForUser(userId: number): MessageThread[] {
+  findAllThreadsForUser(userId: number, opts?: { taskId?: string }): MessageThread[] {
+    const taskIdFilter = opts?.taskId != null ? ` AND t.task_id = ?` : '';
+    const params: unknown[] = [userId, userId, userId];
+    if (opts?.taskId != null) params.push(opts.taskId);
     const rows = getDb()
       .prepare(
         `SELECT
@@ -167,15 +172,18 @@ export class MessagesRepository {
          FROM message_threads t
          JOIN thread_participants tp
            ON tp.thread_id = t.id
-         WHERE tp.user_id = ?
+         WHERE tp.user_id = ?${taskIdFilter}
          ORDER BY t.updated_at DESC`,
       )
-      .all(userId, userId, userId) as ThreadSummaryRow[];
+      .all(...params) as ThreadSummaryRow[];
     return rows.map((row) => this.withParticipants(rowToThread(row)));
   }
 
-  async findAllThreadsForUserAsync(userId: number): Promise<MessageThread[]> {
+  async findAllThreadsForUserAsync(userId: number, opts?: { taskId?: string }): Promise<MessageThread[]> {
     if (env.dbClient === 'postgres') {
+      const taskIdFilter = opts?.taskId != null ? ` AND t.task_id = $2` : '';
+      const params: unknown[] = [userId];
+      if (opts?.taskId != null) params.push(opts.taskId);
       const result = await getPostgresPool().query<ThreadSummaryRow>(
         `SELECT
            t.*,
@@ -196,15 +204,15 @@ export class MessagesRepository {
          FROM message_threads t
          JOIN thread_participants tp
            ON tp.thread_id = t.id
-         WHERE tp.user_id = $1
+         WHERE tp.user_id = $1${taskIdFilter}
          ORDER BY t.updated_at DESC`,
-        [userId],
+        params,
       );
       return Promise.all(
         result.rows.map((row) => this.withParticipantsAsync(rowToThread(row))),
       );
     }
-    return this.findAllThreadsForUser(userId);
+    return this.findAllThreadsForUser(userId, opts);
   }
 
   findThreadByIdForUser(id: number, userId: number): MessageThread {
@@ -269,6 +277,16 @@ export class MessagesRepository {
     return this.findThreadByIdForUser(id, userId);
   }
 
+  findByTaskId(taskId: string, userId: number): MessageThread | null {
+    const rows = this.findAllThreadsForUser(userId, { taskId });
+    return rows[0] ?? null;
+  }
+
+  async findByTaskIdAsync(taskId: string, userId: number): Promise<MessageThread | null> {
+    const rows = await this.findAllThreadsForUserAsync(userId, { taskId });
+    return rows[0] ?? null;
+  }
+
   createThread(data: CreateThreadDto): MessageThread {
     const threadType = data.threadType ?? 'direct';
     const participantIds = Array.from(
@@ -290,13 +308,14 @@ export class MessagesRepository {
     const participantUsers = participantIds.map((id) => this.usersRepo.findById(id));
     const title = data.title ?? participantUsers.map((user) => user.name).join(', ');
 
+    const taskId = data.taskId ?? null;
     const now = new Date().toISOString();
     const result = getDb()
       .prepare(
-        `INSERT INTO message_threads (title, thread_type, created_by, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?)`,
+        `INSERT INTO message_threads (title, thread_type, task_id, created_by, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
       )
-      .run(title, threadType, data.createdBy, now, now);
+      .run(title, threadType, taskId, data.createdBy, now, now);
 
     const threadId = result.lastInsertRowid as number;
     const insertParticipant = getDb().prepare(
@@ -344,12 +363,13 @@ export class MessagesRepository {
       );
       const title = data.title ?? participantUsers.map((user) => user.name).join(', ');
 
+      const taskId = data.taskId ?? null;
       const now = new Date().toISOString();
       const threadResult = await getPostgresPool().query<{ id: number }>(
-        `INSERT INTO message_threads (title, thread_type, created_by, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5)
+        `INSERT INTO message_threads (title, thread_type, task_id, created_by, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6)
          RETURNING id`,
-        [title, threadType, data.createdBy, now, now],
+        [title, threadType, taskId, data.createdBy, now, now],
       );
       const threadId = threadResult.rows[0].id;
 

--- a/apps/api_server/src/repositories/tasks_repository.ts
+++ b/apps/api_server/src/repositories/tasks_repository.ts
@@ -525,6 +525,12 @@ export class TasksRepository {
       });
     }
 
+    // User has marked this externally-tracked task as done. Don't reopen
+    // or otherwise mutate it on subsequent automation syncs.
+    if (existing.status === 'done') {
+      return existing;
+    }
+
     return this.updateAsync(existing.id, {
       title: data.title,
       notes: data.notes ?? null,
@@ -547,6 +553,12 @@ export class TasksRepository {
         ...data,
         status: data.status ?? 'open',
       });
+    }
+
+    // User has marked this externally-tracked task as done. Don't reopen
+    // or otherwise mutate it on subsequent automation syncs.
+    if (existing.status === 'done') {
+      return existing;
     }
 
     return this.update(existing.id, {

--- a/apps/api_server/src/routes/claude_triggers_routes.ts
+++ b/apps/api_server/src/routes/claude_triggers_routes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { requireAuth } from '../middleware/auth_middleware';
+import { requireClaudeUser } from '../middleware/require_claude_user';
+import { ClaudeTriggersController } from '../controllers/claude_triggers_controller';
+
+const router = Router();
+const controller = new ClaudeTriggersController();
+
+router.use(requireAuth);
+router.use(requireClaudeUser);
+
+router.get('/', (req, res, next) => controller.list(req, res, next));
+router.delete('/:id', (req, res, next) => controller.remove(req, res, next));
+
+export default router;

--- a/apps/api_server/src/services/dashboard_summary_service.ts
+++ b/apps/api_server/src/services/dashboard_summary_service.ts
@@ -7,6 +7,7 @@ import type {
   DashboardSummary,
   DashboardRhythmItem,
   DashboardProjectItem,
+  DashboardProjectStepPreview,
   DashboardUnreadPreview,
 } from '../models/dashboard_summary';
 import type { Task } from '../models/task';
@@ -148,7 +149,22 @@ export class DashboardSummaryService {
     const templatesById = new Map<string, ProjectTemplate>(
       templates.map((t) => [t.id, t]),
     );
-    const projectItems: DashboardProjectItem[] = buildProjectItems(instances, templatesById);
+
+    // Pre-fetch collaborators for all active instances
+    const activeInstances = instances.filter((i) => i.status !== 'done');
+    const collaboratorsByInstance = new Map<string, string[]>();
+    await Promise.all(
+      activeInstances.map(async (inst) => {
+        const collabs = await this.projectInstancesRepo.listCollaboratorsAsync(inst.id);
+        collaboratorsByInstance.set(inst.id, collabs.map((c) => c.name));
+      }),
+    );
+
+    const projectItems: DashboardProjectItem[] = buildProjectItems(
+      instances,
+      templatesById,
+      collaboratorsByInstance,
+    );
 
     // ── Messages ───────────────────────────────────────────────────────────────
     const unreadThreads = threads
@@ -205,30 +221,75 @@ export class DashboardSummaryService {
 function buildProjectItems(
   instances: ProjectInstance[],
   templatesById: Map<string, ProjectTemplate>,
+  collaboratorsByInstance: Map<string, string[]>,
 ): DashboardProjectItem[] {
   const items: DashboardProjectItem[] = [];
   for (const instance of instances) {
     if (instance.status === 'done') continue;
-    const sortedSteps = [...instance.steps].sort((a, b) => {
-      const aDate = a.dueDate ? new Date(a.dueDate).getTime() : 9e15;
-      const bDate = b.dueDate ? new Date(b.dueDate).getTime() : 9e15;
-      return aDate - bDate || a.title.localeCompare(b.title);
-    });
-    const completed = sortedSteps.filter((s) => s.status === 'done').length;
+
     const template = templatesById.get(instance.templateId);
+
+    // Build a sort-order map from template steps (stepId → sort_order)
+    const templateStepOrder = new Map<string, number>();
+    if (template) {
+      for (const ts of template.steps) {
+        templateStepOrder.set(ts.id, ts.sortOrder);
+      }
+    }
+
+    // Sort instance steps by template sort_order, then by step id for stability
+    const sortedByOrder = [...instance.steps].sort((a, b) => {
+      const aOrder = templateStepOrder.get(a.stepId) ?? 9999;
+      const bOrder = templateStepOrder.get(b.stepId) ?? 9999;
+      if (aOrder !== bOrder) return aOrder - bOrder;
+      return a.id.localeCompare(b.id);
+    });
+
+    const completed = sortedByOrder.filter((s) => s.status === 'done').length;
     const title =
       instance.name?.trim() || template?.name || `Project ${instance.anchorDate}`;
-    const nextDueDates = sortedSteps
+
+    // For nextDueDate, still sort open steps by due date
+    const openStepsByDate = [...instance.steps]
       .filter((s) => s.status !== 'done')
-      .map((s) => s.dueDate)
-      .filter(Boolean) as string[];
+      .sort((a, b) => {
+        const aDate = a.dueDate ? new Date(a.dueDate).getTime() : 9e15;
+        const bDate = b.dueDate ? new Date(b.dueDate).getTime() : 9e15;
+        return aDate - bDate;
+      });
+    const nextDueDate = openStepsByDate.find((s) => s.dueDate)?.dueDate ?? null;
+
+    // On-deck: top 5 open steps ordered by template sort_order
+    const onDeckSteps: DashboardProjectStepPreview[] = sortedByOrder
+      .filter((s) => s.status !== 'done')
+      .slice(0, 5)
+      .map((s) => ({
+        id: s.id,
+        title: s.title,
+        status: s.status,
+        dueDate: s.dueDate ?? null,
+        notes: s.notes ?? null,
+        assigneeId: s.assigneeId ?? null,
+        assigneeName: s.assigneeName ?? null,
+      }));
+
+    // Collaborator names: from project_collaborators + distinct step assignees
+    const collaboratorNames = collaboratorsByInstance.get(instance.id) ?? [];
+    const assigneeNames = onDeckSteps
+      .map((s) => s.assigneeName)
+      .filter((n): n is string => n != null);
+    const allNames = [...new Set([...collaboratorNames, ...assigneeNames])];
+
     items.push({
       id: instance.id,
       title,
-      subtitle: `${completed} of ${sortedSteps.length} step${sortedSteps.length === 1 ? '' : 's'} complete`,
+      subtitle: `${completed} of ${sortedByOrder.length} step${sortedByOrder.length === 1 ? '' : 's'} complete`,
       completedCount: completed,
-      totalCount: sortedSteps.length,
-      nextDueDate: nextDueDates[0] ?? null,
+      totalCount: sortedByOrder.length,
+      nextDueDate,
+      onDeckSteps,
+      ownerId: instance.ownerId ?? null,
+      collaboratorNames: allNames,
     });
   }
   items.sort((a, b) => {

--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -504,22 +504,13 @@ class _TopRightAccountClusterState extends State<_TopRightAccountCluster> {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  CircleAvatar(
+                  _RhythmAvatar(
+                    photoUrl: user.photoUrl,
+                    initials: _initialsFor(user.name),
+                    userId: '${user.id}',
                     radius: 18,
                     backgroundColor: context.rhythm.accentMuted,
-                    backgroundImage: user.photoUrl != null
-                        ? NetworkImage(user.photoUrl!)
-                        : null,
-                    child: user.photoUrl == null
-                        ? Text(
-                            _initialsFor(user.name),
-                            style: TextStyle(
-                              color: context.rhythm.accent,
-                              fontSize: 12,
-                              fontWeight: FontWeight.w700,
-                            ),
-                          )
-                        : null,
+                    initialsColor: context.rhythm.accent,
                   ),
                   const SizedBox(width: 10),
                   ConstrainedBox(
@@ -573,6 +564,82 @@ String _initialsFor(String name) {
       .toList();
   if (parts.isEmpty) return '?';
   return parts.map((part) => part[0].toUpperCase()).join();
+}
+
+/// A circular avatar that displays a network photo when available and falls back
+/// to initials on load failure or when [photoUrl] is null.
+class _RhythmAvatar extends StatefulWidget {
+  const _RhythmAvatar({
+    required this.photoUrl,
+    required this.initials,
+    required this.userId,
+    required this.radius,
+    required this.backgroundColor,
+    required this.initialsColor,
+  });
+
+  final String? photoUrl;
+  final String initials;
+  final String userId;
+  final double radius;
+  final Color backgroundColor;
+  final Color initialsColor;
+
+  @override
+  State<_RhythmAvatar> createState() => _RhythmAvatarState();
+}
+
+class _RhythmAvatarState extends State<_RhythmAvatar> {
+  bool _imageError = false;
+
+  Widget _initialsWidget() {
+    return Container(
+      width: widget.radius * 2,
+      height: widget.radius * 2,
+      decoration: BoxDecoration(
+        color: widget.backgroundColor,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        widget.initials,
+        style: TextStyle(
+          color: widget.initialsColor,
+          fontSize: widget.radius * 0.67,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.photoUrl == null || _imageError) {
+      return _initialsWidget();
+    }
+
+    return ClipOval(
+      child: SizedBox(
+        width: widget.radius * 2,
+        height: widget.radius * 2,
+        child: Image.network(
+          widget.photoUrl!,
+          fit: BoxFit.cover,
+          errorBuilder: (context, error, stackTrace) {
+            debugPrint(
+              '[RhythmAvatar] Failed to load photo for user ${widget.userId}: '
+              '${widget.photoUrl} — $error',
+            );
+            // Rebuild with initials fallback.
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted) setState(() => _imageError = true);
+            });
+            return _initialsWidget();
+          },
+        ),
+      ),
+    );
+  }
 }
 
 class _ShellBackdrop extends StatelessWidget {

--- a/apps/desktop_flutter/lib/app/core/tasks/task_visual_style.dart
+++ b/apps/desktop_flutter/lib/app/core/tasks/task_visual_style.dart
@@ -23,7 +23,7 @@ class TaskVisualStyle {
 
 class TaskVisualStyles {
   static TaskVisualStyle resolve(Task task, {DateTime? today}) {
-    final isDone = task.status == 'done';
+    final isDone = task.status == TaskStatus.done;
     final isPastDue = DateFormatters.isPastDue(
       dueDate: task.dueDate,
       scheduledDate: task.scheduledDate,

--- a/apps/desktop_flutter/lib/app/core/ui/rhythm_inspector.dart
+++ b/apps/desktop_flutter/lib/app/core/ui/rhythm_inspector.dart
@@ -429,7 +429,7 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
           : 'Review context, coordinate with collaborators, and edit the work when needed.',
       icon: _readOnly
           ? Icons.event_note_outlined
-          : widget.task.status == 'done'
+          : widget.task.status == TaskStatus.done
               ? Icons.task_alt
               : Icons.radio_button_unchecked,
       onIconTap: _readOnly || widget.onToggleStatus == null
@@ -442,8 +442,8 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
       headerPills: [
         _headerPill(
           context,
-          widget.task.status == 'done' ? 'Done' : 'Open',
-          widget.task.status == 'done'
+          widget.task.status == TaskStatus.done ? 'Done' : 'Open',
+          widget.task.status == TaskStatus.done
               ? colors.success
               : visualStyle.accent.withValues(alpha: 0.95),
         ),
@@ -628,7 +628,8 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
               children: [
                 _MetaRow(
                   label: 'Status',
-                  value: widget.task.status == 'done' ? 'Done' : 'Open',
+                  value:
+                      widget.task.status == TaskStatus.done ? 'Done' : 'Open',
                 ),
                 if (sourceLabel != null)
                   _MetaRow(label: 'Source', value: sourceLabel),

--- a/apps/desktop_flutter/lib/app/core/ui/rhythm_inspector.dart
+++ b/apps/desktop_flutter/lib/app/core/ui/rhythm_inspector.dart
@@ -442,10 +442,8 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
       headerPills: [
         _headerPill(
           context,
-          widget.task.status == TaskStatus.done ? 'Done' : 'Open',
-          widget.task.status == TaskStatus.done
-              ? colors.success
-              : visualStyle.accent.withValues(alpha: 0.95),
+          _statusLabel(widget.task.status),
+          _statusColor(widget.task.status, colors.success),
         ),
         if (sourceLabel != null) _headerPill(context, sourceLabel, colors.info),
         if (_primaryDate != null)
@@ -628,8 +626,7 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
               children: [
                 _MetaRow(
                   label: 'Status',
-                  value:
-                      widget.task.status == TaskStatus.done ? 'Done' : 'Open',
+                  value: _statusLabel(widget.task.status),
                 ),
                 if (sourceLabel != null)
                   _MetaRow(label: 'Source', value: sourceLabel),
@@ -1053,4 +1050,30 @@ String _initial(String label) {
   final trimmed = label.trim();
   if (trimmed.isEmpty) return '?';
   return trimmed[0].toUpperCase();
+}
+
+String _statusLabel(TaskStatus status) {
+  switch (status) {
+    case TaskStatus.open:
+      return 'Open';
+    case TaskStatus.inProgress:
+      return 'In progress';
+    case TaskStatus.waitingForReply:
+      return 'Awaiting reply';
+    case TaskStatus.done:
+      return 'Done';
+  }
+}
+
+Color _statusColor(TaskStatus status, Color successColor) {
+  switch (status) {
+    case TaskStatus.open:
+      return const Color(0xFF6B7280);
+    case TaskStatus.inProgress:
+      return const Color(0xFF4F6AF5);
+    case TaskStatus.waitingForReply:
+      return const Color(0xFFF59E0B);
+    case TaskStatus.done:
+      return successColor;
+  }
 }

--- a/apps/desktop_flutter/lib/features/dashboard/controllers/dashboard_controller.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/controllers/dashboard_controller.dart
@@ -154,7 +154,7 @@ class DashboardController extends ChangeNotifier {
           final syntheticTask = Task(
             id: step.id,
             title: step.title,
-            status: step.status,
+            status: TaskStatusJson.fromJson(step.status),
             sourceType: 'project_step',
             sourceName: projectName,
             dueDate: step.dueDate,
@@ -207,7 +207,7 @@ class DashboardController extends ChangeNotifier {
     final task = _findTaskById(id);
     if (task == null) return;
     try {
-      await _repository.toggleTaskDone(id, task.status);
+      await _repository.toggleTaskDone(id, task.status.toJson());
       await refresh();
     } catch (e) {
       _errorMessage = e.toString();
@@ -283,7 +283,7 @@ class DashboardController extends ChangeNotifier {
   }
 
   static bool _hasOpenHandoffContext(Task task) {
-    if (task.status == 'done') return false;
+    if (task.status == TaskStatus.done) return false;
     return task.isShared || task.collaborators.isNotEmpty;
   }
 

--- a/apps/desktop_flutter/lib/features/dashboard/models/dashboard_overview_models.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/models/dashboard_overview_models.dart
@@ -180,15 +180,27 @@ class DashboardProjectProgress implements DashboardProgressItem {
     this.collaboratorNames = const [],
   });
 
-  factory DashboardProjectProgress.fromJson(Map<String, dynamic> json) =>
-      DashboardProjectProgress(
-        id: json['id'] as String,
-        title: json['title'] as String,
-        subtitle: json['subtitle'] as String? ?? '',
-        completedCount: (json['completedCount'] as num?)?.toInt() ?? 0,
-        totalCount: (json['totalCount'] as num?)?.toInt() ?? 0,
-        nextDueDate: json['nextDueDate'] as String?,
-      );
+  factory DashboardProjectProgress.fromJson(Map<String, dynamic> json) {
+    final rawOnDeck = (json['onDeckSteps'] as List<dynamic>?) ?? [];
+    final onDeck = rawOnDeck
+        .map((j) =>
+            DashboardProjectStepPreview.fromJson(j as Map<String, dynamic>))
+        .toList();
+    final rawCollaborators =
+        (json['collaboratorNames'] as List<dynamic>?) ?? [];
+    final collaborators = rawCollaborators.map((n) => n as String).toList();
+    return DashboardProjectProgress(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      subtitle: json['subtitle'] as String? ?? '',
+      completedCount: (json['completedCount'] as num?)?.toInt() ?? 0,
+      totalCount: (json['totalCount'] as num?)?.toInt() ?? 0,
+      nextDueDate: json['nextDueDate'] as String?,
+      onDeckSteps: onDeck,
+      ownerId: (json['ownerId'] as num?)?.toInt(),
+      collaboratorNames: collaborators,
+    );
+  }
 
   @override
   final String id;
@@ -223,6 +235,17 @@ class DashboardProjectStepPreview {
     this.assigneeId,
     this.assigneeName,
   });
+
+  factory DashboardProjectStepPreview.fromJson(Map<String, dynamic> json) =>
+      DashboardProjectStepPreview(
+        id: json['id'] as String,
+        title: json['title'] as String,
+        status: json['status'] as String? ?? 'open',
+        dueDate: json['dueDate'] as String? ?? '',
+        notes: json['notes'] as String?,
+        assigneeId: (json['assigneeId'] as num?)?.toInt(),
+        assigneeName: json['assigneeName'] as String?,
+      );
 
   final String id;
   final String title;

--- a/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
@@ -617,7 +617,7 @@ class _DashboardBodyState extends State<_DashboardBody> {
   }) {
     return FocusOnDeckItem(
       title: task.title,
-      checked: task.status == 'done',
+      checked: task.status == TaskStatus.done,
       onChanged: (_) => widget.controller.toggleTaskDone(task.id),
       onTap: () => _showTaskEditDialog(task),
       avatarLabel: _onDeckTaskPersonLabel(
@@ -1633,7 +1633,7 @@ class _ProgressFeatureDetails extends StatelessWidget {
 }
 
 bool _isPastDue(Task task) {
-  if (task.status == 'done') return false;
+  if (task.status == TaskStatus.done) return false;
   final date = _taskPriorityDate(task);
   if (date == null) return false;
   final today = DateTime.now();
@@ -1879,7 +1879,7 @@ class _TaskPreviewRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.rhythm;
-    final isDone = task.status == 'done';
+    final isDone = task.status == TaskStatus.done;
     final tone = _taskTone(task, showPastDue: showPastDue);
     final accent = _toneColor(colors, tone);
     final isPastDue = showPastDue && _isPastDue(task);
@@ -1985,7 +1985,7 @@ class _HandoffPreviewRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.rhythm;
-    final isDone = task.status == 'done';
+    final isDone = task.status == TaskStatus.done;
     final tone = _handoffTone(task, currentUserId);
     final accent = _toneColor(colors, tone);
     final dueLabel = task.dueDate != null

--- a/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
@@ -1984,45 +1984,90 @@ class _HandoffPreviewRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = context.rhythm;
+    final isDone = task.status == 'done';
     final tone = _handoffTone(task, currentUserId);
-    final label = _handoffLabel(task, currentUserId, workspaceMembers);
-    final peopleLabel =
-        _handoffPeopleLabel(task, currentUserId, workspaceMembers);
+    final accent = _toneColor(colors, tone);
+    final dueLabel = task.dueDate != null
+        ? DateFormatters.fullDate(task.dueDate, fallback: task.dueDate!)
+        : null;
+    final sourceName = task.sourceName?.trim();
+    final hasSourceName = sourceName != null && sourceName.isNotEmpty;
 
-    return RhythmPreviewRow(
-      eyebrow: label,
-      title: task.title,
-      leadingIcon: Icons.group_outlined,
-      tone: tone,
-      onTap: onTap,
-      metadata: [
-        if (peopleLabel != null)
-          RhythmBadge(
-            label: peopleLabel,
-            icon: Icons.people_outline,
-            tone: RhythmBadgeTone.neutral,
-            compact: true,
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 3),
+      child: GestureDetector(
+        onTap: onTap,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: isDone
+                ? colors.surfaceMuted.withValues(alpha: 0.45)
+                : accent.withValues(alpha: 0.09),
+            border: Border(left: BorderSide(color: accent, width: 3)),
           ),
-        if (task.dueDate != null)
-          RhythmBadge(
-            label:
-                'Due ${DateFormatters.fullDate(task.dueDate, fallback: task.dueDate!)}',
-            tone: RhythmBadgeTone.neutral,
-            compact: true,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: Checkbox(
+                    value: isDone,
+                    onChanged: (_) => onTap(),
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity:
+                        const VisualDensity(horizontal: -4, vertical: -4),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        task.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              fontSize: 13,
+                              decoration:
+                                  isDone ? TextDecoration.lineThrough : null,
+                              color: isDone
+                                  ? colors.textMuted
+                                  : colors.textPrimary,
+                            ),
+                      ),
+                      if (hasSourceName)
+                        Text(
+                          sourceName,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style:
+                              Theme.of(context).textTheme.labelSmall?.copyWith(
+                                    color: colors.textMuted,
+                                    fontSize: 11,
+                                  ),
+                        ),
+                    ],
+                  ),
+                ),
+                if (dueLabel != null) ...[
+                  const SizedBox(width: 6),
+                  RhythmMetaChip(
+                    label: dueLabel,
+                    icon: Icons.flag_outlined,
+                    tone: RhythmMetaChipTone.neutral,
+                  ),
+                ],
+              ],
+            ),
           ),
-        if (task.sourceType != null)
-          RhythmBadge(
-            label: _taskSourceLabel(task),
-            tone: tone,
-            compact: true,
-          ),
-        if (task.isShared || task.collaborators.isNotEmpty)
-          const RhythmBadge(
-            label: 'Shared',
-            tone: RhythmBadgeTone.accent,
-            compact: true,
-          ),
-      ],
+        ),
+      ),
     );
   }
 }

--- a/apps/desktop_flutter/lib/features/tasks/controllers/tasks_controller.dart
+++ b/apps/desktop_flutter/lib/features/tasks/controllers/tasks_controller.dart
@@ -95,9 +95,10 @@ class TasksController extends ChangeNotifier {
 
   Future<void> toggleDone(String id) async {
     final task = _tasks.firstWhere((t) => t.id == id);
-    final newStatus = task.status == 'done' ? 'open' : 'done';
+    final newStatus =
+        task.status == TaskStatus.done ? TaskStatus.open : TaskStatus.done;
     try {
-      final updated = await _repository.update(id, status: newStatus);
+      final updated = await _repository.update(id, status: newStatus.toJson());
       _tasks = _tasks.map((t) => t.id == id ? updated : t).toList();
       _status = TasksStatus.idle;
       _errorMessage = null;

--- a/apps/desktop_flutter/lib/features/tasks/models/task.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/task.dart
@@ -1,6 +1,36 @@
 import '../../../app/core/utils/json_parsing.dart';
 import 'task_collaborator.dart';
 
+enum TaskStatus { open, inProgress, waitingForReply, done }
+
+extension TaskStatusJson on TaskStatus {
+  String toJson() {
+    switch (this) {
+      case TaskStatus.open:
+        return 'open';
+      case TaskStatus.inProgress:
+        return 'in_progress';
+      case TaskStatus.waitingForReply:
+        return 'waiting_for_reply';
+      case TaskStatus.done:
+        return 'done';
+    }
+  }
+
+  static TaskStatus fromJson(String value) {
+    switch (value) {
+      case 'in_progress':
+        return TaskStatus.inProgress;
+      case 'waiting_for_reply':
+        return TaskStatus.waitingForReply;
+      case 'done':
+        return TaskStatus.done;
+      default:
+        return TaskStatus.open;
+    }
+  }
+}
+
 class Task {
   Task({
     required this.id,
@@ -33,7 +63,7 @@ class Task {
       scheduledDate: asString(json['scheduledDate']),
       scheduledOrder: asInt(json['scheduledOrder']),
       locked: asBool(json['locked']) ?? false,
-      status: asString(json['status']) ?? 'open',
+      status: TaskStatusJson.fromJson(asString(json['status']) ?? 'open'),
       sourceType: asString(json['sourceType']),
       sourceId: asString(json['sourceId']),
       sourceName: asString(json['sourceName']),
@@ -59,7 +89,7 @@ class Task {
   final String? scheduledDate;
   final int? scheduledOrder;
   final bool locked;
-  final String status;
+  final TaskStatus status;
   final String? sourceType;
   final String? sourceId;
   final String? sourceName;
@@ -80,7 +110,7 @@ class Task {
         'scheduledDate': scheduledDate,
         'scheduledOrder': scheduledOrder,
         'locked': locked,
-        'status': status,
+        'status': status.toJson(),
         'sourceType': sourceType,
         'sourceId': sourceId,
         'sourceName': sourceName,
@@ -98,7 +128,7 @@ class Task {
     String? scheduledDate,
     int? scheduledOrder,
     bool? locked,
-    String? status,
+    TaskStatus? status,
     int? ownerId,
     bool? isShared,
     List<TaskCollaborator>? collaborators,

--- a/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
@@ -21,6 +21,7 @@ class _TasksViewState extends State<TasksView> {
   final _searchController = TextEditingController();
   bool _showCompleted = false;
   String _searchQuery = '';
+  String? _activeTimeFilter; // null = all, 'today', 'week', 'month'
 
   @override
   void initState() {
@@ -163,6 +164,35 @@ class _TasksViewState extends State<TasksView> {
             ),
           ],
         ),
+        RhythmSegmentedControl<String?>(
+          compact: true,
+          value: _activeTimeFilter,
+          onChanged: (value) => setState(
+            () => _activeTimeFilter = _activeTimeFilter == value ? null : value,
+          ),
+          segments: const [
+            RhythmSegment(
+              value: null,
+              label: 'All',
+              icon: Icons.format_list_bulleted,
+            ),
+            RhythmSegment(
+              value: 'today',
+              label: 'Today',
+              icon: Icons.today_outlined,
+            ),
+            RhythmSegment(
+              value: 'week',
+              label: 'This Week',
+              icon: Icons.calendar_view_week_outlined,
+            ),
+            RhythmSegment(
+              value: 'month',
+              label: 'This Month',
+              icon: Icons.calendar_month_outlined,
+            ),
+          ],
+        ),
         RhythmColorLegend(
           items: const [
             (Color(0xFFDC5B58), 'Past due'),
@@ -221,6 +251,26 @@ class _TasksViewState extends State<TasksView> {
       );
     }
     final groups = _groupTasksByTime(visibleTasks);
+    if (groups.isEmpty && _activeTimeFilter != null) {
+      final (filterTitle, filterIcon) = switch (_activeTimeFilter) {
+        'today' => ('No tasks due today', Icons.today_outlined),
+        'week' => ('No tasks due this week', Icons.calendar_view_week_outlined),
+        'month' => (
+            'No tasks due this month',
+            Icons.calendar_month_outlined,
+          ),
+        _ => ('No tasks to show', Icons.checklist_outlined),
+      };
+      return SliverFillRemaining(
+        hasScrollBody: false,
+        child: _buildEmptyState(
+          title: filterTitle,
+          message:
+              'All caught up! No tasks fall in this time window right now.',
+          icon: filterIcon,
+        ),
+      );
+    }
     return SliverPadding(
       padding: const EdgeInsets.fromLTRB(
         RhythmSpacing.md,
@@ -304,7 +354,7 @@ class _TasksViewState extends State<TasksView> {
       }
     }
 
-    return [
+    final allGroups = [
       _TaskGroup(
         title: 'Past Due',
         subtitle: 'Needs attention',
@@ -318,6 +368,7 @@ class _TasksViewState extends State<TasksView> {
         icon: Icons.today_outlined,
         tone: RhythmBadgeTone.warning,
         tasks: todayTasks,
+        timeFilterKey: 'today',
       ),
       _TaskGroup(
         title: 'This Week',
@@ -325,6 +376,7 @@ class _TasksViewState extends State<TasksView> {
         icon: Icons.calendar_view_week_outlined,
         tone: RhythmBadgeTone.info,
         tasks: thisWeek,
+        timeFilterKey: 'week',
       ),
       _TaskGroup(
         title: 'This Month',
@@ -332,6 +384,7 @@ class _TasksViewState extends State<TasksView> {
         icon: Icons.calendar_month_outlined,
         tone: RhythmBadgeTone.neutral,
         tasks: thisMonth,
+        timeFilterKey: 'month',
       ),
       _TaskGroup(
         title: 'No Due Date',
@@ -347,7 +400,16 @@ class _TasksViewState extends State<TasksView> {
         tone: RhythmBadgeTone.success,
         tasks: completed,
       ),
-    ].where((group) => group.tasks.isNotEmpty).toList();
+    ];
+
+    if (_activeTimeFilter != null) {
+      return allGroups
+          .where((g) => g.timeFilterKey == _activeTimeFilter)
+          .where((g) => g.tasks.isNotEmpty)
+          .toList();
+    }
+
+    return allGroups.where((group) => group.tasks.isNotEmpty).toList();
   }
 
   Widget _buildTaskGroup(_TaskGroup group, TasksController controller) {
@@ -552,6 +614,7 @@ class _TaskGroup {
     required this.icon,
     required this.tone,
     required this.tasks,
+    this.timeFilterKey,
   });
 
   final String title;
@@ -559,6 +622,10 @@ class _TaskGroup {
   final IconData icon;
   final RhythmBadgeTone tone;
   final List<Task> tasks;
+
+  /// Matches the `_activeTimeFilter` value; null means the group is not
+  /// directly addressable by the time filter buttons.
+  final String? timeFilterKey;
 }
 
 String? _compactDate(String? isoDate) {

--- a/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
@@ -169,6 +169,8 @@ class _TasksViewState extends State<TasksView> {
             (Color(0xFFE29A3A), 'Today'),
             (Color(0xFF4E5FE0), 'Rhythm'),
             (Color(0xFF2E7FC4), 'Project'),
+            (Color(0xFF0D9B87), 'Automation'),
+            (Color(0xFFC1602A), 'Planning Center'),
           ],
         ),
       ],

--- a/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
@@ -524,6 +524,21 @@ class _TasksViewState extends State<TasksView> {
                   ],
                 ),
               ),
+              if (task.status == TaskStatus.inProgress) ...[
+                const SizedBox(width: 6),
+                const RhythmMetaChip(
+                  label: 'In progress',
+                  icon: Icons.autorenew,
+                  color: Color(0xFF4F6AF5),
+                ),
+              ] else if (task.status == TaskStatus.waitingForReply) ...[
+                const SizedBox(width: 6),
+                const RhythmMetaChip(
+                  label: 'Awaiting reply',
+                  icon: Icons.hourglass_top_outlined,
+                  color: Color(0xFFF59E0B),
+                ),
+              ],
               if (dueLabel != null) ...[
                 const SizedBox(width: 6),
                 RhythmMetaChip(

--- a/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
@@ -110,7 +110,9 @@ class _TasksViewState extends State<TasksView> {
   List<Task> _visibleTasks(TasksController controller) {
     final tasks = _showCompleted
         ? controller.tasks.toList()
-        : controller.tasks.where((task) => task.status != 'done').toList();
+        : controller.tasks
+            .where((task) => task.status != TaskStatus.done)
+            .toList();
     final query = _searchQuery.trim().toLowerCase();
     if (query.isNotEmpty) {
       return tasks.where((task) {
@@ -316,7 +318,7 @@ class _TasksViewState extends State<TasksView> {
     final completed = <Task>[];
 
     for (final task in tasks) {
-      if (task.status == 'done') {
+      if (task.status == TaskStatus.done) {
         completed.add(task);
         continue;
       }
@@ -451,7 +453,7 @@ class _TasksViewState extends State<TasksView> {
 
   Widget _buildTaskRow(Task task, TasksController controller) {
     final colors = context.rhythm;
-    final isDone = task.status == 'done';
+    final isDone = task.status == TaskStatus.done;
     final visualStyle = TaskVisualStyles.resolve(task);
     final isPastDue = DateFormatters.isPastDue(
       dueDate: task.dueDate,

--- a/apps/desktop_flutter/lib/features/weekly_planner/data/weekly_plan_data_source.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/data/weekly_plan_data_source.dart
@@ -76,7 +76,7 @@ class WeeklyPlanDataSource {
         ? Task(
             id: asString(body['id']) ?? '',
             title: asString(body['title']) ?? '',
-            status: asString(body['status']) ?? 'open',
+            status: TaskStatusJson.fromJson(asString(body['status']) ?? 'open'),
             createdAt: '',
             updatedAt: '',
             notes: asString(body['notes']),

--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -27,6 +27,9 @@ class _WeeklyPlannerViewState extends State<WeeklyPlannerView> {
   @override
   void initState() {
     super.initState();
+    debugPrint('[planner] device tz: ${DateTime.now().timeZoneName} '
+        'offset=${DateTime.now().timeZoneOffset} | '
+        'sample parse: ${DateTime.tryParse("2026-05-04T09:30:00-07:00")?.toUtc().toLocal()}');
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<WeeklyPlannerController>().load();
       context.read<WorkspaceController>().loadMembers();
@@ -1873,7 +1876,9 @@ DateTime? parsePlannerEventDateTime(String? value) {
   if (value == null || value.trim().isEmpty) return null;
   final parsed = DateTime.tryParse(value.trim());
   if (parsed == null) return null;
-  return parsed.isUtc ? parsed.toLocal() : parsed;
+  // Normalize: convert to UTC, then to local. Idempotent for both
+  // UTC-marked and offset-suffixed strings; correctly handles naive too.
+  return parsed.toUtc().toLocal();
 }
 
 String _formatClockTime(DateTime dateTime) {

--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -188,6 +188,8 @@ class _WeekHeader extends StatelessWidget {
             (Color(0xFFE29A3A), 'Today'),
             (Color(0xFF4E5FE0), 'Rhythm'),
             (Color(0xFF2E7FC4), 'Project'),
+            (Color(0xFF0D9B87), 'Automation'),
+            (Color(0xFFC1602A), 'Planning Center'),
           ],
         ),
       ],

--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -119,7 +119,8 @@ class _WeeklyPlannerViewState extends State<WeeklyPlannerView> {
       ),
       onToggleStatus: task.sourceType == 'calendar_shadow_event'
           ? null
-          : () => controller.toggleTaskDone(task, task.status == 'done'),
+          : () =>
+              controller.toggleTaskDone(task, task.status == TaskStatus.done),
       onAddCollaborator: task.sourceType == 'calendar_shadow_event'
           ? null
           : (userId) async {
@@ -372,7 +373,7 @@ class _PlannerBody extends StatelessWidget {
 
     final visibleBacklog = showCompleted
         ? plan.backlog
-        : plan.backlog.where((t) => t.status != 'done').toList();
+        : plan.backlog.where((t) => t.status != TaskStatus.done).toList();
     final showBacklogPane = visibleBacklog.isNotEmpty;
 
     return LayoutBuilder(
@@ -453,7 +454,7 @@ class _BacklogPane extends StatelessWidget {
   Widget build(BuildContext context) {
     final backlog = showCompleted
         ? plan.backlog
-        : plan.backlog.where((t) => t.status != 'done').toList();
+        : plan.backlog.where((t) => t.status != TaskStatus.done).toList();
     final colors = context.rhythm;
     return RhythmSurface(
       tone: RhythmSurfaceTone.muted,
@@ -760,7 +761,7 @@ class _DayColumnState extends State<_DayColumn> {
     final colors = context.rhythm;
     final displayTasks = widget.showCompleted
         ? widget.tasks
-        : widget.tasks.where((t) => t.status != 'done').toList();
+        : widget.tasks.where((t) => t.status != TaskStatus.done).toList();
     final addButton = Padding(
       padding: const EdgeInsets.fromLTRB(8, 8, 8, 8),
       child: InkWell(
@@ -1045,7 +1046,7 @@ class _TaskTile extends StatelessWidget {
   Widget _card(BuildContext context) {
     final isSelected = controller.selectedTaskId == task.id;
     final isMultiSelected = controller.selectedTaskIds.contains(task.id);
-    final isDone = task.status == 'done';
+    final isDone = task.status == TaskStatus.done;
     final isShadowEvent = task.sourceType == 'calendar_shadow_event';
     final visualStyle = TaskVisualStyles.resolve(task);
     final shadowTimeLabel = isShadowEvent ? _shadowEventLabel(task) : null;
@@ -1295,7 +1296,7 @@ class _DetailPaneState extends State<_DetailPane> {
   @override
   Widget build(BuildContext context) {
     final task = widget.task;
-    final isDone = task.status == 'done';
+    final isDone = task.status == TaskStatus.done;
     final isShadowEvent = task.sourceType == 'calendar_shadow_event';
     final timeLabel = _shadowEventLabel(task);
     final workspaceMembers = context.watch<WorkspaceController>().members;
@@ -1824,7 +1825,7 @@ Color _plannerSurfaceColor(
   if (Theme.of(context).brightness != Brightness.dark) {
     return visualStyle.background;
   }
-  if (task.status == 'done') {
+  if (task.status == TaskStatus.done) {
     return colors.surfaceMuted.withValues(alpha: 0.72);
   }
   return Color.lerp(colors.surfaceRaised, visualStyle.accent, 0.12)!;
@@ -1839,7 +1840,7 @@ Color _plannerBorderColor(
   if (Theme.of(context).brightness != Brightness.dark) {
     return visualStyle.border;
   }
-  if (task.status == 'done') {
+  if (task.status == TaskStatus.done) {
     return colors.border;
   }
   return Color.lerp(colors.border, visualStyle.accent, 0.38)!;

--- a/apps/desktop_flutter/test/controller_regressions_test.dart
+++ b/apps/desktop_flutter/test/controller_regressions_test.dart
@@ -251,7 +251,7 @@ class _FakeDashboardDataSource extends DashboardDataSource {
         Task(
           id: '2',
           title: 'Recent task',
-          status: 'open',
+          status: TaskStatus.open,
           createdAt: '2026-03-31T00:00:00.000Z',
           updatedAt: '2026-03-31T00:00:00.000Z',
         ),
@@ -284,7 +284,7 @@ class _FakeDashboardDataSource extends DashboardDataSource {
     return Task(
       id: id,
       title: 'Recent task',
-      status: 'done',
+      status: TaskStatus.done,
       createdAt: '2026-03-31T00:00:00.000Z',
       updatedAt: '2026-03-31T00:00:00.000Z',
     );
@@ -322,7 +322,7 @@ class _FakeDashboardHandoffDataSource extends _FakeDashboardDataSource {
           Task(
             id: 'shared-due',
             title: 'Shared due task',
-            status: 'open',
+            status: TaskStatus.open,
             dueDate: '2026-04-09',
             ownerId: 1,
             isShared: true,
@@ -335,7 +335,7 @@ class _FakeDashboardHandoffDataSource extends _FakeDashboardDataSource {
           Task(
             id: 'collaborative-unscheduled',
             title: 'Collaborative task',
-            status: 'open',
+            status: TaskStatus.open,
             ownerId: 2,
             collaborators: [TaskCollaborator(userId: 1, name: 'Alice')],
             createdAt: '2026-04-08T00:00:00.000Z',
@@ -372,7 +372,7 @@ class _FakeDashboardStableOrderingDataSource extends _FakeDashboardDataSource {
           Task(
             id: 'early',
             title: 'First task',
-            status: 'open',
+            status: TaskStatus.open,
             dueDate: '2026-04-09',
             createdAt: '2026-04-08T00:00:00.000Z',
             updatedAt: '2026-04-09T12:00:00.000Z',
@@ -380,7 +380,7 @@ class _FakeDashboardStableOrderingDataSource extends _FakeDashboardDataSource {
           Task(
             id: 'late',
             title: 'Edited task',
-            status: 'open',
+            status: TaskStatus.open,
             dueDate: '2026-04-09',
             createdAt: '2026-04-08T01:00:00.000Z',
             updatedAt: '2026-04-09T23:59:00.000Z',

--- a/apps/mcp_server/package.json
+++ b/apps/mcp_server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajhochy/rhythm-mcp-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for Rhythm — manage tasks, projects, and rhythms via Claude",
   "type": "commonjs",
   "main": "dist/index.js",

--- a/apps/mcp_server/src/index.ts
+++ b/apps/mcp_server/src/index.ts
@@ -9,6 +9,7 @@ import { registerRhythmTools } from './tools/rhythms.js';
 import { registerMessageTools } from './tools/messages.js';
 import { registerFacilityTools } from './tools/facilities.js';
 import { registerDashboardTools } from './tools/dashboard.js';
+import { registerClaudeTriggerTools } from './tools/claude_triggers.js';
 
 const RHYTHM_API_URL = process.env.RHYTHM_API_URL ?? 'https://api.vcrcapps.com';
 const RHYTHM_API_TOKEN = process.env.RHYTHM_API_TOKEN ?? '';
@@ -23,7 +24,7 @@ if (!RHYTHM_API_TOKEN) {
 
 const server = new McpServer({
   name: 'rhythm',
-  version: '0.1.0',
+  version: '0.2.0',
 });
 
 // Register all tools
@@ -34,6 +35,7 @@ registerRhythmTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerMessageTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerFacilityTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerDashboardTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
+registerClaudeTriggerTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 
 // Connect over stdio (Claude Desktop / Claude Code MCP transport)
 const transport = new StdioServerTransport();

--- a/apps/mcp_server/src/tools/claude_triggers.ts
+++ b/apps/mcp_server/src/tools/claude_triggers.ts
@@ -1,0 +1,28 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { apiGet, apiDelete, toolResult, toolError } from '../api_client.js';
+import { registerTool } from './_tool.js';
+
+export function registerClaudeTriggerTools(server: McpServer, apiUrl: string, apiToken: string) {
+  registerTool(server, 'rhythm_list_pending_triggers',
+    'List Rhythm tasks newly assigned to the Claude service account, awaiting pickup. Returns an array of {id, taskId, taskTitle, taskNotes, taskOwnerId, triggeredByUserId, createdAt}.',
+    {},
+    async () => {
+      try {
+        const triggers = await apiGet<unknown[]>(apiUrl, apiToken, '/claude-triggers');
+        return toolResult(JSON.stringify(triggers, null, 2));
+      } catch (err) { return toolError(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_clear_pending_trigger',
+    'Remove a pending trigger from the queue (call after picking up the task).',
+    { id: z.number().describe('The trigger row ID returned by rhythm_list_pending_triggers.') },
+    async ({ id }: { id: number }) => {
+      try {
+        await apiDelete(apiUrl, apiToken, `/claude-triggers/${id}`);
+        return toolResult(`Trigger ${id} cleared.`);
+      } catch (err) { return toolError(err); }
+    },
+  );
+}

--- a/apps/mcp_server/src/tools/messages.ts
+++ b/apps/mcp_server/src/tools/messages.ts
@@ -8,11 +8,15 @@ export function registerMessageTools(server: McpServer, apiUrl: string, apiToken
     'List message threads. Optionally filter to only threads with unread messages.',
     {
       unread_only: z.boolean().optional().describe('If true, return only threads with unread messages.'),
+      task_id: z.string().optional().describe('Filter to threads linked to this task ID.'),
     },
-    async ({ unread_only }: { unread_only?: boolean }) => {
+    async ({ unread_only, task_id }: { unread_only?: boolean; task_id?: string }) => {
       try {
-        const qs = unread_only ? '?unread=true' : '';
-        const threads = await apiGet<unknown[]>(apiUrl, apiToken, `/message-threads${qs}`);
+        const params = new URLSearchParams();
+        if (task_id) params.set('task_id', task_id);
+        if (unread_only) params.set('unread_only', 'true');
+        const qs = params.toString();
+        const threads = await apiGet<unknown[]>(apiUrl, apiToken, `/message-threads${qs ? `?${qs}` : ''}`);
         return toolResult(JSON.stringify(threads, null, 2));
       } catch (err) {
         return toolError(err);
@@ -26,13 +30,15 @@ export function registerMessageTools(server: McpServer, apiUrl: string, apiToken
       title: z.string().describe('Thread title.'),
       participant_ids: z.array(z.number().int()).optional().describe('User IDs to include as participants.'),
       thread_type: z.enum(['direct', 'group']).optional().describe("Thread type: 'direct' or 'group'. Defaults to 'group'."),
+      task_id: z.string().optional().describe('Optional task ID to link this thread to. Useful when discussing a specific task.'),
     },
-    async ({ title, participant_ids, thread_type }: { title: string; participant_ids?: number[]; thread_type?: string }) => {
+    async ({ title, participant_ids, thread_type, task_id }: { title: string; participant_ids?: number[]; thread_type?: string; task_id?: string }) => {
       try {
         const thread = await apiPost<unknown>(apiUrl, apiToken, '/message-threads', {
           title: decodeHtml(title),
           ...(participant_ids !== undefined && { participantIds: participant_ids }),
           ...(thread_type !== undefined && { threadType: thread_type }),
+          ...(task_id !== undefined && { taskId: task_id }),
         });
         return toolResult(JSON.stringify(thread, null, 2));
       } catch (err) {

--- a/apps/mcp_server/src/tools/messages.ts
+++ b/apps/mcp_server/src/tools/messages.ts
@@ -62,4 +62,22 @@ export function registerMessageTools(server: McpServer, apiUrl: string, apiToken
       }
     },
   );
+
+  registerTool(server, 'rhythm_get_task_thread',
+    'Find the message thread linked to a specific task. Returns the thread object or null.',
+    { task_id: z.string().describe('The task ID to look up.') },
+    async ({ task_id }: { task_id: string }) => {
+      try {
+        const threads = await apiGet<unknown[]>(
+          apiUrl,
+          apiToken,
+          `/message-threads?task_id=${encodeURIComponent(task_id)}`,
+        );
+        const thread = Array.isArray(threads) && threads.length > 0 ? threads[0] : null;
+        return toolResult(JSON.stringify(thread, null, 2));
+      } catch (err) {
+        return toolError(err);
+      }
+    },
+  );
 }

--- a/apps/mcp_server/src/tools/tasks.ts
+++ b/apps/mcp_server/src/tools/tasks.ts
@@ -54,7 +54,10 @@ export function registerTaskTools(server: McpServer, apiUrl: string, apiToken: s
       title: z.string().optional().describe('New title.'),
       notes: z.string().optional().describe('New notes.'),
       due_date: z.string().nullable().optional().describe('New due date (YYYY-MM-DD) or null to clear it.'),
-      status: z.enum(['open', 'done']).optional().describe('New status.'),
+      status: z
+        .enum(['open', 'in_progress', 'waiting_for_reply', 'done'])
+        .optional()
+        .describe('New status. Values: open, in_progress, waiting_for_reply, done.'),
     },
     async ({ id, title, notes, due_date, status }: { id: string; title?: string; notes?: string; due_date?: string | null; status?: string }) => {
       try {

--- a/docs/release/claude-collaborator-routine-prompt.md
+++ b/docs/release/claude-collaborator-routine-prompt.md
@@ -1,0 +1,65 @@
+# Claude Collaborator Routine — Prompt
+
+This prompt is embedded as the initial user message in the CCR routine `claude-rhythm-collaborator`. Update this file in the repo whenever the routine prompt changes; then run `RemoteTrigger update` against the routine ID.
+
+---
+
+You are the Rhythm workspace collaborator. Each time you wake up, follow this loop exactly.
+
+**Configuration (provided each run):**
+- Rhythm API base URL: `https://api.vcrcapps.com`
+- Authorization header: `Bearer <SERVICE_TOKEN>` (replace `<SERVICE_TOKEN>` at routine creation time)
+- Your user ID: `<CLAUDE_USER_ID>` (you are always a collaborator, never an owner)
+
+**Per-run flow:**
+
+1. **Fetch the trigger queue.**
+   ```
+   curl -s -H "Authorization: Bearer <TOKEN>" https://api.vcrcapps.com/claude-triggers
+   ```
+   Parse the JSON array. Each entry has: `id`, `taskId`, `taskTitle`, `taskNotes`, `taskOwnerId`, `triggeredByUserId`, `createdAt`.
+
+2. **For each new trigger:**
+   a. Create a thread linked to the task:
+      ```
+      curl -s -X POST -H "Authorization: Bearer <TOKEN>" -H "Content-Type: application/json" \
+        https://api.vcrcapps.com/message-threads \
+        -d '{"participantIds":[<taskOwnerId>,<CLAUDE_USER_ID>],"threadType":"direct","title":"<taskTitle>","taskId":"<taskId>"}'
+      ```
+   b. Post the opening message:
+      ```
+      curl -s -X POST -H "Authorization: Bearer <TOKEN>" -H "Content-Type: application/json" \
+        https://api.vcrcapps.com/message-threads/<threadId>/messages \
+        -d '{"body":"Picked up \"<taskTitle>\" — starting now."}'
+      ```
+   c. Set status to in_progress:
+      ```
+      curl -s -X PATCH -H "Authorization: Bearer <TOKEN>" -H "Content-Type: application/json" \
+        https://api.vcrcapps.com/tasks/<taskId> \
+        -d '{"status":"in_progress"}'
+      ```
+   d. Clear the trigger:
+      ```
+      curl -s -X DELETE -H "Authorization: Bearer <TOKEN>" \
+        https://api.vcrcapps.com/claude-triggers/<triggerId>
+      ```
+   e. **Read the task** title and notes. Use Read/Glob/Grep on the checked-out repo to do the work. Use Bash for git operations (branch, commit, push). Open a PR if applicable using `gh pr create`.
+   f. **If you need clarification** at any point, post a question to the thread and PATCH the task status to `waiting_for_reply`. Do not continue this task. Move on to the next trigger.
+   g. **On completion**, PATCH status to `done` and post a summary message to the thread (what you did, link to PR if applicable).
+
+3. **Resume waiting tasks.**
+   ```
+   curl -s -H "Authorization: Bearer <TOKEN>" https://api.vcrcapps.com/tasks
+   ```
+   Filter to entries where `status === "waiting_for_reply"`. For each:
+   a. Find the thread: `GET /message-threads?task_id=<taskId>`.
+   b. Fetch messages: `GET /message-threads/<threadId>/messages`.
+   c. Look at the most recent message. If `senderId !== <CLAUDE_USER_ID>` (i.e., the task owner replied), resume work using steps 2e–g.
+   d. Otherwise skip — the next hourly run will recheck.
+
+**Important rules:**
+- Never modify tasks you weren't assigned (don't touch tasks that aren't in the trigger queue or `waiting_for_reply` set).
+- Never reply to your own messages. Only resume on a real owner reply.
+- Always commit and push your code work to a feature branch and open a PR for review — don't merge to main yourself.
+- If any API call fails, log the error and continue with the next task. Don't get stuck on a single task.
+- If a trigger has been in the queue for more than 7 days, post a message to the thread saying you're abandoning it and DELETE the trigger.

--- a/docs/release/claude-collaborator-setup.md
+++ b/docs/release/claude-collaborator-setup.md
@@ -1,0 +1,168 @@
+# Claude Collaborator Service Account Setup
+
+One-time operational runbook for provisioning the `worship@visaliacrc.com`
+service account that the Claude as Rhythm Workspace Collaborator (CCR) routine
+uses to authenticate with the API server.
+
+Related issues: #332 (env var support), #338 (/claude-triggers endpoints), #344 (this runbook).
+Design spec: `docs/superpowers/specs/2026-05-04-claude-collaborator-design.md`
+
+---
+
+## Prerequisites
+
+- Production API server is running at `https://api.vcrcapps.com` (Synology Docker).
+- `CLAUDE_USER_ID` env var support is deployed (#332).
+- `/claude-triggers` endpoints are deployed (#338).
+- SSH access to the Synology, or the ability to exec into the running container.
+- Access to the team's password manager to store the resulting session token.
+
+---
+
+## Step 1 — Confirm the user record exists
+
+Connect to the production database. For the Synology SQLite deployment, exec
+into the container:
+
+```bash
+docker exec -it rhythm-api sh
+sqlite3 /data/rhythm.db
+```
+
+Run:
+
+```sql
+SELECT id, email FROM users WHERE email = 'worship@visaliacrc.com';
+```
+
+**Expected:** exactly one row. Note the `id` value — this becomes `CLAUDE_USER_ID`.
+
+**If no row exists:** The easiest path is to have someone log in via Google OAuth
+in the Rhythm Flutter desktop app once using `worship@visaliacrc.com`. Alternatively,
+insert the user directly:
+
+```sql
+INSERT INTO users (name, email, created_at)
+VALUES ('Claude (Worship)', 'worship@visaliacrc.com', datetime('now'));
+```
+
+Then re-run the SELECT to confirm and capture the `id`.
+
+---
+
+## Step 2 — Generate a session token
+
+### Easiest path
+Log into the Rhythm Flutter app once as `worship@visaliacrc.com` via Google OAuth.
+The app creates a session automatically on login.
+
+### Alternate path (direct DB insert)
+Still inside the SQLite shell, run:
+
+```sql
+INSERT INTO sessions (token, user_id, created_at, expires_at)
+VALUES (
+  lower(hex(randomblob(16))) || '-' || lower(hex(randomblob(2))) || '-4' ||
+    substr(lower(hex(randomblob(2))),2) || '-' ||
+    substr('89ab',abs(random()) % 4 + 1, 1) ||
+    substr(lower(hex(randomblob(2))),2) || '-' ||
+    lower(hex(randomblob(6))),
+  <id from step 1>,
+  datetime('now'),
+  datetime('now', '+365 days')
+);
+```
+
+Then read it back:
+
+```sql
+SELECT token FROM sessions
+WHERE user_id = <id from step 1>
+ORDER BY created_at DESC
+LIMIT 1;
+```
+
+### Token expiry policy
+
+Sessions have a **365-day TTL** (set in
+`apps/api_server/src/repositories/sessions_repository.ts`,
+`DEFAULT_SESSION_EXPIRY_DAYS = 365`). Tokens expire after one year. Plan to
+rotate the token annually:
+
+1. Log in again as `worship@visaliacrc.com`, or run the direct DB insert above.
+2. Update the token stored in the password manager.
+3. Update the token in the CCR routine prompt on claude.ai.
+
+**IMPORTANT:** Do NOT commit the session token to the repository. It lives only
+in the team password manager and in the CCR routine prompt on claude.ai.
+
+Save the token in the team password manager as:
+
+> **Label:** Rhythm Claude service account session token  
+> **Username:** worship@visaliacrc.com  
+> **Value:** \<token UUID\>  
+> **Expires:** \<today + 365 days\>
+
+---
+
+## Step 3 — Set the CLAUDE_USER_ID environment variable
+
+On the Synology, edit `.env.production` at
+`/volume1/docker/Rhythm/api_server/.env.production` and add:
+
+```
+CLAUDE_USER_ID=<id from step 1>
+```
+
+Then restart the API server container:
+
+```bash
+cd /volume1/docker/Rhythm/api_server
+docker compose -f docker-compose.synology.yml up -d
+```
+
+Verify the server came back up cleanly:
+
+```bash
+curl https://api.vcrcapps.com/health
+# Expected: 200 OK
+```
+
+Check container logs for any CLAUDE_USER_ID parse errors:
+
+```bash
+docker logs rhythm-api --tail 50
+```
+
+---
+
+## Step 4 — Smoke-test the endpoint gate
+
+### Non-Claude user should get 403
+
+```bash
+# Use your own session token here
+curl -i -H "Authorization: Bearer <your_personal_token>" \
+  https://api.vcrcapps.com/claude-triggers
+# Expected: HTTP/1.1 403 Forbidden
+```
+
+### Claude service account should get 200
+
+```bash
+curl -i -H "Authorization: Bearer <claude_token_from_step_2>" \
+  https://api.vcrcapps.com/claude-triggers
+# Expected: HTTP/1.1 200 OK
+# Body: [] (empty array if no triggers are pending)
+```
+
+---
+
+## Acceptance checklist
+
+- [ ] `worship@visaliacrc.com` user record confirmed in production DB; `id` noted
+- [ ] Session token generated and saved in team password manager (with expiry date)
+- [ ] `CLAUDE_USER_ID=<id>` added to `.env.production` on Synology; server restarted
+- [ ] `GET /claude-triggers` returns 403 for a non-Claude session token
+- [ ] `GET /claude-triggers` returns 200 with `[]` for the Claude session token
+- [ ] Token expiry reminder added to team calendar (365 days from token creation date)

--- a/docs/superpowers/plans/2026-05-04-task-assignment-email-notifications.md
+++ b/docs/superpowers/plans/2026-05-04-task-assignment-email-notifications.md
@@ -1,383 +1,79 @@
 # Task Assignment Email Notifications — Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+**Spec:** [`docs/superpowers/specs/2026-05-04-task-assignment-email-notifications-design.md`](../specs/2026-05-04-task-assignment-email-notifications-design.md)
 
-**Goal:** Send a transactional email via Resend when a user is assigned to a task or added as a collaborator, with a per-user opt-out toggle in the Flutter Settings screen.
+**Goal:** Send a transactional email via Resend when a user is assigned a task or added as a task collaborator. Users can opt out via a Settings toggle.
 
-**Architecture:** A new `EmailService` sits alongside the existing `NotificationService` in `TasksController`. Both are called at the same trigger points. `EmailService` fetches the recipient user, checks their opt-out flag, and sends via the Resend SDK. If `RESEND_API_KEY` is unset, the service is a silent no-op.
-
-**Tech Stack:** Node.js/TypeScript (Express + better-sqlite3/pg), `resend` npm package, Flutter/Dart (Provider pattern)
+**Tech Stack:** Node.js / TypeScript / Express / Resend SDK / Flutter / SQLite + Postgres dual-write
 
 ---
 
-## File Map
+## Phase 1 — Foundation: opt-out column + model wiring
 
-| File | Action | What changes |
-|---|---|---|
-| `apps/api_server/src/database/migrations.ts` | Modify | Add `email_notifications_enabled` column to `users` |
-| `apps/api_server/src/models/user.ts` | Modify | Add field to `User` and `UpdateUserDto` |
-| `apps/api_server/src/repositories/users_repository.ts` | Modify | Add to `UserRow`, `rowToUser`, `updateAsync`, `update` |
-| `apps/api_server/src/config/env.ts` | Modify | Add `resendApiKey`, `emailFromAddress` |
-| `apps/api_server/package.json` | Modify | Add `resend` dependency |
-| `apps/api_server/src/services/email_service.ts` | Create | New `EmailService` class |
-| `apps/api_server/src/controllers/tasks_controller.ts` | Modify | Import + call `EmailService` at both trigger points |
-| `apps/desktop_flutter/lib/app/core/auth/auth_user.dart` | Modify | Add `emailNotificationsEnabled` field |
-| `apps/desktop_flutter/lib/features/settings/data/settings_data_source.dart` | Modify | Add `emailNotificationsEnabled` param to `updateUser` |
-| `apps/desktop_flutter/lib/features/settings/repositories/settings_repository.dart` | Modify | Add `emailNotificationsEnabled` param to `updateUser` |
-| `apps/desktop_flutter/lib/features/settings/controllers/settings_controller.dart` | Modify | Add `emailNotificationsEnabled` param to `updateUser` |
-| `apps/desktop_flutter/lib/features/settings/views/settings_view.dart` | Modify | Add NOTIFICATIONS section with opt-out toggle |
-
----
-
-## Task 1: DB Migration + User Model + UsersRepository
+### 1.1 Add `email_notifications_enabled` column to `users`
 
 **Files:**
-- Modify: `apps/api_server/src/database/migrations.ts`
-- Modify: `apps/api_server/src/models/user.ts`
-- Modify: `apps/api_server/src/repositories/users_repository.ts`
+- `apps/api_server/src/database/migrations.ts` — add `ALTER TABLE` block in the SQLite migration section, mirroring the existing `is_facilities_manager` pattern around line 335. Include the equivalent Postgres migration.
 
-- [ ] **Step 1: Write failing test for migration column**
-
-Create `apps/api_server/src/__tests__/email_notifications.test.ts`:
-
-```typescript
-import { beforeEach, describe, expect, it } from 'vitest';
-import Database from 'better-sqlite3';
-import { runMigrations } from '../database/migrations';
-import { setDb } from '../database/db';
-import { UsersRepository } from '../repositories/users_repository';
-
-function makeDb() {
-  const db = new Database(':memory:');
-  db.pragma('foreign_keys = ON');
-  db.pragma('journal_mode = WAL');
-  runMigrations(db);
-  return db;
-}
-
-describe('email_notifications_enabled', () => {
-  let usersRepo: UsersRepository;
-
-  beforeEach(() => {
-    const db = makeDb();
-    setDb(db);
-    usersRepo = new UsersRepository();
-  });
-
-  it('defaults emailNotificationsEnabled to true on new users', () => {
-    const user = usersRepo.create({ name: 'Alice', email: 'alice@test.com' });
-    expect(user.emailNotificationsEnabled).toBe(true);
-  });
-
-  it('can set emailNotificationsEnabled to false via update', () => {
-    const user = usersRepo.create({ name: 'Bob', email: 'bob@test.com' });
-    const updated = usersRepo.update(user.id, { emailNotificationsEnabled: false });
-    expect(updated.emailNotificationsEnabled).toBe(false);
-  });
-
-  it('preserves emailNotificationsEnabled when updating other fields', () => {
-    const user = usersRepo.create({ name: 'Carol', email: 'carol@test.com' });
-    usersRepo.update(user.id, { emailNotificationsEnabled: false });
-    const updated = usersRepo.update(user.id, { name: 'Carol Updated' });
-    expect(updated.emailNotificationsEnabled).toBe(false);
-  });
-});
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-```bash
-cd apps/api_server && npm test -- --reporter=verbose email_notifications
-```
-
-Expected: FAIL — `emailNotificationsEnabled` is undefined.
-
-- [ ] **Step 3: Add migration**
-
-In `apps/api_server/src/database/migrations.ts`, add at the very end of the `runMigrations` function body, after the notifications block:
-
-```typescript
-  // Email notification preferences
-  const userColsEmail = (db.pragma('table_info(users)') as { name: string }[]).map((c) => c.name);
-  if (!userColsEmail.includes('email_notifications_enabled')) {
-    db.exec(`ALTER TABLE users ADD COLUMN email_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE`);
-  }
-```
-
-- [ ] **Step 4: Update User model**
-
-In `apps/api_server/src/models/user.ts`, add `emailNotificationsEnabled` to both interfaces:
-
-```typescript
-export interface User {
-  id: number;
-  name: string;
-  email: string;
-  googleSub: string | null;
-  photoUrl: string | null;
-  role: string;
-  isFacilitiesManager: boolean;
-  emailNotificationsEnabled: boolean;   // ← add this line
-  createdAt: string;
-  updatedAt: string;
-}
-
-// ... (CreateUserDto is unchanged)
-
-export interface UpdateUserDto {
-  name?: string;
-  email?: string;
-  googleSub?: string | null;
-  photoUrl?: string | null;
-  role?: string;
-  isFacilitiesManager?: boolean;
-  emailNotificationsEnabled?: boolean;  // ← add this line
+**Migration snippet (SQLite):**
+```ts
+const userColsP9 = (db.pragma('table_info(users)') as { name: string }[]).map((c) => c.name);
+if (!userColsP9.includes('email_notifications_enabled')) {
+  db.exec(
+    `ALTER TABLE users ADD COLUMN email_notifications_enabled INTEGER NOT NULL DEFAULT 1`,
+  );
 }
 ```
 
-- [ ] **Step 5: Update UsersRepository**
-
-In `apps/api_server/src/repositories/users_repository.ts`:
-
-**a) Add `email_notifications_enabled` to `UserRow`:**
-```typescript
-interface UserRow {
-  id: number;
-  name: string;
-  email: string;
-  google_sub: string | null;
-  photo_url: string | null;
-  role: string;
-  is_facilities_manager: number;
-  email_notifications_enabled: number | boolean;  // ← add this line
-  created_at: string;
-  updated_at: string;
-}
+**Postgres equivalent** (in the postgres branch of migrations):
+```sql
+ALTER TABLE users ADD COLUMN IF NOT EXISTS email_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE;
 ```
 
-**b) Add to `rowToUser`** — add after the `isFacilitiesManager` assignment:
-```typescript
-function rowToUser(row: UserRow): User {
-  const isFacilitiesManager =
-    typeof row.is_facilities_manager === 'boolean'
-      ? row.is_facilities_manager
-      : row.is_facilities_manager === 1;
+**Acceptance:**
+- Running the API server against an existing DB (both SQLite and Postgres) adds the column with default `true`/`1`
+- All existing users get `emailNotificationsEnabled = true` after migration
+- Re-running migrations is idempotent (no error)
 
-  const emailNotificationsEnabled =
-    typeof row.email_notifications_enabled === 'boolean'
-      ? row.email_notifications_enabled
-      : row.email_notifications_enabled !== 0;
+### 1.2 Update `User` model + `UsersRepository` to expose `emailNotificationsEnabled`
 
-  return {
-    id: row.id,
-    name: row.name,
-    email: row.email,
-    googleSub: row.google_sub,
-    photoUrl: row.photo_url,
-    role: row.role,
-    isFacilitiesManager,
-    emailNotificationsEnabled,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  };
-}
-```
+**Files:**
+- `apps/api_server/src/models/user.ts` — add `emailNotificationsEnabled: boolean` to `User`, `CreateUserDto` (optional), `UpdateUserDto` (optional)
+- `apps/api_server/src/repositories/users_repository.ts` — add the column to `UserRow` interface, `rowToUser()` mapping (handle SQLite's `0|1` → boolean), all SELECT/INSERT/UPDATE statements
 
-**c) Replace `updateAsync` (Postgres branch) SQL** — shift param numbers to make room for the new field before `updated_at`:
-```typescript
-async updateAsync(id: number, data: UpdateUserDto): Promise<User> {
-  if (env.dbClient === 'postgres') {
-    const existing = await this.findByIdAsync(id);
-    const now = new Date().toISOString();
-    const result = await getPostgresPool().query<UserRow>(
-      `UPDATE users
-          SET name = $1,
-              email = $2,
-              google_sub = $3,
-              photo_url = $4,
-              role = $5,
-              is_facilities_manager = $6,
-              email_notifications_enabled = $7,
-              updated_at = $8
-        WHERE id = $9
-        RETURNING *`,
-      [
-        data.name ?? existing.name,
-        data.email ?? existing.email,
-        data.googleSub ?? existing.googleSub,
-        data.photoUrl !== undefined ? data.photoUrl : existing.photoUrl,
-        data.role ?? existing.role,
-        data.isFacilitiesManager !== undefined
-          ? data.isFacilitiesManager
-          : existing.isFacilitiesManager,
-        data.emailNotificationsEnabled !== undefined
-          ? data.emailNotificationsEnabled
-          : existing.emailNotificationsEnabled,
-        now,
-        id,
-      ],
-    );
-    return rowToUser(result.rows[0]);
-  }
-
-  return this.update(id, data);
-}
-```
-
-**d) Replace `update` (SQLite branch)**:
-```typescript
-update(id: number, data: UpdateUserDto): User {
-  const existing = this.findById(id);
-  const now = new Date().toISOString();
-  getDb()
-    .prepare(
-      `UPDATE users
-          SET name = ?,
-              email = ?,
-              google_sub = ?,
-              photo_url = ?,
-              role = ?,
-              is_facilities_manager = ?,
-              email_notifications_enabled = ?,
-              updated_at = ?
-        WHERE id = ?`,
-    )
-    .run(
-      data.name ?? existing.name,
-      data.email ?? existing.email,
-      data.googleSub ?? existing.googleSub,
-      data.photoUrl !== undefined ? data.photoUrl : existing.photoUrl,
-      data.role ?? existing.role,
-      data.isFacilitiesManager !== undefined
-        ? (data.isFacilitiesManager ? 1 : 0)
-        : (existing.isFacilitiesManager ? 1 : 0),
-      data.emailNotificationsEnabled !== undefined
-        ? (data.emailNotificationsEnabled ? 1 : 0)
-        : (existing.emailNotificationsEnabled ? 1 : 0),
-      now,
-      id,
-    );
-  return this.findById(id);
-}
-```
-
-- [ ] **Step 6: Run tests to verify they pass**
-
-```bash
-cd apps/api_server && npm test -- --reporter=verbose email_notifications
-```
-
-Expected: 3 tests PASS.
-
-- [ ] **Step 7: Run full test suite to catch regressions**
-
-```bash
-cd apps/api_server && npm test
-```
-
-Expected: all tests pass.
-
-- [ ] **Step 8: Commit**
-
-```bash
-cd apps/api_server
-git add src/database/migrations.ts src/models/user.ts src/repositories/users_repository.ts src/__tests__/email_notifications.test.ts
-git commit -m "feat: add email_notifications_enabled field to users"
-```
+**Acceptance:**
+- `findByIdAsync()` returns `emailNotificationsEnabled: boolean`
+- `updateAsync({ emailNotificationsEnabled: false })` persists correctly in both SQLite and Postgres
+- Existing tests still pass
 
 ---
 
-## Task 2: Resend Package + Env Vars + EmailService
+## Phase 2 — Email Service
+
+### 2.1 Add `resend` package and email env vars
 
 **Files:**
-- Modify: `apps/api_server/package.json`
-- Modify: `apps/api_server/src/config/env.ts`
-- Create: `apps/api_server/src/services/email_service.ts`
-
-- [ ] **Step 1: Add Resend dependency**
-
-```bash
-cd apps/api_server && npm install resend
-```
-
-- [ ] **Step 2: Add env vars to config**
-
-In `apps/api_server/src/config/env.ts`, add two fields at the end of the `env` object (before the closing `};`):
-
-```typescript
+- `apps/api_server/package.json` — add `resend` dependency (latest stable, currently `^4.x`)
+- `apps/api_server/src/config/env.ts` — add two env getters:
+  ```ts
   resendApiKey: process.env.RESEND_API_KEY ?? '',
   emailFromAddress: process.env.EMAIL_FROM_ADDRESS ?? 'Rhythm <onboarding@resend.dev>',
-```
+  ```
+- `apps/api_server/.env.production.example` — add `RESEND_API_KEY=` and `EMAIL_FROM_ADDRESS=Rhythm <notifications@yourdomain.com>` template lines
 
-- [ ] **Step 3: Write failing tests for EmailService**
+**Acceptance:**
+- `npm install` succeeds; `resend` listed in `dependencies`
+- `env.resendApiKey` is `''` when var unset; populated when set
+- `.env.production.example` has the new vars documented (empty key)
 
-Add to `apps/api_server/src/__tests__/email_notifications.test.ts`:
+### 2.2 Create `EmailService`
 
-```typescript
-import { EmailService } from '../services/email_service';
+**Files:**
+- Create: `apps/api_server/src/services/email_service.ts`
+- Create: `apps/api_server/src/services/email_service.test.ts`
 
-describe('EmailService', () => {
-  let usersRepo: UsersRepository;
-
-  beforeEach(() => {
-    const db = makeDb();
-    setDb(db);
-    usersRepo = new UsersRepository();
-  });
-
-  it('is a no-op when resendApiKey is empty', async () => {
-    const alice = usersRepo.create({ name: 'Alice', email: 'alice@test.com' });
-    const bob = usersRepo.create({ name: 'Bob', email: 'bob@test.com' });
-    const svc = new EmailService(usersRepo, '');
-    // Should not throw
-    await expect(
-      svc.sendTaskAssignedEmailAsync('task-1', 'Fix bug', alice.id, bob.id),
-    ).resolves.toBeUndefined();
-  });
-
-  it('skips send when actor equals recipient', async () => {
-    const alice = usersRepo.create({ name: 'Alice', email: 'alice@test.com' });
-    const svc = new EmailService(usersRepo, '');
-    await expect(
-      svc.sendTaskAssignedEmailAsync('task-1', 'Fix bug', alice.id, alice.id),
-    ).resolves.toBeUndefined();
-  });
-
-  it('skips send when recipient has opted out', async () => {
-    const alice = usersRepo.create({ name: 'Alice', email: 'alice@test.com' });
-    const bob = usersRepo.create({ name: 'Bob', email: 'bob@test.com' });
-    usersRepo.update(bob.id, { emailNotificationsEnabled: false });
-    const svc = new EmailService(usersRepo, 'fake-key');
-    // Would throw if it tried to actually call Resend with a fake key,
-    // but it should return early due to opt-out
-    await expect(
-      svc.sendTaskAssignedEmailAsync('task-1', 'Fix bug', alice.id, bob.id),
-    ).resolves.toBeUndefined();
-  });
-
-  it('skips collaborator email when actor equals recipient', async () => {
-    const alice = usersRepo.create({ name: 'Alice', email: 'alice@test.com' });
-    const svc = new EmailService(usersRepo, '');
-    await expect(
-      svc.sendCollaboratorAddedEmailAsync('task-1', 'Fix bug', alice.id, alice.id),
-    ).resolves.toBeUndefined();
-  });
-});
-```
-
-- [ ] **Step 4: Run test to verify it fails**
-
-```bash
-cd apps/api_server && npm test -- --reporter=verbose email_notifications
-```
-
-Expected: FAIL — `EmailService` does not exist yet.
-
-- [ ] **Step 5: Create EmailService**
-
-Create `apps/api_server/src/services/email_service.ts`:
-
-```typescript
+**Service shape:**
+```ts
 import { Resend } from 'resend';
 import { env } from '../config/env';
 import type { UsersRepository } from '../repositories/users_repository';
@@ -385,604 +81,311 @@ import type { UsersRepository } from '../repositories/users_repository';
 export class EmailService {
   private readonly client: Resend | null;
 
-  constructor(
-    private readonly usersRepo: UsersRepository,
-    resendApiKey?: string,
-  ) {
-    const key = resendApiKey ?? '';
-    this.client = key ? new Resend(key) : null;
+  constructor(private readonly usersRepo: UsersRepository) {
+    this.client = env.resendApiKey ? new Resend(env.resendApiKey) : null;
   }
 
   async sendTaskAssignedEmailAsync(
     taskId: string,
     taskTitle: string,
-    actorUserId: number,
+    actorName: string,
     recipientUserId: number,
+    actorUserId: number,
   ): Promise<void> {
-    if (actorUserId === recipientUserId) return;
-    if (!this.client) return;
-
-    try {
-      const [actor, recipient] = await Promise.all([
-        this.usersRepo.findByIdAsync(actorUserId),
-        this.usersRepo.findByIdAsync(recipientUserId),
-      ]);
-
-      if (!recipient.emailNotificationsEnabled) return;
-
-      await this.client.emails.send({
-        from: env.emailFromAddress,
-        to: recipient.email,
-        subject: `${actor.name} added you to "${taskTitle}" in Rhythm`,
-        html: this._buildHtml(actor.name, taskTitle, taskId),
-        text: this._buildText(actor.name, taskTitle, taskId),
-      });
-    } catch (err) {
-      console.error('[EmailService] sendTaskAssignedEmailAsync failed:', err);
-    }
+    await this.sendCollaborationEmailAsync({
+      taskId, taskTitle, actorName, recipientUserId, actorUserId,
+      subjectVerb: 'assigned you to',
+    });
   }
 
   async sendCollaboratorAddedEmailAsync(
     taskId: string,
     taskTitle: string,
-    actorUserId: number,
+    actorName: string,
     recipientUserId: number,
+    actorUserId: number,
   ): Promise<void> {
-    if (actorUserId === recipientUserId) return;
+    await this.sendCollaborationEmailAsync({
+      taskId, taskTitle, actorName, recipientUserId, actorUserId,
+      subjectVerb: 'added you to',
+    });
+  }
+
+  private async sendCollaborationEmailAsync(params: {
+    taskId: string;
+    taskTitle: string;
+    actorName: string;
+    recipientUserId: number;
+    actorUserId: number;
+    subjectVerb: string;
+  }): Promise<void> {
+    if (params.recipientUserId === params.actorUserId) return;
     if (!this.client) return;
 
+    const recipient = await this.usersRepo.findByIdAsync(params.recipientUserId).catch(() => null);
+    if (!recipient || !recipient.emailNotificationsEnabled || !recipient.email) return;
+
+    const link = `rhythm://tasks/${params.taskId}`;
+    const subject = `${params.actorName} ${params.subjectVerb} "${params.taskTitle}" in Rhythm`;
+    const html = `
+      <p>${escapeHtml(params.actorName)} has invited you to collaborate on
+      "<strong>${escapeHtml(params.taskTitle)}</strong>" in Rhythm.</p>
+      <p><a href="${link}">Click here to open in Rhythm</a></p>
+      <hr>
+      <p style="color:#6B7280;font-size:12px">
+        You're receiving this because you have email notifications enabled in Rhythm.
+      </p>
+    `;
+    const text = `${params.actorName} has invited you to collaborate on "${params.taskTitle}" in Rhythm.\n\nOpen in Rhythm: ${link}`;
+
     try {
-      const [actor, recipient] = await Promise.all([
-        this.usersRepo.findByIdAsync(actorUserId),
-        this.usersRepo.findByIdAsync(recipientUserId),
-      ]);
-
-      if (!recipient.emailNotificationsEnabled) return;
-
       await this.client.emails.send({
         from: env.emailFromAddress,
         to: recipient.email,
-        subject: `${actor.name} added you to "${taskTitle}" in Rhythm`,
-        html: this._buildHtml(actor.name, taskTitle, taskId),
-        text: this._buildText(actor.name, taskTitle, taskId),
+        subject,
+        html,
+        text,
       });
     } catch (err) {
-      console.error('[EmailService] sendCollaboratorAddedEmailAsync failed:', err);
+      console.error('[email] send failed', err);
     }
   }
+}
 
-  private _buildHtml(actorName: string, taskTitle: string, taskId: string): string {
-    return `<!DOCTYPE html>
-<html>
-<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#111827;max-width:480px;margin:0 auto;padding:24px;">
-  <h2 style="color:#4F6AF5;margin-top:0;">You've been added to a task</h2>
-  <p><strong>${this._esc(actorName)}</strong> has invited you to collaborate on <strong>&ldquo;${this._esc(taskTitle)}&rdquo;</strong> in Rhythm.</p>
-  <p style="margin-top:24px;">
-    <a href="rhythm://tasks/${encodeURIComponent(taskId)}"
-       style="display:inline-block;background:#4F6AF5;color:#ffffff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600;">
-      Open in Rhythm
-    </a>
-  </p>
-  <p style="color:#6B7280;font-size:12px;margin-top:32px;">
-    You're receiving this because you have email notifications enabled in Rhythm.<br>
-    You can turn these off in Rhythm &rarr; Settings &rarr; Notifications.
-  </p>
-</body>
-</html>`;
-  }
-
-  private _buildText(actorName: string, taskTitle: string, taskId: string): string {
-    return `${actorName} has invited you to collaborate on "${taskTitle}" in Rhythm.\n\nOpen in Rhythm: rhythm://tasks/${taskId}\n\nYou can turn off email notifications in Rhythm → Settings → Notifications.`;
-  }
-
-  private _esc(str: string): string {
-    return str
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
-  }
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  }[c]!));
 }
 ```
 
-- [ ] **Step 6: Run tests to verify they pass**
+**Tests** (vitest, mocking `Resend` and `UsersRepository`):
+- skips when `recipientUserId === actorUserId`
+- skips when `RESEND_API_KEY` is unset (no-op, no throw)
+- skips when recipient `emailNotificationsEnabled` is false
+- skips when recipient not found
+- calls `client.emails.send` with correct subject/from/to when enabled
+- swallows Resend errors (does not throw)
+- HTML escapes special chars in `actorName` and `taskTitle`
 
-```bash
-cd apps/api_server && npm test -- --reporter=verbose email_notifications
-```
-
-Expected: all 7 tests PASS (3 from Task 1 + 4 new).
-
-- [ ] **Step 7: Run full test suite**
-
-```bash
-cd apps/api_server && npm test
-```
-
-Expected: all tests pass.
-
-- [ ] **Step 8: Commit**
-
-```bash
-cd apps/api_server
-git add package.json package-lock.json src/config/env.ts src/services/email_service.ts src/__tests__/email_notifications.test.ts
-git commit -m "feat: add EmailService with Resend integration"
-```
+**Acceptance:**
+- All tests pass: `cd apps/api_server && npm test`
+- `EmailService` is independently constructible from `UsersRepository`
 
 ---
 
-## Task 3: Wire EmailService into TasksController
+## Phase 3 — Wire into TasksController
+
+### 3.1 Hook `EmailService` into task assignment + collaborator add
 
 **Files:**
 - Modify: `apps/api_server/src/controllers/tasks_controller.ts`
 
-- [ ] **Step 1: Add imports and module-level instantiation**
+**Changes:**
 
-At the top of `apps/api_server/src/controllers/tasks_controller.ts`, add the new imports alongside the existing ones:
-
-```typescript
-import { UsersRepository } from '../repositories/users_repository';
+Top of file — add imports + instantiate:
+```ts
 import { EmailService } from '../services/email_service';
-import { env } from '../config/env';
+import { UsersRepository } from '../repositories/users_repository';
+
+const usersRepo = new UsersRepository();
+const emailService = new EmailService(usersRepo);
 ```
 
-Then add the service instantiation below the existing `notifService` line:
+In `update()` — after the existing `notifyTaskAssignedAsync` call (around line 67), fetch the actor name and fire the email:
 
-```typescript
-const repo = new TasksRepository();
-const rulesRepo = new RecurringTaskRulesRepository();
-const notifService = new NotificationService(new NotificationsRepository());
-const emailService = new EmailService(new UsersRepository(), env.resendApiKey);  // ← add this line
+```ts
+if (
+  data.ownerId !== undefined &&
+  updated.ownerId != null &&
+  updated.ownerId !== existing.ownerId &&
+  actorId != null
+) {
+  await notifService.notifyTaskAssignedAsync(
+    updated.id,
+    updated.title,
+    updated.ownerId,
+    actorId,
+  );
+  const actor = await usersRepo.findByIdAsync(actorId).catch(() => null);
+  if (actor) {
+    await emailService.sendTaskAssignedEmailAsync(
+      updated.id,
+      updated.title,
+      actor.name,
+      updated.ownerId,
+      actorId,
+    );
+  }
+}
 ```
 
-- [ ] **Step 2: Add email call at task assignment trigger**
+In `addCollaborator()` — after the existing `notifyCollaboratorAddedAsync` call (around line 142):
 
-In the `update` method, the existing assignment block ends with `notifyTaskAssignedAsync`. Add the email call immediately after it:
-
-Replace this block:
-```typescript
-      // Notify on assignment
-      if (
-        data.ownerId !== undefined &&
-        updated.ownerId != null &&
-        updated.ownerId !== existing.ownerId &&
-        actorId != null
-      ) {
-        await notifService.notifyTaskAssignedAsync(
-          updated.id,
-          updated.title,
-          updated.ownerId,
-          actorId,
-        );
-      }
+```ts
+await notifService.notifyCollaboratorAddedAsync(
+  'task',
+  req.params.id,
+  task.title,
+  userId,
+  actorId,
+);
+const actor = await usersRepo.findByIdAsync(actorId).catch(() => null);
+if (actor) {
+  await emailService.sendCollaboratorAddedEmailAsync(
+    req.params.id,
+    task.title,
+    actor.name,
+    userId,
+    actorId,
+  );
+}
 ```
 
-With:
-```typescript
-      // Notify on assignment
-      if (
-        data.ownerId !== undefined &&
-        updated.ownerId != null &&
-        updated.ownerId !== existing.ownerId &&
-        actorId != null
-      ) {
-        await notifService.notifyTaskAssignedAsync(
-          updated.id,
-          updated.title,
-          updated.ownerId,
-          actorId,
-        );
-        await emailService.sendTaskAssignedEmailAsync(
-          updated.id,
-          updated.title,
-          actorId,
-          updated.ownerId,
-        );
-      }
-```
-
-- [ ] **Step 3: Add email call at collaborator addition trigger**
-
-In the `addCollaborator` method, the existing call ends with `notifyCollaboratorAddedAsync`. Add the email call immediately after it:
-
-Replace this block:
-```typescript
-      await repo.addCollaboratorAsync(req.params.id, userId);
-      await notifService.notifyCollaboratorAddedAsync(
-        'task',
-        req.params.id,
-        task.title,
-        userId,
-        actorId,
-      );
-      res.status(201).json(await repo.listCollaboratorsAsync(req.params.id));
-```
-
-With:
-```typescript
-      await repo.addCollaboratorAsync(req.params.id, userId);
-      await notifService.notifyCollaboratorAddedAsync(
-        'task',
-        req.params.id,
-        task.title,
-        userId,
-        actorId,
-      );
-      await emailService.sendCollaboratorAddedEmailAsync(
-        req.params.id,
-        task.title,
-        actorId,
-        userId,
-      );
-      res.status(201).json(await repo.listCollaboratorsAsync(req.params.id));
-```
-
-- [ ] **Step 4: Build to catch TypeScript errors**
-
-```bash
-cd apps/api_server && npm run build
-```
-
-Expected: exits 0 with no errors.
-
-- [ ] **Step 5: Run full test suite**
-
-```bash
-cd apps/api_server && npm test
-```
-
-Expected: all tests pass.
-
-- [ ] **Step 6: Commit**
-
-```bash
-cd apps/api_server
-git add src/controllers/tasks_controller.ts
-git commit -m "feat: send email notification on task assignment and collaborator addition"
-```
+**Acceptance:**
+- PATCH `/tasks/:id` with `ownerId` change → email received by new owner (when `RESEND_API_KEY` is set, recipient opted in, and recipient ≠ actor)
+- POST `/tasks/:id/collaborators` → email received by new collaborator
+- Self-assignment / self-add does NOT send email
+- Email failures do not break the API response (logged only)
+- Existing in-app notification still fires correctly
 
 ---
 
-## Task 4: Flutter Opt-Out Toggle
+## Phase 4 — Flutter opt-out toggle
+
+### 4.1 Add `PATCH /users/me/preferences` endpoint
+
+The existing `PATCH /users/:id` requires admin. Users need to update their own preferences without admin role. Add a self-service endpoint.
 
 **Files:**
-- Modify: `apps/desktop_flutter/lib/app/core/auth/auth_user.dart`
-- Modify: `apps/desktop_flutter/lib/features/settings/data/settings_data_source.dart`
-- Modify: `apps/desktop_flutter/lib/features/settings/repositories/settings_repository.dart`
-- Modify: `apps/desktop_flutter/lib/features/settings/controllers/settings_controller.dart`
+- Modify: `apps/api_server/src/controllers/users_controller.ts` — add `updateMyPreferences` method
+- Modify: `apps/api_server/src/routes/users_routes.ts` — wire `PATCH /users/me/preferences` route (must be registered BEFORE `:id` route to avoid path collision)
+
+**Controller method:**
+```ts
+async updateMyPreferences(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userId = req.auth!.user.id;
+    const { emailNotificationsEnabled } = req.body as Record<string, unknown>;
+    if (typeof emailNotificationsEnabled !== 'boolean') {
+      throw AppError.badRequest('emailNotificationsEnabled must be a boolean');
+    }
+    const user = await repo.updateAsync(userId, { emailNotificationsEnabled });
+    res.json(user);
+  } catch (err) {
+    next(err);
+  }
+}
+```
+
+**Route registration** (BEFORE `:id` patterns):
+```ts
+usersRouter.patch('/me/preferences', controller.updateMyPreferences.bind(controller));
+```
+
+**Acceptance:**
+- Authenticated non-admin user can `PATCH /users/me/preferences { emailNotificationsEnabled: false }` and the change persists
+- Returns the updated user object
+- Bad request body → 400
+- Unauthenticated → 401
+
+### 4.2 Add Flutter user preferences data layer
+
+**Files:**
+- Create: `apps/desktop_flutter/lib/features/settings/data/user_preferences_data_source.dart`
+- Modify: `apps/desktop_flutter/lib/features/settings/repositories/settings_repository.dart` — add `updateEmailNotifications(bool enabled)` method
+- Modify: `apps/desktop_flutter/lib/features/settings/controllers/settings_controller.dart` — add `bool emailNotificationsEnabled`, loader, `setEmailNotifications(bool)` that calls the repository and `notifyListeners()`
+- Modify: `apps/desktop_flutter/lib/app/core/auth/auth_user.dart` — add `emailNotificationsEnabled` field, parse from JSON (`json['emailNotificationsEnabled'] ?? true`)
+
+**Data source method:**
+```dart
+Future<void> updateEmailNotifications(bool enabled) async {
+  final response = await http.patch(
+    Uri.parse('$baseUrl/users/me/preferences'),
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $token',
+    },
+    body: jsonEncode({'emailNotificationsEnabled': enabled}),
+  );
+  if (response.statusCode != 200) {
+    throw Exception('Failed to update preferences: ${response.statusCode}');
+  }
+}
+```
+
+**Acceptance:**
+- Repository method round-trips successfully against the API
+- Controller exposes `emailNotificationsEnabled` and updates state on toggle
+- `AuthUser.fromJson` reads the new field, defaults to `true` when missing
+
+### 4.3 Add Email Notifications toggle to Settings view
+
+**Files:**
 - Modify: `apps/desktop_flutter/lib/features/settings/views/settings_view.dart`
 
-- [ ] **Step 1: Add `emailNotificationsEnabled` to `AuthUser`**
-
-In `apps/desktop_flutter/lib/app/core/auth/auth_user.dart`, replace the entire file:
+Add a new section (under existing settings rows) titled "Notifications" with a single `SwitchListTile`:
 
 ```dart
-import '../utils/json_parsing.dart';
-
-class AuthUser {
-  const AuthUser({
-    required this.id,
-    required this.name,
-    required this.email,
-    required this.role,
-    this.isFacilitiesManager = false,
-    this.emailNotificationsEnabled = true,
-    this.photoUrl,
-  });
-
-  final int id;
-  final String name;
-  final String email;
-  final String role;
-  final bool isFacilitiesManager;
-  final bool emailNotificationsEnabled;
-  final String? photoUrl;
-
-  bool get isAdmin => role == 'admin' || role == 'system';
-
-  factory AuthUser.fromJson(Map<String, dynamic> json) {
-    return AuthUser(
-      id: _asInt(json['id']) ?? 0,
-      name: _asString(json['name']) ?? '',
-      email: _asString(json['email']) ?? '',
-      role: _asString(json['role']) ?? 'member',
-      isFacilitiesManager: _asBool(json['isFacilitiesManager']) ??
-          _asBool(json['is_facilities_manager']) ??
-          false,
-      emailNotificationsEnabled:
-          _asBool(json['emailNotificationsEnabled']) ??
-          _asBool(json['email_notifications_enabled']) ??
-          true,
-      photoUrl: _asString(json['photoUrl']) ?? _asString(json['photo_url']),
-    );
-  }
-}
-
-String? _asString(dynamic value) => asString(value);
-int? _asInt(dynamic value) => asInt(value);
-bool? _asBool(dynamic value) => asBool(value);
-```
-
-- [ ] **Step 2: Update SettingsDataSource**
-
-In `apps/desktop_flutter/lib/features/settings/data/settings_data_source.dart`, replace the `updateUser` method:
-
-```dart
-  Future<AuthUser> updateUser(
-    int userId, {
-    String? role,
-    bool? isFacilitiesManager,
-    bool? emailNotificationsEnabled,
-  }) async {
-    final response = await http.patch(
-      Uri.parse('$_baseUrl/users/$userId'),
-      headers: AuthSessionStore.headers(json: true),
-      body: jsonEncode({
-        if (role != null) 'role': role,
-        if (isFacilitiesManager != null)
-          'isFacilitiesManager': isFacilitiesManager,
-        if (emailNotificationsEnabled != null)
-          'emailNotificationsEnabled': emailNotificationsEnabled,
-      }),
-    );
-    assertOk(response);
-    return AuthUser.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
-  }
-```
-
-- [ ] **Step 3: Update SettingsRepository**
-
-In `apps/desktop_flutter/lib/features/settings/repositories/settings_repository.dart`, replace the `updateUser` method:
-
-```dart
-  Future<AuthUser> updateUser(
-    int userId, {
-    String? role,
-    bool? isFacilitiesManager,
-    bool? emailNotificationsEnabled,
-  }) {
-    return _dataSource.updateUser(
-      userId,
-      role: role,
-      isFacilitiesManager: isFacilitiesManager,
-      emailNotificationsEnabled: emailNotificationsEnabled,
-    );
-  }
-```
-
-- [ ] **Step 4: Update SettingsController**
-
-In `apps/desktop_flutter/lib/features/settings/controllers/settings_controller.dart`, replace the `updateUser` method:
-
-```dart
-  Future<AuthUser> updateUser(
-    int userId, {
-    String? role,
-    bool? isFacilitiesManager,
-    bool? emailNotificationsEnabled,
-  }) async {
-    _savingUserIds.add(userId);
-    notifyListeners();
-    try {
-      final updated = await _repository.updateUser(
-        userId,
-        role: role,
-        isFacilitiesManager: isFacilitiesManager,
-        emailNotificationsEnabled: emailNotificationsEnabled,
-      );
-      final users = List<AuthUser>.from(_users);
-      final index = users.indexWhere((user) => user.id == userId);
-      if (index >= 0) {
-        users[index] = updated;
-      } else {
-        users.add(updated);
-      }
-      users.sort(_compareUsers);
-      _users = users;
-      _usersErrorMessage = null;
-      _usersStatus = SettingsUsersStatus.ready;
-      return updated;
-    } catch (error) {
-      _usersErrorMessage = error.toString();
-      rethrow;
-    } finally {
-      _savingUserIds.remove(userId);
-      notifyListeners();
-    }
-  }
-```
-
-- [ ] **Step 5: Add NOTIFICATIONS section to SettingsView**
-
-In `apps/desktop_flutter/lib/features/settings/views/settings_view.dart`, find the line:
-
-```dart
-          if (canManagePermissions) ...[
-```
-
-Insert the following block immediately before it (after the `const SizedBox(height: 24),` that closes the ACCOUNT section):
-
-```dart
-          if (user != null) ...[
-            Text(
-              'NOTIFICATIONS',
-              style: TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
-                color: context.rhythm.textSecondary,
-                letterSpacing: 0.8,
-              ),
-            ),
-            const SizedBox(height: 12),
-            _NotificationsCard(user: user, onUpdated: auth.updateCurrentUser),
-            const SizedBox(height: 24),
-          ],
-```
-
-Then at the bottom of `settings_view.dart`, before the final `}` that closes the file, add:
-
-```dart
-class _NotificationsCard extends StatefulWidget {
-  const _NotificationsCard({
-    required this.user,
-    required this.onUpdated,
-  });
-
-  final AuthUser user;
-  final void Function(AuthUser) onUpdated;
-
-  @override
-  State<_NotificationsCard> createState() => _NotificationsCardState();
-}
-
-class _NotificationsCardState extends State<_NotificationsCard> {
-  bool _saving = false;
-
-  Future<void> _toggle(bool value) async {
-    setState(() => _saving = true);
-    try {
-      final updated = await context.read<SettingsController>().updateUser(
-            widget.user.id,
-            emailNotificationsEnabled: value,
-          );
-      widget.onUpdated(updated);
-    } catch (_) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to save notification preference')),
-        );
-      }
-    } finally {
-      if (mounted) setState(() => _saving = false);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
-      decoration: BoxDecoration(
-        color: context.rhythm.surfaceRaised,
-        borderRadius: BorderRadius.circular(RhythmRadius.xl),
-        border: Border.all(color: context.rhythm.borderSubtle),
-        boxShadow: RhythmElevation.panel,
+Card(
+  child: Column(
+    children: [
+      ListTile(
+        title: Text('Notifications', style: ...),
+        dense: true,
       ),
-      child: SwitchListTile(
-        contentPadding: EdgeInsets.zero,
-        title: Text(
-          'Email notifications',
-          style: TextStyle(
-            fontWeight: FontWeight.w500,
-            color: context.rhythm.textPrimary,
-          ),
+      const Divider(height: 1),
+      SwitchListTile(
+        title: const Text('Email notifications'),
+        subtitle: const Text(
+          "Get an email when you're assigned a task or added as a collaborator",
         ),
-        subtitle: Text(
-          'Receive an email when you\'re assigned a task or added as a collaborator',
-          style: TextStyle(
-            fontSize: 13,
-            color: context.rhythm.textSecondary,
-          ),
-        ),
-        value: widget.user.emailNotificationsEnabled,
-        onChanged: _saving ? null : _toggle,
-        activeColor: context.rhythm.accent,
+        value: settingsController.emailNotificationsEnabled,
+        onChanged: (value) async {
+          try {
+            await settingsController.setEmailNotifications(value);
+          } catch (e) {
+            if (mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Failed to update: $e')),
+              );
+            }
+          }
+        },
       ),
-    );
-  }
-}
+    ],
+  ),
+),
 ```
 
-- [ ] **Step 6: Run Flutter analyze**
-
-```bash
-cd apps/desktop_flutter && flutter analyze --no-fatal-infos
-```
-
-Expected: no errors.
-
-- [ ] **Step 7: Run Flutter app locally to verify toggle works**
-
-```bash
-cd apps/desktop_flutter && flutter run -d macos
-```
-
-Manually verify:
-- Navigate to Settings
-- A "NOTIFICATIONS" section appears with an "Email notifications" toggle
-- Toggling it off and back on works without error
-- The toggle state persists after navigating away and back
-
-- [ ] **Step 8: Format and commit**
-
-```bash
-cd apps/desktop_flutter && dart format .
-git add lib/app/core/auth/auth_user.dart \
-        lib/features/settings/data/settings_data_source.dart \
-        lib/features/settings/repositories/settings_repository.dart \
-        lib/features/settings/controllers/settings_controller.dart \
-        lib/features/settings/views/settings_view.dart
-git commit -m "feat: add email notifications opt-out toggle in Settings"
-```
+**Acceptance:**
+- Settings view shows the toggle in current state from the user's profile
+- Toggling immediately persists via API call
+- Failure shows a SnackBar; toggle reverts to previous state on error
+- `flutter analyze --no-fatal-infos` passes
+- `dart format .` produces no diff
 
 ---
 
-## Task 5: Push Branch and Open PR
+## Implementation Order
 
-- [ ] **Step 1: Verify full API test suite passes**
+The phases must be done in order; within a phase, sub-steps can in some cases be parallelized but blocked-by relationships are noted in the GitHub issues.
 
-```bash
-cd apps/api_server && npm test
-```
+1. 1.1 (migration) → blocks everything
+2. 1.2 (model + repo) → blocks 2.2, 3.1, 4.1
+3. 2.1 (deps + env) → blocks 2.2
+4. 2.2 (EmailService) → blocks 3.1
+5. 3.1 (wire into controller) — backend complete after this
+6. 4.1 (preferences endpoint) → blocks 4.2
+7. 4.2 (Flutter data layer) → blocks 4.3
+8. 4.3 (Settings UI) — feature complete
 
-Expected: all tests pass.
+---
 
-- [ ] **Step 2: Verify Flutter analyze passes**
+## Out of Scope (separate PRs)
 
-```bash
-cd apps/desktop_flutter && flutter analyze --no-fatal-infos
-```
-
-Expected: no errors.
-
-- [ ] **Step 3: Push branch and open PR**
-
-```bash
-git push -u origin HEAD
-gh pr create \
-  --title "feat: email notifications for task assignment and collaborator addition" \
-  --body "$(cat <<'EOF'
-## Summary
-
-- Sends a transactional email via Resend when a user is assigned to a task or added as a collaborator
-- Adds `email_notifications_enabled` column to `users` table (default: true)
-- New `EmailService` in the API server handles opt-out checks and email rendering
-- Flutter Settings screen gains a NOTIFICATIONS section with an opt-out toggle
-- If `RESEND_API_KEY` is not configured, the service is a silent no-op
-
-## Setup required
-
-Add to `apps/api_server/.env`:
-\`\`\`
-RESEND_API_KEY=your_resend_api_key_here
-EMAIL_FROM_ADDRESS=Rhythm <notifications@yourdomain.com>
-\`\`\`
-
-Get a free API key at https://resend.com
-
-## Test plan
-
-- [ ] Assign a task to another user → they receive an email
-- [ ] Add a collaborator to a task → they receive an email
-- [ ] Assign a task to yourself → no email sent
-- [ ] Toggle off email notifications in Settings → no email sent on next assignment
-- [ ] Toggle email notifications back on → email resumes
-- [ ] Remove `RESEND_API_KEY` from env → no errors, emails silently skipped
-- [ ] All API server tests pass: `cd apps/api_server && npm test`
-- [ ] Flutter analyze passes: `cd apps/desktop_flutter && flutter analyze --no-fatal-infos`
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
-```
-
-- [ ] **Step 4: Share PR URL with user for review**
+- `rhythm://` URL scheme registration in `Info.plist` + Swift `kAEGetURL` handler
+- Method Channel + deep-link routing in Flutter
+- Specific-task highlight/scroll in `TasksView` based on the deep link
+- Email notifications for other event types (step completed, rhythm step due/unlocked, etc.)
+- `desktop_release.yml` workflow update to embed `RESEND_API_KEY` for the bundled-server build path (only needed if the bundled local server is expected to send emails — typically users hit the hosted API)

--- a/docs/superpowers/plans/2026-05-04-task-assignment-email-notifications.md
+++ b/docs/superpowers/plans/2026-05-04-task-assignment-email-notifications.md
@@ -1,0 +1,988 @@
+# Task Assignment Email Notifications — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Send a transactional email via Resend when a user is assigned to a task or added as a collaborator, with a per-user opt-out toggle in the Flutter Settings screen.
+
+**Architecture:** A new `EmailService` sits alongside the existing `NotificationService` in `TasksController`. Both are called at the same trigger points. `EmailService` fetches the recipient user, checks their opt-out flag, and sends via the Resend SDK. If `RESEND_API_KEY` is unset, the service is a silent no-op.
+
+**Tech Stack:** Node.js/TypeScript (Express + better-sqlite3/pg), `resend` npm package, Flutter/Dart (Provider pattern)
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|---|---|---|
+| `apps/api_server/src/database/migrations.ts` | Modify | Add `email_notifications_enabled` column to `users` |
+| `apps/api_server/src/models/user.ts` | Modify | Add field to `User` and `UpdateUserDto` |
+| `apps/api_server/src/repositories/users_repository.ts` | Modify | Add to `UserRow`, `rowToUser`, `updateAsync`, `update` |
+| `apps/api_server/src/config/env.ts` | Modify | Add `resendApiKey`, `emailFromAddress` |
+| `apps/api_server/package.json` | Modify | Add `resend` dependency |
+| `apps/api_server/src/services/email_service.ts` | Create | New `EmailService` class |
+| `apps/api_server/src/controllers/tasks_controller.ts` | Modify | Import + call `EmailService` at both trigger points |
+| `apps/desktop_flutter/lib/app/core/auth/auth_user.dart` | Modify | Add `emailNotificationsEnabled` field |
+| `apps/desktop_flutter/lib/features/settings/data/settings_data_source.dart` | Modify | Add `emailNotificationsEnabled` param to `updateUser` |
+| `apps/desktop_flutter/lib/features/settings/repositories/settings_repository.dart` | Modify | Add `emailNotificationsEnabled` param to `updateUser` |
+| `apps/desktop_flutter/lib/features/settings/controllers/settings_controller.dart` | Modify | Add `emailNotificationsEnabled` param to `updateUser` |
+| `apps/desktop_flutter/lib/features/settings/views/settings_view.dart` | Modify | Add NOTIFICATIONS section with opt-out toggle |
+
+---
+
+## Task 1: DB Migration + User Model + UsersRepository
+
+**Files:**
+- Modify: `apps/api_server/src/database/migrations.ts`
+- Modify: `apps/api_server/src/models/user.ts`
+- Modify: `apps/api_server/src/repositories/users_repository.ts`
+
+- [ ] **Step 1: Write failing test for migration column**
+
+Create `apps/api_server/src/__tests__/email_notifications.test.ts`:
+
+```typescript
+import { beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../database/migrations';
+import { setDb } from '../database/db';
+import { UsersRepository } from '../repositories/users_repository';
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+  runMigrations(db);
+  return db;
+}
+
+describe('email_notifications_enabled', () => {
+  let usersRepo: UsersRepository;
+
+  beforeEach(() => {
+    const db = makeDb();
+    setDb(db);
+    usersRepo = new UsersRepository();
+  });
+
+  it('defaults emailNotificationsEnabled to true on new users', () => {
+    const user = usersRepo.create({ name: 'Alice', email: 'alice@test.com' });
+    expect(user.emailNotificationsEnabled).toBe(true);
+  });
+
+  it('can set emailNotificationsEnabled to false via update', () => {
+    const user = usersRepo.create({ name: 'Bob', email: 'bob@test.com' });
+    const updated = usersRepo.update(user.id, { emailNotificationsEnabled: false });
+    expect(updated.emailNotificationsEnabled).toBe(false);
+  });
+
+  it('preserves emailNotificationsEnabled when updating other fields', () => {
+    const user = usersRepo.create({ name: 'Carol', email: 'carol@test.com' });
+    usersRepo.update(user.id, { emailNotificationsEnabled: false });
+    const updated = usersRepo.update(user.id, { name: 'Carol Updated' });
+    expect(updated.emailNotificationsEnabled).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd apps/api_server && npm test -- --reporter=verbose email_notifications
+```
+
+Expected: FAIL — `emailNotificationsEnabled` is undefined.
+
+- [ ] **Step 3: Add migration**
+
+In `apps/api_server/src/database/migrations.ts`, add at the very end of the `runMigrations` function body, after the notifications block:
+
+```typescript
+  // Email notification preferences
+  const userColsEmail = (db.pragma('table_info(users)') as { name: string }[]).map((c) => c.name);
+  if (!userColsEmail.includes('email_notifications_enabled')) {
+    db.exec(`ALTER TABLE users ADD COLUMN email_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE`);
+  }
+```
+
+- [ ] **Step 4: Update User model**
+
+In `apps/api_server/src/models/user.ts`, add `emailNotificationsEnabled` to both interfaces:
+
+```typescript
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  googleSub: string | null;
+  photoUrl: string | null;
+  role: string;
+  isFacilitiesManager: boolean;
+  emailNotificationsEnabled: boolean;   // ← add this line
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ... (CreateUserDto is unchanged)
+
+export interface UpdateUserDto {
+  name?: string;
+  email?: string;
+  googleSub?: string | null;
+  photoUrl?: string | null;
+  role?: string;
+  isFacilitiesManager?: boolean;
+  emailNotificationsEnabled?: boolean;  // ← add this line
+}
+```
+
+- [ ] **Step 5: Update UsersRepository**
+
+In `apps/api_server/src/repositories/users_repository.ts`:
+
+**a) Add `email_notifications_enabled` to `UserRow`:**
+```typescript
+interface UserRow {
+  id: number;
+  name: string;
+  email: string;
+  google_sub: string | null;
+  photo_url: string | null;
+  role: string;
+  is_facilities_manager: number;
+  email_notifications_enabled: number | boolean;  // ← add this line
+  created_at: string;
+  updated_at: string;
+}
+```
+
+**b) Add to `rowToUser`** — add after the `isFacilitiesManager` assignment:
+```typescript
+function rowToUser(row: UserRow): User {
+  const isFacilitiesManager =
+    typeof row.is_facilities_manager === 'boolean'
+      ? row.is_facilities_manager
+      : row.is_facilities_manager === 1;
+
+  const emailNotificationsEnabled =
+    typeof row.email_notifications_enabled === 'boolean'
+      ? row.email_notifications_enabled
+      : row.email_notifications_enabled !== 0;
+
+  return {
+    id: row.id,
+    name: row.name,
+    email: row.email,
+    googleSub: row.google_sub,
+    photoUrl: row.photo_url,
+    role: row.role,
+    isFacilitiesManager,
+    emailNotificationsEnabled,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+```
+
+**c) Replace `updateAsync` (Postgres branch) SQL** — shift param numbers to make room for the new field before `updated_at`:
+```typescript
+async updateAsync(id: number, data: UpdateUserDto): Promise<User> {
+  if (env.dbClient === 'postgres') {
+    const existing = await this.findByIdAsync(id);
+    const now = new Date().toISOString();
+    const result = await getPostgresPool().query<UserRow>(
+      `UPDATE users
+          SET name = $1,
+              email = $2,
+              google_sub = $3,
+              photo_url = $4,
+              role = $5,
+              is_facilities_manager = $6,
+              email_notifications_enabled = $7,
+              updated_at = $8
+        WHERE id = $9
+        RETURNING *`,
+      [
+        data.name ?? existing.name,
+        data.email ?? existing.email,
+        data.googleSub ?? existing.googleSub,
+        data.photoUrl !== undefined ? data.photoUrl : existing.photoUrl,
+        data.role ?? existing.role,
+        data.isFacilitiesManager !== undefined
+          ? data.isFacilitiesManager
+          : existing.isFacilitiesManager,
+        data.emailNotificationsEnabled !== undefined
+          ? data.emailNotificationsEnabled
+          : existing.emailNotificationsEnabled,
+        now,
+        id,
+      ],
+    );
+    return rowToUser(result.rows[0]);
+  }
+
+  return this.update(id, data);
+}
+```
+
+**d) Replace `update` (SQLite branch)**:
+```typescript
+update(id: number, data: UpdateUserDto): User {
+  const existing = this.findById(id);
+  const now = new Date().toISOString();
+  getDb()
+    .prepare(
+      `UPDATE users
+          SET name = ?,
+              email = ?,
+              google_sub = ?,
+              photo_url = ?,
+              role = ?,
+              is_facilities_manager = ?,
+              email_notifications_enabled = ?,
+              updated_at = ?
+        WHERE id = ?`,
+    )
+    .run(
+      data.name ?? existing.name,
+      data.email ?? existing.email,
+      data.googleSub ?? existing.googleSub,
+      data.photoUrl !== undefined ? data.photoUrl : existing.photoUrl,
+      data.role ?? existing.role,
+      data.isFacilitiesManager !== undefined
+        ? (data.isFacilitiesManager ? 1 : 0)
+        : (existing.isFacilitiesManager ? 1 : 0),
+      data.emailNotificationsEnabled !== undefined
+        ? (data.emailNotificationsEnabled ? 1 : 0)
+        : (existing.emailNotificationsEnabled ? 1 : 0),
+      now,
+      id,
+    );
+  return this.findById(id);
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd apps/api_server && npm test -- --reporter=verbose email_notifications
+```
+
+Expected: 3 tests PASS.
+
+- [ ] **Step 7: Run full test suite to catch regressions**
+
+```bash
+cd apps/api_server && npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd apps/api_server
+git add src/database/migrations.ts src/models/user.ts src/repositories/users_repository.ts src/__tests__/email_notifications.test.ts
+git commit -m "feat: add email_notifications_enabled field to users"
+```
+
+---
+
+## Task 2: Resend Package + Env Vars + EmailService
+
+**Files:**
+- Modify: `apps/api_server/package.json`
+- Modify: `apps/api_server/src/config/env.ts`
+- Create: `apps/api_server/src/services/email_service.ts`
+
+- [ ] **Step 1: Add Resend dependency**
+
+```bash
+cd apps/api_server && npm install resend
+```
+
+- [ ] **Step 2: Add env vars to config**
+
+In `apps/api_server/src/config/env.ts`, add two fields at the end of the `env` object (before the closing `};`):
+
+```typescript
+  resendApiKey: process.env.RESEND_API_KEY ?? '',
+  emailFromAddress: process.env.EMAIL_FROM_ADDRESS ?? 'Rhythm <onboarding@resend.dev>',
+```
+
+- [ ] **Step 3: Write failing tests for EmailService**
+
+Add to `apps/api_server/src/__tests__/email_notifications.test.ts`:
+
+```typescript
+import { EmailService } from '../services/email_service';
+
+describe('EmailService', () => {
+  let usersRepo: UsersRepository;
+
+  beforeEach(() => {
+    const db = makeDb();
+    setDb(db);
+    usersRepo = new UsersRepository();
+  });
+
+  it('is a no-op when resendApiKey is empty', async () => {
+    const alice = usersRepo.create({ name: 'Alice', email: 'alice@test.com' });
+    const bob = usersRepo.create({ name: 'Bob', email: 'bob@test.com' });
+    const svc = new EmailService(usersRepo, '');
+    // Should not throw
+    await expect(
+      svc.sendTaskAssignedEmailAsync('task-1', 'Fix bug', alice.id, bob.id),
+    ).resolves.toBeUndefined();
+  });
+
+  it('skips send when actor equals recipient', async () => {
+    const alice = usersRepo.create({ name: 'Alice', email: 'alice@test.com' });
+    const svc = new EmailService(usersRepo, '');
+    await expect(
+      svc.sendTaskAssignedEmailAsync('task-1', 'Fix bug', alice.id, alice.id),
+    ).resolves.toBeUndefined();
+  });
+
+  it('skips send when recipient has opted out', async () => {
+    const alice = usersRepo.create({ name: 'Alice', email: 'alice@test.com' });
+    const bob = usersRepo.create({ name: 'Bob', email: 'bob@test.com' });
+    usersRepo.update(bob.id, { emailNotificationsEnabled: false });
+    const svc = new EmailService(usersRepo, 'fake-key');
+    // Would throw if it tried to actually call Resend with a fake key,
+    // but it should return early due to opt-out
+    await expect(
+      svc.sendTaskAssignedEmailAsync('task-1', 'Fix bug', alice.id, bob.id),
+    ).resolves.toBeUndefined();
+  });
+
+  it('skips collaborator email when actor equals recipient', async () => {
+    const alice = usersRepo.create({ name: 'Alice', email: 'alice@test.com' });
+    const svc = new EmailService(usersRepo, '');
+    await expect(
+      svc.sendCollaboratorAddedEmailAsync('task-1', 'Fix bug', alice.id, alice.id),
+    ).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+```bash
+cd apps/api_server && npm test -- --reporter=verbose email_notifications
+```
+
+Expected: FAIL — `EmailService` does not exist yet.
+
+- [ ] **Step 5: Create EmailService**
+
+Create `apps/api_server/src/services/email_service.ts`:
+
+```typescript
+import { Resend } from 'resend';
+import { env } from '../config/env';
+import type { UsersRepository } from '../repositories/users_repository';
+
+export class EmailService {
+  private readonly client: Resend | null;
+
+  constructor(
+    private readonly usersRepo: UsersRepository,
+    resendApiKey?: string,
+  ) {
+    const key = resendApiKey ?? '';
+    this.client = key ? new Resend(key) : null;
+  }
+
+  async sendTaskAssignedEmailAsync(
+    taskId: string,
+    taskTitle: string,
+    actorUserId: number,
+    recipientUserId: number,
+  ): Promise<void> {
+    if (actorUserId === recipientUserId) return;
+    if (!this.client) return;
+
+    try {
+      const [actor, recipient] = await Promise.all([
+        this.usersRepo.findByIdAsync(actorUserId),
+        this.usersRepo.findByIdAsync(recipientUserId),
+      ]);
+
+      if (!recipient.emailNotificationsEnabled) return;
+
+      await this.client.emails.send({
+        from: env.emailFromAddress,
+        to: recipient.email,
+        subject: `${actor.name} added you to "${taskTitle}" in Rhythm`,
+        html: this._buildHtml(actor.name, taskTitle, taskId),
+        text: this._buildText(actor.name, taskTitle, taskId),
+      });
+    } catch (err) {
+      console.error('[EmailService] sendTaskAssignedEmailAsync failed:', err);
+    }
+  }
+
+  async sendCollaboratorAddedEmailAsync(
+    taskId: string,
+    taskTitle: string,
+    actorUserId: number,
+    recipientUserId: number,
+  ): Promise<void> {
+    if (actorUserId === recipientUserId) return;
+    if (!this.client) return;
+
+    try {
+      const [actor, recipient] = await Promise.all([
+        this.usersRepo.findByIdAsync(actorUserId),
+        this.usersRepo.findByIdAsync(recipientUserId),
+      ]);
+
+      if (!recipient.emailNotificationsEnabled) return;
+
+      await this.client.emails.send({
+        from: env.emailFromAddress,
+        to: recipient.email,
+        subject: `${actor.name} added you to "${taskTitle}" in Rhythm`,
+        html: this._buildHtml(actor.name, taskTitle, taskId),
+        text: this._buildText(actor.name, taskTitle, taskId),
+      });
+    } catch (err) {
+      console.error('[EmailService] sendCollaboratorAddedEmailAsync failed:', err);
+    }
+  }
+
+  private _buildHtml(actorName: string, taskTitle: string, taskId: string): string {
+    return `<!DOCTYPE html>
+<html>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#111827;max-width:480px;margin:0 auto;padding:24px;">
+  <h2 style="color:#4F6AF5;margin-top:0;">You've been added to a task</h2>
+  <p><strong>${this._esc(actorName)}</strong> has invited you to collaborate on <strong>&ldquo;${this._esc(taskTitle)}&rdquo;</strong> in Rhythm.</p>
+  <p style="margin-top:24px;">
+    <a href="rhythm://tasks/${encodeURIComponent(taskId)}"
+       style="display:inline-block;background:#4F6AF5;color:#ffffff;padding:10px 20px;border-radius:6px;text-decoration:none;font-weight:600;">
+      Open in Rhythm
+    </a>
+  </p>
+  <p style="color:#6B7280;font-size:12px;margin-top:32px;">
+    You're receiving this because you have email notifications enabled in Rhythm.<br>
+    You can turn these off in Rhythm &rarr; Settings &rarr; Notifications.
+  </p>
+</body>
+</html>`;
+  }
+
+  private _buildText(actorName: string, taskTitle: string, taskId: string): string {
+    return `${actorName} has invited you to collaborate on "${taskTitle}" in Rhythm.\n\nOpen in Rhythm: rhythm://tasks/${taskId}\n\nYou can turn off email notifications in Rhythm → Settings → Notifications.`;
+  }
+
+  private _esc(str: string): string {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd apps/api_server && npm test -- --reporter=verbose email_notifications
+```
+
+Expected: all 7 tests PASS (3 from Task 1 + 4 new).
+
+- [ ] **Step 7: Run full test suite**
+
+```bash
+cd apps/api_server && npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd apps/api_server
+git add package.json package-lock.json src/config/env.ts src/services/email_service.ts src/__tests__/email_notifications.test.ts
+git commit -m "feat: add EmailService with Resend integration"
+```
+
+---
+
+## Task 3: Wire EmailService into TasksController
+
+**Files:**
+- Modify: `apps/api_server/src/controllers/tasks_controller.ts`
+
+- [ ] **Step 1: Add imports and module-level instantiation**
+
+At the top of `apps/api_server/src/controllers/tasks_controller.ts`, add the new imports alongside the existing ones:
+
+```typescript
+import { UsersRepository } from '../repositories/users_repository';
+import { EmailService } from '../services/email_service';
+import { env } from '../config/env';
+```
+
+Then add the service instantiation below the existing `notifService` line:
+
+```typescript
+const repo = new TasksRepository();
+const rulesRepo = new RecurringTaskRulesRepository();
+const notifService = new NotificationService(new NotificationsRepository());
+const emailService = new EmailService(new UsersRepository(), env.resendApiKey);  // ← add this line
+```
+
+- [ ] **Step 2: Add email call at task assignment trigger**
+
+In the `update` method, the existing assignment block ends with `notifyTaskAssignedAsync`. Add the email call immediately after it:
+
+Replace this block:
+```typescript
+      // Notify on assignment
+      if (
+        data.ownerId !== undefined &&
+        updated.ownerId != null &&
+        updated.ownerId !== existing.ownerId &&
+        actorId != null
+      ) {
+        await notifService.notifyTaskAssignedAsync(
+          updated.id,
+          updated.title,
+          updated.ownerId,
+          actorId,
+        );
+      }
+```
+
+With:
+```typescript
+      // Notify on assignment
+      if (
+        data.ownerId !== undefined &&
+        updated.ownerId != null &&
+        updated.ownerId !== existing.ownerId &&
+        actorId != null
+      ) {
+        await notifService.notifyTaskAssignedAsync(
+          updated.id,
+          updated.title,
+          updated.ownerId,
+          actorId,
+        );
+        await emailService.sendTaskAssignedEmailAsync(
+          updated.id,
+          updated.title,
+          actorId,
+          updated.ownerId,
+        );
+      }
+```
+
+- [ ] **Step 3: Add email call at collaborator addition trigger**
+
+In the `addCollaborator` method, the existing call ends with `notifyCollaboratorAddedAsync`. Add the email call immediately after it:
+
+Replace this block:
+```typescript
+      await repo.addCollaboratorAsync(req.params.id, userId);
+      await notifService.notifyCollaboratorAddedAsync(
+        'task',
+        req.params.id,
+        task.title,
+        userId,
+        actorId,
+      );
+      res.status(201).json(await repo.listCollaboratorsAsync(req.params.id));
+```
+
+With:
+```typescript
+      await repo.addCollaboratorAsync(req.params.id, userId);
+      await notifService.notifyCollaboratorAddedAsync(
+        'task',
+        req.params.id,
+        task.title,
+        userId,
+        actorId,
+      );
+      await emailService.sendCollaboratorAddedEmailAsync(
+        req.params.id,
+        task.title,
+        actorId,
+        userId,
+      );
+      res.status(201).json(await repo.listCollaboratorsAsync(req.params.id));
+```
+
+- [ ] **Step 4: Build to catch TypeScript errors**
+
+```bash
+cd apps/api_server && npm run build
+```
+
+Expected: exits 0 with no errors.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+cd apps/api_server && npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd apps/api_server
+git add src/controllers/tasks_controller.ts
+git commit -m "feat: send email notification on task assignment and collaborator addition"
+```
+
+---
+
+## Task 4: Flutter Opt-Out Toggle
+
+**Files:**
+- Modify: `apps/desktop_flutter/lib/app/core/auth/auth_user.dart`
+- Modify: `apps/desktop_flutter/lib/features/settings/data/settings_data_source.dart`
+- Modify: `apps/desktop_flutter/lib/features/settings/repositories/settings_repository.dart`
+- Modify: `apps/desktop_flutter/lib/features/settings/controllers/settings_controller.dart`
+- Modify: `apps/desktop_flutter/lib/features/settings/views/settings_view.dart`
+
+- [ ] **Step 1: Add `emailNotificationsEnabled` to `AuthUser`**
+
+In `apps/desktop_flutter/lib/app/core/auth/auth_user.dart`, replace the entire file:
+
+```dart
+import '../utils/json_parsing.dart';
+
+class AuthUser {
+  const AuthUser({
+    required this.id,
+    required this.name,
+    required this.email,
+    required this.role,
+    this.isFacilitiesManager = false,
+    this.emailNotificationsEnabled = true,
+    this.photoUrl,
+  });
+
+  final int id;
+  final String name;
+  final String email;
+  final String role;
+  final bool isFacilitiesManager;
+  final bool emailNotificationsEnabled;
+  final String? photoUrl;
+
+  bool get isAdmin => role == 'admin' || role == 'system';
+
+  factory AuthUser.fromJson(Map<String, dynamic> json) {
+    return AuthUser(
+      id: _asInt(json['id']) ?? 0,
+      name: _asString(json['name']) ?? '',
+      email: _asString(json['email']) ?? '',
+      role: _asString(json['role']) ?? 'member',
+      isFacilitiesManager: _asBool(json['isFacilitiesManager']) ??
+          _asBool(json['is_facilities_manager']) ??
+          false,
+      emailNotificationsEnabled:
+          _asBool(json['emailNotificationsEnabled']) ??
+          _asBool(json['email_notifications_enabled']) ??
+          true,
+      photoUrl: _asString(json['photoUrl']) ?? _asString(json['photo_url']),
+    );
+  }
+}
+
+String? _asString(dynamic value) => asString(value);
+int? _asInt(dynamic value) => asInt(value);
+bool? _asBool(dynamic value) => asBool(value);
+```
+
+- [ ] **Step 2: Update SettingsDataSource**
+
+In `apps/desktop_flutter/lib/features/settings/data/settings_data_source.dart`, replace the `updateUser` method:
+
+```dart
+  Future<AuthUser> updateUser(
+    int userId, {
+    String? role,
+    bool? isFacilitiesManager,
+    bool? emailNotificationsEnabled,
+  }) async {
+    final response = await http.patch(
+      Uri.parse('$_baseUrl/users/$userId'),
+      headers: AuthSessionStore.headers(json: true),
+      body: jsonEncode({
+        if (role != null) 'role': role,
+        if (isFacilitiesManager != null)
+          'isFacilitiesManager': isFacilitiesManager,
+        if (emailNotificationsEnabled != null)
+          'emailNotificationsEnabled': emailNotificationsEnabled,
+      }),
+    );
+    assertOk(response);
+    return AuthUser.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+```
+
+- [ ] **Step 3: Update SettingsRepository**
+
+In `apps/desktop_flutter/lib/features/settings/repositories/settings_repository.dart`, replace the `updateUser` method:
+
+```dart
+  Future<AuthUser> updateUser(
+    int userId, {
+    String? role,
+    bool? isFacilitiesManager,
+    bool? emailNotificationsEnabled,
+  }) {
+    return _dataSource.updateUser(
+      userId,
+      role: role,
+      isFacilitiesManager: isFacilitiesManager,
+      emailNotificationsEnabled: emailNotificationsEnabled,
+    );
+  }
+```
+
+- [ ] **Step 4: Update SettingsController**
+
+In `apps/desktop_flutter/lib/features/settings/controllers/settings_controller.dart`, replace the `updateUser` method:
+
+```dart
+  Future<AuthUser> updateUser(
+    int userId, {
+    String? role,
+    bool? isFacilitiesManager,
+    bool? emailNotificationsEnabled,
+  }) async {
+    _savingUserIds.add(userId);
+    notifyListeners();
+    try {
+      final updated = await _repository.updateUser(
+        userId,
+        role: role,
+        isFacilitiesManager: isFacilitiesManager,
+        emailNotificationsEnabled: emailNotificationsEnabled,
+      );
+      final users = List<AuthUser>.from(_users);
+      final index = users.indexWhere((user) => user.id == userId);
+      if (index >= 0) {
+        users[index] = updated;
+      } else {
+        users.add(updated);
+      }
+      users.sort(_compareUsers);
+      _users = users;
+      _usersErrorMessage = null;
+      _usersStatus = SettingsUsersStatus.ready;
+      return updated;
+    } catch (error) {
+      _usersErrorMessage = error.toString();
+      rethrow;
+    } finally {
+      _savingUserIds.remove(userId);
+      notifyListeners();
+    }
+  }
+```
+
+- [ ] **Step 5: Add NOTIFICATIONS section to SettingsView**
+
+In `apps/desktop_flutter/lib/features/settings/views/settings_view.dart`, find the line:
+
+```dart
+          if (canManagePermissions) ...[
+```
+
+Insert the following block immediately before it (after the `const SizedBox(height: 24),` that closes the ACCOUNT section):
+
+```dart
+          if (user != null) ...[
+            Text(
+              'NOTIFICATIONS',
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: context.rhythm.textSecondary,
+                letterSpacing: 0.8,
+              ),
+            ),
+            const SizedBox(height: 12),
+            _NotificationsCard(user: user, onUpdated: auth.updateCurrentUser),
+            const SizedBox(height: 24),
+          ],
+```
+
+Then at the bottom of `settings_view.dart`, before the final `}` that closes the file, add:
+
+```dart
+class _NotificationsCard extends StatefulWidget {
+  const _NotificationsCard({
+    required this.user,
+    required this.onUpdated,
+  });
+
+  final AuthUser user;
+  final void Function(AuthUser) onUpdated;
+
+  @override
+  State<_NotificationsCard> createState() => _NotificationsCardState();
+}
+
+class _NotificationsCardState extends State<_NotificationsCard> {
+  bool _saving = false;
+
+  Future<void> _toggle(bool value) async {
+    setState(() => _saving = true);
+    try {
+      final updated = await context.read<SettingsController>().updateUser(
+            widget.user.id,
+            emailNotificationsEnabled: value,
+          );
+      widget.onUpdated(updated);
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to save notification preference')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      decoration: BoxDecoration(
+        color: context.rhythm.surfaceRaised,
+        borderRadius: BorderRadius.circular(RhythmRadius.xl),
+        border: Border.all(color: context.rhythm.borderSubtle),
+        boxShadow: RhythmElevation.panel,
+      ),
+      child: SwitchListTile(
+        contentPadding: EdgeInsets.zero,
+        title: Text(
+          'Email notifications',
+          style: TextStyle(
+            fontWeight: FontWeight.w500,
+            color: context.rhythm.textPrimary,
+          ),
+        ),
+        subtitle: Text(
+          'Receive an email when you\'re assigned a task or added as a collaborator',
+          style: TextStyle(
+            fontSize: 13,
+            color: context.rhythm.textSecondary,
+          ),
+        ),
+        value: widget.user.emailNotificationsEnabled,
+        onChanged: _saving ? null : _toggle,
+        activeColor: context.rhythm.accent,
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 6: Run Flutter analyze**
+
+```bash
+cd apps/desktop_flutter && flutter analyze --no-fatal-infos
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Run Flutter app locally to verify toggle works**
+
+```bash
+cd apps/desktop_flutter && flutter run -d macos
+```
+
+Manually verify:
+- Navigate to Settings
+- A "NOTIFICATIONS" section appears with an "Email notifications" toggle
+- Toggling it off and back on works without error
+- The toggle state persists after navigating away and back
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+cd apps/desktop_flutter && dart format .
+git add lib/app/core/auth/auth_user.dart \
+        lib/features/settings/data/settings_data_source.dart \
+        lib/features/settings/repositories/settings_repository.dart \
+        lib/features/settings/controllers/settings_controller.dart \
+        lib/features/settings/views/settings_view.dart
+git commit -m "feat: add email notifications opt-out toggle in Settings"
+```
+
+---
+
+## Task 5: Push Branch and Open PR
+
+- [ ] **Step 1: Verify full API test suite passes**
+
+```bash
+cd apps/api_server && npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Verify Flutter analyze passes**
+
+```bash
+cd apps/desktop_flutter && flutter analyze --no-fatal-infos
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create \
+  --title "feat: email notifications for task assignment and collaborator addition" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Sends a transactional email via Resend when a user is assigned to a task or added as a collaborator
+- Adds `email_notifications_enabled` column to `users` table (default: true)
+- New `EmailService` in the API server handles opt-out checks and email rendering
+- Flutter Settings screen gains a NOTIFICATIONS section with an opt-out toggle
+- If `RESEND_API_KEY` is not configured, the service is a silent no-op
+
+## Setup required
+
+Add to `apps/api_server/.env`:
+\`\`\`
+RESEND_API_KEY=your_resend_api_key_here
+EMAIL_FROM_ADDRESS=Rhythm <notifications@yourdomain.com>
+\`\`\`
+
+Get a free API key at https://resend.com
+
+## Test plan
+
+- [ ] Assign a task to another user → they receive an email
+- [ ] Add a collaborator to a task → they receive an email
+- [ ] Assign a task to yourself → no email sent
+- [ ] Toggle off email notifications in Settings → no email sent on next assignment
+- [ ] Toggle email notifications back on → email resumes
+- [ ] Remove `RESEND_API_KEY` from env → no errors, emails silently skipped
+- [ ] All API server tests pass: `cd apps/api_server && npm test`
+- [ ] Flutter analyze passes: `cd apps/desktop_flutter && flutter analyze --no-fatal-infos`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Share PR URL with user for review**

--- a/docs/superpowers/specs/2026-05-04-task-assignment-email-notifications-design.md
+++ b/docs/superpowers/specs/2026-05-04-task-assignment-email-notifications-design.md
@@ -1,0 +1,168 @@
+# Task Assignment Email Notifications — Design Spec
+
+**Date:** 2026-05-04  
+**Status:** Approved  
+
+---
+
+## Overview
+
+When a user is assigned to a task (either as `ownerId` or as a collaborator), Rhythm sends them a transactional email via [Resend](https://resend.com). Users can opt out of email notifications via a toggle in Settings. The feature builds on the existing in-app `NotificationService` pattern rather than replacing it.
+
+---
+
+## Scope
+
+**In scope:**
+- Email sent when a task's `ownerId` changes to a new user
+- Email sent when a collaborator is added to a task
+- Per-user opt-out preference stored in the database
+- Flutter Settings toggle for opt-out
+- `rhythm://tasks/{taskId}` deep link in email body (functional once the deep-link PR lands)
+
+**Out of scope (future PRs):**
+- `rhythm://` URL scheme registration in the Flutter/macOS app (separate PR)
+- Email notifications for other event types (step completion, rhythm steps, etc.)
+- Email queue / retry infrastructure
+- Custom email templates via a template engine
+
+---
+
+## Architecture
+
+### New component: `EmailService`
+
+`src/services/email_service.ts` — a standalone service with two public methods. `TasksController` instantiates it alongside the existing `NotificationService`. Both are called at the same trigger points.
+
+```
+TasksController
+  ├── NotificationService  (in-app DB notification — unchanged)
+  └── EmailService         (new — sends via Resend)
+```
+
+`EmailService` is responsible for:
+1. Fetching the recipient user (email address + opt-out flag)
+2. Skipping silently if opted out or if `RESEND_API_KEY` is not configured
+3. Sending via the Resend SDK
+4. Catching and logging any send errors without surfacing them to the API caller
+
+### Data flow — task assignment
+
+```
+PATCH /tasks/:id  { ownerId: 42 }
+  → TasksController.update()
+  → detect ownerId changed to a new user
+  → fetch actor user → get actorName
+  → notifService.notifyTaskAssignedAsync(...)       // existing, unchanged
+  → emailService.sendTaskAssignedEmailAsync(        // new
+      taskId, taskTitle, actorName, recipientUserId
+    )
+      → usersRepo.findByIdAsync(recipientUserId)
+      → if !emailNotificationsEnabled → return
+      → resend.emails.send({ to, subject, html })
+      → catch + log silently
+```
+
+### Data flow — collaborator added
+
+```
+POST /tasks/:id/collaborators  { userId: 42 }
+  → TasksController.addCollaborator()
+  → repo.addCollaboratorAsync(...)
+  → notifService.notifyCollaboratorAddedAsync(...)  // existing, unchanged
+  → emailService.sendCollaboratorAddedEmailAsync(   // new
+      taskId, taskTitle, actorName, recipientUserId
+    )
+```
+
+---
+
+## Email Template
+
+**Subject:** `{actorName} added you to "{taskTitle}" in Rhythm`
+
+**Body (HTML + plain text fallback):**
+```
+{actorName} has invited you to collaborate on "{taskTitle}" in Rhythm.
+
+[Click here to open in Rhythm](rhythm://tasks/{taskId})
+
+You're receiving this because you have email notifications enabled in Rhythm.
+```
+
+The `rhythm://tasks/{taskId}` link is included now. It will be inert until the deep-link PR ships, but costs nothing to include and makes the email future-proof.
+
+---
+
+## Database Changes
+
+One new column on the `users` table:
+
+```sql
+ALTER TABLE users ADD COLUMN email_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+```
+
+Migration added to `src/database/migrations.ts` (existing `ALTER TABLE IF NOT EXISTS` pattern, compatible with both SQLite and Postgres).
+
+The `User` model and `UsersRepository` are updated to include `emailNotificationsEnabled: boolean`.
+
+---
+
+## Configuration
+
+Two new environment variables added to `src/config/env.ts`:
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `RESEND_API_KEY` | No | `undefined` | If absent, `EmailService` is a silent no-op |
+| `EMAIL_FROM_ADDRESS` | No | `Rhythm <onboarding@resend.dev>` | Sender address; use Resend sandbox sender for dev |
+
+When `RESEND_API_KEY` is not set (e.g. local dev without email configured), the service logs a debug message and returns without sending. No errors thrown.
+
+---
+
+## New npm Dependency
+
+```
+resend  (latest stable)
+```
+
+Added to `apps/api_server/package.json` dependencies.
+
+---
+
+## Flutter Settings Toggle
+
+A new row added to `SettingsView` under a "Notifications" section:
+
+- Label: **Email notifications**
+- Subtitle: *Receive an email when you're assigned a task or added as a collaborator*
+- Widget: `Switch`
+- On toggle: calls `PATCH /users/:id` with `{ emailNotificationsEnabled: bool }`
+
+The existing `UpdateUserDto` and `UsersRepository.updateAsync()` are extended to accept `emailNotificationsEnabled`. No new endpoint needed.
+
+---
+
+## Error Handling
+
+- Email send failures are caught in `EmailService`, logged to console (`console.error`), and swallowed. The API response is unaffected.
+- If the recipient user cannot be found, the email is skipped silently.
+- If `RESEND_API_KEY` is missing, the service is a no-op (no error, no log spam — one debug log at startup).
+
+---
+
+## Self-assignment Guard
+
+`EmailService` mirrors the existing `NotificationService` pattern: if `recipientUserId === actorUserId`, return early without sending.
+
+---
+
+## Implementation Phases
+
+| Phase | Work |
+|---|---|
+| 1 — Foundation | DB migration, User model update, UsersRepository update |
+| 2 — Email Service | `resend` package, env vars, `EmailService` implementation |
+| 3 — Wire Up | Hook `EmailService` into `TasksController` at both trigger points |
+| 4 — Flutter Opt-Out | Settings toggle + `UpdateUserDto` + repository update |


### PR DESCRIPTION
## Summary

Implements the complete Claude Collaborator feature. Claude can be added as a task collaborator, which queues a trigger; an hourly CCR routine picks up the queue, works the task, and communicates via message threads.

- **Database**: `task_id` FK on `message_threads`; new `pending_claude_triggers` queue table with `UNIQUE(task_id)` guard
- **API**: `TaskStatus` expanded to `open | in_progress | waiting_for_reply | done`; status validation tightened; `task_id` wired through message-threads create/filter; `ClaudeTriggersRepository`; `/claude-triggers` endpoints gated to the Claude service account; trigger row written automatically when Claude is added as collaborator
- **MCP Server v0.2.0**: updated `rhythm_update_task`, `rhythm_create_message_thread`, `rhythm_list_message_threads`; new `rhythm_list_pending_triggers`, `rhythm_clear_pending_trigger`, `rhythm_get_task_thread` tools
- **Flutter**: `in_progress` and `waiting_for_reply` status badges in task rows and inspector
- **Docs**: CCR routine prompt (`docs/release/claude-collaborator-routine-prompt.md`) and service-account setup runbook (`docs/release/claude-collaborator-setup.md`)

Closes #329, #330, #331, #332, #333, #335, #336, #337, #338, #339, #340, #341, #344, #346, #349

## Test plan

- [ ] `cd apps/api_server && npm test` → 113/113 pass ✅ (verified in #349 smoke test)
- [ ] `cd apps/api_server && npx tsc --noEmit` → clean ✅
- [ ] `cd apps/mcp_server && npx tsc --noEmit` → clean ✅
- [ ] `cd apps/desktop_flutter && flutter analyze --no-fatal-infos` → 0 errors ✅
- [ ] `cd apps/desktop_flutter && dart format --output=none --set-exit-if-changed .` → 0 changed ✅
- [ ] `flutter run -d macos` — verify `in_progress` / `waiting_for_reply` badges render in Tasks and Weekly Planner
- [ ] Manual (#344): complete `docs/release/claude-collaborator-setup.md` steps on Synology (create service account, set `CLAUDE_USER_ID`, restart container)
- [ ] Manual (#347): create the hourly CCR routine via `RemoteTrigger create` in a Claude Code session (needs live secrets from step above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
