### PR TITLE
Email notifications & message thread task-id support

### DIFF
--- a/apps/api_server/.env.production.example
+++ b/apps/api_server/.env.production.example
@@ -22,5 +22,5 @@ PCO_REDIRECT_URI=https://api.vcrcapps.com/auth/planning-center/callback
 TUNNEL_TOKEN=your-cloudflare-tunnel-token
 SQLITE_MIGRATION_PATH=/data/rhythm.db
 
-RESEND_API_KEY=re_your_actual_key_here
-EMAIL_FROM_ADDRESS=Rhythm <notifications@vcrcapps.com>
+RESEND_API_KEY=
+EMAIL_FROM_ADDRESS=Rhythm <notifications@yourdomain.com>

--- a/apps/api_server/package.json
+++ b/apps/api_server/package.json
@@ -19,6 +19,7 @@
     "express": "^4.19.2",
     "node-cron": "^3.0.3",
     "pg": "^8.20.0",
+    "resend": "^6.12.2",
     "uuid": "^13.0.0"
   },
   "devDependencies": {

--- a/apps/api_server/src/__tests__/phase8_collaboration.test.ts
+++ b/apps/api_server/src/__tests__/phase8_collaboration.test.ts
@@ -76,7 +76,7 @@ describe('Phase 8 collaboration APIs', () => {
         title: 'Sunday Prep',
         frequency: 'weekly',
         dayOfWeek: 0,
-        steps: [{ title: 'Prep charts' }],
+        steps: [{ title: 'Prep charts', dayOfWeek: 0 }],
       }),
     });
     expect(createResponse.status).toBe(201);

--- a/apps/api_server/src/__tests__/users_permissions.test.ts
+++ b/apps/api_server/src/__tests__/users_permissions.test.ts
@@ -54,6 +54,119 @@ describe('UsersController permissions', () => {
     expect(usersRepo.findById(target.id).isFacilitiesManager).toBe(false);
   });
 
+  it('allows any authenticated user to update their own emailNotificationsEnabled', async () => {
+    const member = usersRepo.create({
+      name: 'Member',
+      email: 'member@example.com',
+    });
+    let payload: unknown;
+    let forwardedError: unknown;
+
+    await controller.updateMyPreferences(
+      {
+        auth: { user: member },
+        body: { emailNotificationsEnabled: false },
+      } as never,
+      {
+        json(value: unknown) {
+          payload = value;
+          return this;
+        },
+      } as never,
+      (error?: unknown) => {
+        forwardedError = error;
+      },
+    );
+
+    expect(forwardedError).toBeUndefined();
+    expect(payload).toMatchObject({
+      id: member.id,
+      emailNotificationsEnabled: false,
+    });
+  });
+
+  it('rejects missing emailNotificationsEnabled with 400', async () => {
+    const member = usersRepo.create({
+      name: 'Member',
+      email: 'member@example.com',
+    });
+    let forwardedError: unknown;
+
+    await controller.updateMyPreferences(
+      {
+        auth: { user: member },
+        body: {},
+      } as never,
+      {} as never,
+      (error?: unknown) => {
+        forwardedError = error;
+      },
+    );
+
+    expect(forwardedError).toMatchObject({
+      statusCode: 400,
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('rejects non-boolean emailNotificationsEnabled with 400', async () => {
+    const member = usersRepo.create({
+      name: 'Member',
+      email: 'member@example.com',
+    });
+    let forwardedError: unknown;
+
+    await controller.updateMyPreferences(
+      {
+        auth: { user: member },
+        body: { emailNotificationsEnabled: 'yes' },
+      } as never,
+      {} as never,
+      (error?: unknown) => {
+        forwardedError = error;
+      },
+    );
+
+    expect(forwardedError).toMatchObject({
+      statusCode: 400,
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('only updates the requesting user, not another user', async () => {
+    const member = usersRepo.create({
+      name: 'Member',
+      email: 'member@example.com',
+    });
+    const other = usersRepo.create({
+      name: 'Other',
+      email: 'other@example.com',
+    });
+    let payload: unknown;
+    let forwardedError: unknown;
+
+    await controller.updateMyPreferences(
+      {
+        auth: { user: member },
+        body: { emailNotificationsEnabled: false },
+      } as never,
+      {
+        json(value: unknown) {
+          payload = value;
+          return this;
+        },
+      } as never,
+      (error?: unknown) => {
+        forwardedError = error;
+      },
+    );
+
+    expect(forwardedError).toBeUndefined();
+    expect((payload as { id: number }).id).toBe(member.id);
+    // Other user is unchanged
+    expect(usersRepo.findById(other.id).emailNotificationsEnabled).toBe(true);
+  });
+
   it('allows admins to update user permissions', async () => {
     const admin = usersRepo.create({
       name: 'Admin',

--- a/apps/api_server/src/config/env.ts
+++ b/apps/api_server/src/config/env.ts
@@ -75,4 +75,6 @@ export const env = {
     }
     return parsed;
   })(),
+  resendApiKey: process.env.RESEND_API_KEY ?? '',
+  emailFromAddress: process.env.EMAIL_FROM_ADDRESS ?? 'Rhythm <onboarding@resend.dev>',
 };

--- a/apps/api_server/src/controllers/recurring_rules_controller.ts
+++ b/apps/api_server/src/controllers/recurring_rules_controller.ts
@@ -62,6 +62,9 @@ export class RecurringRulesController {
         throw AppError.badRequest('frequency must be weekly, monthly, or annual');
       }
 
+      const parsedSteps = parseSteps(steps);
+      validateSteps(frequency as 'weekly' | 'monthly' | 'annual', parsedSteps);
+
       const rule = await repo.createAsync({
         title,
         frequency: frequency as 'weekly' | 'monthly' | 'annual',
@@ -69,7 +72,7 @@ export class RecurringRulesController {
         dayOfMonth: dayOfMonth as number ?? null,
         month: month as number ?? null,
         ownerId: req.auth!.user.id,
-        steps: parseSteps(steps),
+        steps: parsedSteps,
         sequential: sequential === true,
       });
 
@@ -91,6 +94,20 @@ export class RecurringRulesController {
     try {
       const body = req.body as Record<string, unknown>;
       const userId = req.auth!.user.id;
+
+      // Validate steps if present in the request body
+      if ('steps' in body) {
+        const parsedSteps = parseSteps(body.steps);
+        let effectiveFrequency: 'weekly' | 'monthly' | 'annual';
+        if (body.frequency && VALID_FREQUENCIES.includes(body.frequency as never)) {
+          effectiveFrequency = body.frequency as 'weekly' | 'monthly' | 'annual';
+        } else {
+          const existing = await repo.findByIdAsync(req.params.id, userId);
+          effectiveFrequency = existing.frequency;
+        }
+        validateSteps(effectiveFrequency, parsedSteps);
+      }
+
       const rule = await repo.updateAsync(req.params.id, body, userId);
       await tasksRepo.deleteFutureOpenBySourceIdAsync('recurring_rule', rule.id);
       if (rule.enabled) {
@@ -242,6 +259,35 @@ export class RecurringRulesController {
   }
 }
 
+function validateSteps(
+  frequency: 'weekly' | 'monthly' | 'annual',
+  steps: RecurringTaskRuleStep[],
+): void {
+  if (steps.length === 0) return;
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const stepLabel = `Step ${i + 1}`;
+
+    if (frequency === 'weekly') {
+      if (step.dayOfWeek == null || !Number.isInteger(step.dayOfWeek) || step.dayOfWeek < 0 || step.dayOfWeek > 6) {
+        throw AppError.badRequest(`${stepLabel} requires dayOfWeek (0-6) for weekly rhythms`);
+      }
+    } else if (frequency === 'monthly') {
+      if (step.dayOfMonth == null || !Number.isInteger(step.dayOfMonth) || step.dayOfMonth < 1 || step.dayOfMonth > 31) {
+        throw AppError.badRequest(`${stepLabel} requires dayOfMonth (1-31) for monthly rhythms`);
+      }
+    } else if (frequency === 'annual') {
+      if (step.month == null || !Number.isInteger(step.month) || step.month < 1 || step.month > 12) {
+        throw AppError.badRequest(`${stepLabel} requires month (1-12) for annual rhythms`);
+      }
+      if (step.dayOfMonth == null || !Number.isInteger(step.dayOfMonth) || step.dayOfMonth < 1 || step.dayOfMonth > 31) {
+        throw AppError.badRequest(`${stepLabel} requires dayOfMonth (1-31) for annual rhythms`);
+      }
+    }
+  }
+}
+
 function parseSteps(raw: unknown): RecurringTaskRuleStep[] {
   if (!Array.isArray(raw)) return [];
   return raw
@@ -264,9 +310,25 @@ function normalizeStep(step: unknown, index: number): RecurringTaskRuleStep | nu
       : typeof record.assigneeId === 'string' && record.assigneeId.trim() !== ''
         ? Number(record.assigneeId)
         : null;
+  const dayOfWeek =
+    typeof record.dayOfWeek === 'number' && Number.isFinite(record.dayOfWeek)
+      ? record.dayOfWeek
+      : null;
+  const dayOfMonth =
+    typeof record.dayOfMonth === 'number' && Number.isFinite(record.dayOfMonth)
+      ? record.dayOfMonth
+      : null;
+  const month =
+    typeof record.month === 'number' && Number.isFinite(record.month)
+      ? record.month
+      : null;
+
   return {
     id,
     title,
     assigneeId: Number.isFinite(assigneeId as number) ? (assigneeId as number) : null,
+    dayOfWeek,
+    dayOfMonth,
+    month,
   };
 }

--- a/apps/api_server/src/controllers/tasks_controller.ts
+++ b/apps/api_server/src/controllers/tasks_controller.ts
@@ -6,6 +6,8 @@ import { NotificationService } from '../services/notification_service';
 import { RecurringTaskRulesRepository } from '../repositories/recurring_task_rules_repository';
 import { ClaudeTriggersRepository } from '../repositories/claude_triggers_repository';
 import { env } from '../config/env';
+import { EmailService } from '../services/email_service';
+import { UsersRepository } from '../repositories/users_repository';
 
 const VALID_STATUSES = ['open', 'in_progress', 'waiting_for_reply', 'done'] as const;
 type ValidStatus = (typeof VALID_STATUSES)[number];
@@ -14,6 +16,8 @@ const repo = new TasksRepository();
 const rulesRepo = new RecurringTaskRulesRepository();
 const notifService = new NotificationService(new NotificationsRepository());
 const claudeTriggersRepo = new ClaudeTriggersRepository();
+const usersRepo = new UsersRepository();
+const emailService = new EmailService(usersRepo);
 
 export class TasksController {
   async getAll(req: Request, res: Response, next: NextFunction) {
@@ -83,6 +87,16 @@ export class TasksController {
           updated.ownerId,
           actorId,
         );
+        const actor = await usersRepo.findByIdAsync(actorId).catch(() => null);
+        if (actor) {
+          await emailService.sendTaskAssignedEmailAsync(
+            updated.id,
+            updated.title,
+            actor.name,
+            updated.ownerId,
+            actorId,
+          );
+        }
       }
 
       // Notify collaborators on task completion
@@ -159,6 +173,16 @@ export class TasksController {
         userId,
         actorId,
       );
+      const actor = await usersRepo.findByIdAsync(actorId).catch(() => null);
+      if (actor) {
+        await emailService.sendCollaboratorAddedEmailAsync(
+          req.params.id,
+          task.title,
+          actor.name,
+          userId,
+          actorId,
+        );
+      }
       if (env.claudeUserId != null && userId === env.claudeUserId) {
         await claudeTriggersRepo.insertAsync(req.params.id, actorId);
       }

--- a/apps/api_server/src/controllers/users_controller.ts
+++ b/apps/api_server/src/controllers/users_controller.ts
@@ -57,6 +57,20 @@ export class UsersController {
     }
   }
 
+  async updateMyPreferences(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.auth!.user.id;
+      const { emailNotificationsEnabled } = req.body as Record<string, unknown>;
+      if (typeof emailNotificationsEnabled !== 'boolean') {
+        throw AppError.badRequest('emailNotificationsEnabled must be a boolean');
+      }
+      const user = await repo.updateAsync(userId, { emailNotificationsEnabled });
+      res.json(user);
+    } catch (err) {
+      next(err);
+    }
+  }
+
   async update(req: Request, res: Response, next: NextFunction) {
     try {
       this.requireAdmin(req);

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -166,6 +166,7 @@ export function runMigrations(db: Database.Database): void {
       photo_url TEXT,
       role TEXT NOT NULL DEFAULT 'member',
       is_facilities_manager INTEGER NOT NULL DEFAULT 0,
+      email_notifications_enabled INTEGER NOT NULL DEFAULT 1,
       password_hash TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -335,6 +336,12 @@ export function runMigrations(db: Database.Database): void {
   if (!userCols.includes('is_facilities_manager')) {
     db.exec(
       `ALTER TABLE users ADD COLUMN is_facilities_manager INTEGER NOT NULL DEFAULT 0`,
+    );
+  }
+  const userColsP9 = (db.pragma('table_info(users)') as { name: string }[]).map((c) => c.name);
+  if (!userColsP9.includes('email_notifications_enabled')) {
+    db.exec(
+      `ALTER TABLE users ADD COLUMN email_notifications_enabled INTEGER NOT NULL DEFAULT 1`,
     );
   }
 

--- a/apps/api_server/src/database/postgres_bootstrap.ts
+++ b/apps/api_server/src/database/postgres_bootstrap.ts
@@ -13,6 +13,7 @@ export async function runPostgresBootstrap(pool: Pool): Promise<void> {
       photo_url TEXT,
       role TEXT NOT NULL DEFAULT 'member',
       is_facilities_manager BOOLEAN NOT NULL DEFAULT FALSE,
+      email_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE,
       password_hash TEXT,
       created_at TEXT NOT NULL DEFAULT (${UTC_TEXT_NOW}),
       updated_at TEXT NOT NULL DEFAULT (${UTC_TEXT_NOW})
@@ -316,6 +317,7 @@ export async function runPostgresBootstrap(pool: Pool): Promise<void> {
     ALTER TABLE users ADD COLUMN IF NOT EXISTS photo_url TEXT;
     ALTER TABLE users ADD COLUMN IF NOT EXISTS role TEXT NOT NULL DEFAULT 'member';
     ALTER TABLE users ADD COLUMN IF NOT EXISTS is_facilities_manager BOOLEAN NOT NULL DEFAULT FALSE;
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS email_notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE;
     ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash TEXT;
 
     ALTER TABLE facilities ADD COLUMN IF NOT EXISTS building TEXT;

--- a/apps/api_server/src/models/recurring_task_rule.ts
+++ b/apps/api_server/src/models/recurring_task_rule.ts
@@ -3,6 +3,9 @@ export interface RecurringTaskRuleStep {
   title: string;
   assigneeId: number | null;
   assigneeName?: string | null;
+  dayOfWeek?: number | null;
+  dayOfMonth?: number | null;
+  month?: number | null;
 }
 
 export interface RhythmCollaborator {

--- a/apps/api_server/src/models/user.ts
+++ b/apps/api_server/src/models/user.ts
@@ -6,6 +6,7 @@ export interface User {
   photoUrl: string | null;
   role: string;
   isFacilitiesManager: boolean;
+  emailNotificationsEnabled: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -17,6 +18,7 @@ export interface CreateUserDto {
   photoUrl?: string | null;
   role?: string;
   isFacilitiesManager?: boolean;
+  emailNotificationsEnabled?: boolean;
 }
 
 export interface UpdateUserDto {
@@ -26,4 +28,5 @@ export interface UpdateUserDto {
   photoUrl?: string | null;
   role?: string;
   isFacilitiesManager?: boolean;
+  emailNotificationsEnabled?: boolean;
 }

--- a/apps/api_server/src/repositories/recurring_task_rules_repository.ts
+++ b/apps/api_server/src/repositories/recurring_task_rules_repository.ts
@@ -89,11 +89,32 @@ function normalizeStep(step: unknown, fallbackIndex: number): RecurringTaskRuleS
       : typeof record.assigneeId === 'string' && record.assigneeId.trim() !== ''
         ? Number(record.assigneeId)
         : null;
+  const dayOfWeek =
+    typeof record.dayOfWeek === 'number'
+      ? record.dayOfWeek
+      : typeof record.dayOfWeek === 'string' && record.dayOfWeek.trim() !== ''
+        ? Number(record.dayOfWeek)
+        : null;
+  const dayOfMonth =
+    typeof record.dayOfMonth === 'number'
+      ? record.dayOfMonth
+      : typeof record.dayOfMonth === 'string' && record.dayOfMonth.trim() !== ''
+        ? Number(record.dayOfMonth)
+        : null;
+  const month =
+    typeof record.month === 'number'
+      ? record.month
+      : typeof record.month === 'string' && record.month.trim() !== ''
+        ? Number(record.month)
+        : null;
   return {
     id,
     title,
     assigneeId: Number.isFinite(assigneeId as number) ? (assigneeId as number) : null,
     assigneeName: typeof record.assigneeName === 'string' ? record.assigneeName : null,
+    dayOfWeek: Number.isFinite(dayOfWeek as number) ? (dayOfWeek as number) : null,
+    dayOfMonth: Number.isFinite(dayOfMonth as number) ? (dayOfMonth as number) : null,
+    month: Number.isFinite(month as number) ? (month as number) : null,
   };
 }
 
@@ -103,6 +124,9 @@ function serializeSteps(steps?: RecurringTaskRuleStep[]): string {
       id: step.id.trim().length > 0 ? step.id.trim() : `step-${index + 1}-${uuidv4()}`,
       title: step.title.trim(),
       assigneeId: step.assigneeId ?? null,
+      dayOfWeek: step.dayOfWeek ?? null,
+      dayOfMonth: step.dayOfMonth ?? null,
+      month: step.month ?? null,
     })),
   );
 }

--- a/apps/api_server/src/repositories/users_repository.ts
+++ b/apps/api_server/src/repositories/users_repository.ts
@@ -12,6 +12,7 @@ interface UserRow {
   photo_url: string | null;
   role: string;
   is_facilities_manager: number;
+  email_notifications_enabled: number | boolean;
   created_at: string;
   updated_at: string;
 }
@@ -22,6 +23,11 @@ function rowToUser(row: UserRow): User {
       ? row.is_facilities_manager
       : row.is_facilities_manager === 1;
 
+  const emailNotificationsEnabled =
+    typeof row.email_notifications_enabled === 'boolean'
+      ? row.email_notifications_enabled
+      : row.email_notifications_enabled === 1;
+
   return {
     id: row.id,
     name: row.name,
@@ -30,6 +36,7 @@ function rowToUser(row: UserRow): User {
     photoUrl: row.photo_url,
     role: row.role,
     isFacilitiesManager,
+    emailNotificationsEnabled,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -121,8 +128,8 @@ export class UsersRepository {
   async createAsync(data: CreateUserDto): Promise<User> {
     if (env.dbClient === 'postgres') {
       const result = await getPostgresPool().query<UserRow>(
-        `INSERT INTO users (name, email, google_sub, photo_url, role, is_facilities_manager)
-         VALUES ($1, $2, $3, $4, $5, $6)
+        `INSERT INTO users (name, email, google_sub, photo_url, role, is_facilities_manager, email_notifications_enabled)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
          RETURNING *`,
         [
           data.name,
@@ -131,6 +138,7 @@ export class UsersRepository {
           data.photoUrl ?? null,
           data.role ?? 'member',
           data.isFacilitiesManager ?? false,
+          data.emailNotificationsEnabled ?? true,
         ],
       );
       return rowToUser(result.rows[0]);
@@ -142,7 +150,7 @@ export class UsersRepository {
   create(data: CreateUserDto): User {
     const result = getDb()
       .prepare(
-        `INSERT INTO users (name, email, google_sub, photo_url, role, is_facilities_manager) VALUES (?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO users (name, email, google_sub, photo_url, role, is_facilities_manager, email_notifications_enabled) VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         data.name,
@@ -151,6 +159,7 @@ export class UsersRepository {
         data.photoUrl ?? null,
         data.role ?? 'member',
         data.isFacilitiesManager ? 1 : 0,
+        (data.emailNotificationsEnabled ?? true) ? 1 : 0,
       );
     return this.findById(result.lastInsertRowid as number);
   }
@@ -167,8 +176,9 @@ export class UsersRepository {
                 photo_url = $4,
                 role = $5,
                 is_facilities_manager = $6,
-                updated_at = $7
-          WHERE id = $8
+                email_notifications_enabled = $7,
+                updated_at = $8
+          WHERE id = $9
           RETURNING *`,
         [
           data.name ?? existing.name,
@@ -179,6 +189,9 @@ export class UsersRepository {
           data.isFacilitiesManager !== undefined
             ? data.isFacilitiesManager
             : existing.isFacilitiesManager,
+          data.emailNotificationsEnabled !== undefined
+            ? data.emailNotificationsEnabled
+            : existing.emailNotificationsEnabled,
           now,
           id,
         ],
@@ -194,7 +207,7 @@ export class UsersRepository {
     const now = new Date().toISOString();
     getDb()
       .prepare(
-        `UPDATE users SET name = ?, email = ?, google_sub = ?, photo_url = ?, role = ?, is_facilities_manager = ?, updated_at = ? WHERE id = ?`,
+        `UPDATE users SET name = ?, email = ?, google_sub = ?, photo_url = ?, role = ?, is_facilities_manager = ?, email_notifications_enabled = ?, updated_at = ? WHERE id = ?`,
       )
       .run(
         data.name ?? existing.name,
@@ -205,6 +218,9 @@ export class UsersRepository {
         data.isFacilitiesManager !== undefined
             ? (data.isFacilitiesManager ? 1 : 0)
             : (existing.isFacilitiesManager ? 1 : 0),
+        data.emailNotificationsEnabled !== undefined
+            ? (data.emailNotificationsEnabled ? 1 : 0)
+            : (existing.emailNotificationsEnabled ? 1 : 0),
         now,
         id,
       );

--- a/apps/api_server/src/routes/users_routes.ts
+++ b/apps/api_server/src/routes/users_routes.ts
@@ -7,6 +7,7 @@ export const usersRouter = Router();
 
 usersRouter.use(requireAuth);
 usersRouter.get('/', controller.getAll.bind(controller));
+usersRouter.patch('/me/preferences', controller.updateMyPreferences.bind(controller));
 usersRouter.get('/:id', controller.getById.bind(controller));
 usersRouter.post('/', controller.create.bind(controller));
 usersRouter.patch('/:id', controller.update.bind(controller));

--- a/apps/api_server/src/services/email_service.test.ts
+++ b/apps/api_server/src/services/email_service.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// mockSend is the spy we'll track across all Resend instances
+const mockSend = vi.fn();
+
+// Mock the resend module BEFORE any imports that pull it in
+vi.mock('resend', () => {
+  class MockResend {
+    emails = { send: mockSend };
+  }
+  return { Resend: MockResend };
+});
+
+// Mock env so we can mutate resendApiKey per test
+vi.mock('../config/env', () => ({
+  env: {
+    resendApiKey: 'test-api-key',
+    emailFromAddress: 'Rhythm <noreply@example.com>',
+  },
+}));
+
+import { env } from '../config/env';
+import { EmailService } from './email_service';
+import type { UsersRepository } from '../repositories/users_repository';
+
+function makeUser(overrides: Partial<{
+  id: number;
+  name: string;
+  email: string;
+  emailNotificationsEnabled: boolean;
+}> = {}) {
+  return {
+    id: 10,
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    googleSub: null,
+    photoUrl: null,
+    role: 'member',
+    isFacilitiesManager: false,
+    emailNotificationsEnabled: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeRepo(user: ReturnType<typeof makeUser> | null = makeUser()): UsersRepository {
+  return {
+    findByIdAsync: user
+      ? vi.fn().mockResolvedValue(user)
+      : vi.fn().mockRejectedValue(new Error('Not found')),
+  } as unknown as UsersRepository;
+}
+
+describe('EmailService', () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+    // Ensure env has an API key by default
+    (env as { resendApiKey: string }).resendApiKey = 'test-api-key';
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('1. does NOT send when recipient === actor (self-action skip)', async () => {
+    const repo = makeRepo();
+    const service = new EmailService(repo);
+    await service.sendTaskAssignedEmailAsync('task-1', 'My Task', 'Alice', 5, 5);
+    expect(repo.findByIdAsync).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('2. does NOT send when env.resendApiKey is empty (no API key skip)', async () => {
+    (env as { resendApiKey: string }).resendApiKey = '';
+    const repo = makeRepo();
+    // Create service AFTER clearing the key so the constructor sees the empty key
+    const service = new EmailService(repo);
+    await service.sendTaskAssignedEmailAsync('task-1', 'My Task', 'Alice', 10, 20);
+    expect(repo.findByIdAsync).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('3. does NOT send when recipient has emailNotificationsEnabled = false', async () => {
+    const user = makeUser({ emailNotificationsEnabled: false });
+    const repo = makeRepo(user);
+    const service = new EmailService(repo);
+    await service.sendTaskAssignedEmailAsync('task-1', 'My Task', 'Alice', 10, 20);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('4. does NOT send (and does NOT throw) when findByIdAsync rejects', async () => {
+    const repo = makeRepo(null);
+    const service = new EmailService(repo);
+    await expect(
+      service.sendTaskAssignedEmailAsync('task-1', 'My Task', 'Alice', 10, 20),
+    ).resolves.toBeUndefined();
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('5. happy path: sends email with correct from, to, subject, and HTML link', async () => {
+    mockSend.mockResolvedValueOnce({ data: { id: 'msg-1' }, error: null });
+    const user = makeUser({ id: 10, email: 'jane@example.com', name: 'Jane Doe' });
+    const repo = makeRepo(user);
+    const service = new EmailService(repo);
+
+    await service.sendTaskAssignedEmailAsync('task-abc', 'Plan the Event', 'Bob', 10, 20);
+
+    expect(mockSend).toHaveBeenCalledOnce();
+    const callArg = mockSend.mock.calls[0][0] as {
+      from: string;
+      to: string;
+      subject: string;
+      html: string;
+      text: string;
+    };
+
+    expect(callArg.from).toBe('Rhythm <noreply@example.com>');
+    expect(callArg.to).toBe('jane@example.com');
+    expect(callArg.subject).toContain('Plan the Event');
+    expect(callArg.subject).toContain('Bob');
+    expect(callArg.html).toContain('rhythm://tasks/task-abc');
+  });
+
+  it('6. Resend error is swallowed: method resolves even when send rejects', async () => {
+    mockSend.mockRejectedValueOnce(new Error('Network failure'));
+    const user = makeUser();
+    const repo = makeRepo(user);
+    const service = new EmailService(repo);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(
+      service.sendTaskAssignedEmailAsync('task-1', 'My Task', 'Alice', 10, 20),
+    ).resolves.toBeUndefined();
+    expect(consoleSpy).toHaveBeenCalledWith('[email] send failed', expect.any(Error));
+    consoleSpy.mockRestore();
+  });
+
+  it('7. HTML escaping: dangerous chars in task title and actor name are escaped', async () => {
+    mockSend.mockResolvedValueOnce({ data: { id: 'msg-xss' }, error: null });
+    const user = makeUser();
+    const repo = makeRepo(user);
+    const service = new EmailService(repo);
+
+    await service.sendTaskAssignedEmailAsync(
+      'task-xss',
+      '<script>alert(1)</script>',
+      'Bob & Alice',
+      10,
+      20,
+    );
+
+    expect(mockSend).toHaveBeenCalledOnce();
+    const { html } = mockSend.mock.calls[0][0] as { html: string };
+
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(html).toContain('Bob &amp; Alice');
+    expect(html).not.toContain('<script>');
+  });
+
+  it('sendCollaboratorAddedEmailAsync happy path: uses "added you to" verb', async () => {
+    mockSend.mockResolvedValueOnce({ data: { id: 'msg-2' }, error: null });
+    const user = makeUser({ id: 10, email: 'jane@example.com' });
+    const repo = makeRepo(user);
+    const service = new EmailService(repo);
+
+    await service.sendCollaboratorAddedEmailAsync('task-xyz', 'Team Meeting', 'Carol', 10, 30);
+
+    expect(mockSend).toHaveBeenCalledOnce();
+    const { subject } = mockSend.mock.calls[0][0] as { subject: string };
+    expect(subject).toContain('added you to');
+    expect(subject).toContain('Team Meeting');
+  });
+});

--- a/apps/api_server/src/services/email_service.ts
+++ b/apps/api_server/src/services/email_service.ts
@@ -1,0 +1,89 @@
+import { Resend } from 'resend';
+import { env } from '../config/env';
+import type { UsersRepository } from '../repositories/users_repository';
+
+export class EmailService {
+  private readonly client: Resend | null;
+
+  constructor(private readonly usersRepo: UsersRepository) {
+    this.client = env.resendApiKey ? new Resend(env.resendApiKey) : null;
+  }
+
+  async sendTaskAssignedEmailAsync(
+    taskId: string,
+    taskTitle: string,
+    actorName: string,
+    recipientUserId: number,
+    actorUserId: number,
+  ): Promise<void> {
+    await this.sendCollaborationEmailAsync({
+      taskId, taskTitle, actorName, recipientUserId, actorUserId,
+      subjectVerb: 'assigned you to',
+    });
+  }
+
+  async sendCollaboratorAddedEmailAsync(
+    taskId: string,
+    taskTitle: string,
+    actorName: string,
+    recipientUserId: number,
+    actorUserId: number,
+  ): Promise<void> {
+    await this.sendCollaborationEmailAsync({
+      taskId, taskTitle, actorName, recipientUserId, actorUserId,
+      subjectVerb: 'added you to',
+    });
+  }
+
+  private async sendCollaborationEmailAsync(params: {
+    taskId: string;
+    taskTitle: string;
+    actorName: string;
+    recipientUserId: number;
+    actorUserId: number;
+    subjectVerb: string;
+  }): Promise<void> {
+    if (params.recipientUserId === params.actorUserId) return;
+    if (!this.client) return;
+
+    const recipient = await this.usersRepo
+      .findByIdAsync(params.recipientUserId)
+      .catch(() => null);
+    if (!recipient || !recipient.emailNotificationsEnabled || !recipient.email) return;
+
+    const link = `rhythm://tasks/${params.taskId}`;
+    const subject = `${params.actorName} ${params.subjectVerb} "${params.taskTitle}" in Rhythm`;
+    const html = `
+      <p>${escapeHtml(params.actorName)} has invited you to collaborate on
+      "<strong>${escapeHtml(params.taskTitle)}</strong>" in Rhythm.</p>
+      <p><a href="${link}">Click here to open in Rhythm</a></p>
+      <hr>
+      <p style="color:#6B7280;font-size:12px">
+        You're receiving this because you have email notifications enabled in Rhythm.
+      </p>
+    `;
+    const text = `${params.actorName} has invited you to collaborate on "${params.taskTitle}" in Rhythm.\n\nOpen in Rhythm: ${link}`;
+
+    try {
+      await this.client.emails.send({
+        from: env.emailFromAddress,
+        to: recipient.email,
+        subject,
+        html,
+        text,
+      });
+    } catch (err) {
+      console.error('[email] send failed', err);
+    }
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[c]!));
+}

--- a/apps/api_server/src/services/recurrence_service.test.ts
+++ b/apps/api_server/src/services/recurrence_service.test.ts
@@ -1,0 +1,333 @@
+import Database from 'better-sqlite3';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { setDb } from '../database/db';
+import { runMigrations } from '../database/migrations';
+import type { RecurringTaskRule } from '../models/recurring_task_rule';
+import { TasksRepository } from '../repositories/tasks_repository';
+import { UsersRepository } from '../repositories/users_repository';
+import { RecurrenceService } from './recurrence_service';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let testOwnerId: number;
+
+function makeRule(overrides: Partial<RecurringTaskRule> = {}): RecurringTaskRule {
+  return {
+    id: 'rule-1',
+    title: 'Test Rhythm',
+    frequency: 'weekly',
+    dayOfWeek: 1, // Monday
+    dayOfMonth: null,
+    month: null,
+    enabled: true,
+    sequential: false,
+    ownerId: testOwnerId,
+    steps: [],
+    collaborators: [],
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  const db = new Database(':memory:');
+  runMigrations(db);
+  setDb(db);
+  // Create a real user so that tasks can satisfy the FK constraint on owner_id.
+  const usersRepo = new UsersRepository();
+  const user = usersRepo.create({ name: 'Test User', email: 'test@example.com' });
+  testOwnerId = user.id;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RecurrenceService', () => {
+  const service = new RecurrenceService();
+
+  // -------------------------------------------------------------------------
+  // 0-step rhythms — backward-compatibility
+  // -------------------------------------------------------------------------
+
+  describe('0-step rhythm (legacy / no steps)', () => {
+    test('weekly: produces one task per week on the specified day of week', async () => {
+      const rule = makeRule({ frequency: 'weekly', dayOfWeek: 3 }); // Wednesday
+      // 2026-05-04 (Mon) → 2026-05-18 (Mon) — should hit Wed May 6 and Wed May 13
+      const from = new Date('2026-05-04T00:00:00Z');
+      const to = new Date('2026-05-18T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(2);
+      expect(tasks[0].dueDate).toBe('2026-05-06');
+      expect(tasks[1].dueDate).toBe('2026-05-13');
+    });
+
+    test('monthly: produces one task per month on the specified day', async () => {
+      const rule = makeRule({ frequency: 'monthly', dayOfMonth: 15 });
+      const from = new Date('2026-05-01T00:00:00Z');
+      const to = new Date('2026-06-30T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(2);
+      expect(tasks[0].dueDate).toBe('2026-05-15');
+      expect(tasks[1].dueDate).toBe('2026-06-15');
+    });
+
+    test('annual: produces one task per year on the specified date', async () => {
+      const rule = makeRule({ frequency: 'annual', month: 3, dayOfMonth: 10 });
+      const from = new Date('2026-01-01T00:00:00Z');
+      const to = new Date('2027-12-31T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(2);
+      expect(tasks[0].dueDate).toBe('2026-03-10');
+      expect(tasks[1].dueDate).toBe('2027-03-10');
+    });
+
+    test('idempotent: repeated calls produce no duplicates', async () => {
+      const rule = makeRule({ frequency: 'weekly', dayOfWeek: 1 });
+      const from = new Date('2026-05-04T00:00:00Z');
+      const to = new Date('2026-05-10T23:59:59Z');
+
+      const first = await service.generateInstances(rule, from, to);
+      expect(first).toHaveLength(1);
+
+      const second = await service.generateInstances(rule, from, to);
+      expect(second).toHaveLength(0); // already exists — skip
+
+      // Verify only one task exists in the DB by calling findAllAsync with the real owner id.
+      const tasksRepo = new TasksRepository();
+      const all = await tasksRepo.findAllAsync(testOwnerId);
+      expect(all).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Weekly per-step
+  // -------------------------------------------------------------------------
+
+  describe('weekly rhythm with steps (Mon / Wed / Fri)', () => {
+    function makeWeeklyRule(): RecurringTaskRule {
+      return makeRule({
+        frequency: 'weekly',
+        dayOfWeek: 1, // rhythm-level fallback
+        steps: [
+          { id: 'step-1', title: 'Monday Task', assigneeId: null, dayOfWeek: 1 },
+          { id: 'step-2', title: 'Wednesday Task', assigneeId: null, dayOfWeek: 3 },
+          { id: 'step-3', title: 'Friday Task', assigneeId: null, dayOfWeek: 5 },
+        ],
+      });
+    }
+
+    test('generates 3 tasks per week with correct individual due dates', async () => {
+      const rule = makeWeeklyRule();
+      // One week: Mon 2026-05-04 → Sun 2026-05-10
+      const from = new Date('2026-05-04T00:00:00Z');
+      const to = new Date('2026-05-10T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(3);
+
+      const dueDates = tasks.map((t) => t.dueDate).sort();
+      expect(dueDates).toEqual(['2026-05-04', '2026-05-06', '2026-05-08']);
+    });
+
+    test('generates 6 tasks over two weeks', async () => {
+      const rule = makeWeeklyRule();
+      const from = new Date('2026-05-04T00:00:00Z');
+      const to = new Date('2026-05-17T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(6);
+    });
+
+    test('idempotent: second call within same window creates nothing new', async () => {
+      const rule = makeWeeklyRule();
+      const from = new Date('2026-05-04T00:00:00Z');
+      const to = new Date('2026-05-10T23:59:59Z');
+
+      await service.generateInstances(rule, from, to);
+      const second = await service.generateInstances(rule, from, to);
+      expect(second).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Monthly per-step
+  // -------------------------------------------------------------------------
+
+  describe('monthly rhythm with steps (day 5, day 20)', () => {
+    function makeMonthlyRule(): RecurringTaskRule {
+      return makeRule({
+        frequency: 'monthly',
+        dayOfMonth: 1, // rhythm-level fallback
+        steps: [
+          { id: 'step-1', title: 'Early Month', assigneeId: null, dayOfMonth: 5 },
+          { id: 'step-2', title: 'Late Month', assigneeId: null, dayOfMonth: 20 },
+        ],
+      });
+    }
+
+    test('generates 2 tasks per month with correct dates', async () => {
+      const rule = makeMonthlyRule();
+      const from = new Date('2026-05-01T00:00:00Z');
+      const to = new Date('2026-05-31T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(2);
+
+      const dueDates = tasks.map((t) => t.dueDate).sort();
+      expect(dueDates).toEqual(['2026-05-05', '2026-05-20']);
+    });
+
+    test('generates 4 tasks over two months', async () => {
+      const rule = makeMonthlyRule();
+      const from = new Date('2026-05-01T00:00:00Z');
+      const to = new Date('2026-06-30T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(4);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Annual per-step
+  // -------------------------------------------------------------------------
+
+  describe('annual rhythm with steps (Jan 15, Mar 1)', () => {
+    function makeAnnualRule(): RecurringTaskRule {
+      return makeRule({
+        frequency: 'annual',
+        month: 1,
+        dayOfMonth: 1, // rhythm-level fallbacks
+        steps: [
+          { id: 'step-1', title: 'January Task', assigneeId: null, month: 1, dayOfMonth: 15 },
+          { id: 'step-2', title: 'March Task', assigneeId: null, month: 3, dayOfMonth: 1 },
+        ],
+      });
+    }
+
+    test('generates 2 tasks per year on their respective dates', async () => {
+      const rule = makeAnnualRule();
+      const from = new Date('2026-01-01T00:00:00Z');
+      const to = new Date('2026-12-31T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(2);
+
+      const dueDates = tasks.map((t) => t.dueDate).sort();
+      expect(dueDates).toEqual(['2026-01-15', '2026-03-01']);
+    });
+
+    test('generates 4 tasks over two years', async () => {
+      const rule = makeAnnualRule();
+      const from = new Date('2026-01-01T00:00:00Z');
+      const to = new Date('2027-12-31T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(4);
+
+      const dueDates = tasks.map((t) => t.dueDate).sort();
+      expect(dueDates).toEqual(['2026-01-15', '2026-03-01', '2027-01-15', '2027-03-01']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Fallback: step missing day field falls back to rhythm-level field
+  // -------------------------------------------------------------------------
+
+  describe('fallback to rhythm-level fields when step day is null', () => {
+    test('weekly step with null dayOfWeek falls back to rule.dayOfWeek', async () => {
+      const rule = makeRule({
+        frequency: 'weekly',
+        dayOfWeek: 2, // Tuesday
+        steps: [
+          { id: 'step-1', title: 'Fallback Step', assigneeId: null, dayOfWeek: null },
+        ],
+      });
+      const from = new Date('2026-05-04T00:00:00Z'); // Monday
+      const to = new Date('2026-05-10T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].dueDate).toBe('2026-05-05'); // Tuesday
+    });
+
+    test('monthly step with null dayOfMonth falls back to rule.dayOfMonth', async () => {
+      const rule = makeRule({
+        frequency: 'monthly',
+        dayOfMonth: 10,
+        steps: [
+          { id: 'step-1', title: 'Fallback Step', assigneeId: null, dayOfMonth: null },
+        ],
+      });
+      const from = new Date('2026-05-01T00:00:00Z');
+      const to = new Date('2026-05-31T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].dueDate).toBe('2026-05-10');
+    });
+
+    test('annual step with null month/dayOfMonth falls back to rule-level fields', async () => {
+      const rule = makeRule({
+        frequency: 'annual',
+        month: 6,
+        dayOfMonth: 21,
+        steps: [
+          { id: 'step-1', title: 'Fallback Step', assigneeId: null, month: null, dayOfMonth: null },
+        ],
+      });
+      const from = new Date('2026-01-01T00:00:00Z');
+      const to = new Date('2026-12-31T23:59:59Z');
+
+      const tasks = await service.generateInstances(rule, from, to);
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].dueDate).toBe('2026-06-21');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dates outside [from, to] are skipped
+  // -------------------------------------------------------------------------
+
+  test('step dates outside the lookahead window are not created', async () => {
+    const rule = makeRule({
+      frequency: 'weekly',
+      dayOfWeek: 1,
+      steps: [
+        // Step falls on a day-of-week that is before the start of `from`
+        { id: 'step-1', title: 'Past Step', assigneeId: null, dayOfWeek: 0 }, // Sunday
+      ],
+    });
+    // from is Monday 2026-05-04, so Sunday May 3 is before the window
+    const from = new Date('2026-05-04T00:00:00Z');
+    const to = new Date('2026-05-10T23:59:59Z');
+
+    const tasks = await service.generateInstances(rule, from, to);
+    // Sunday May 3 is out of range; Sunday May 10 IS in range
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].dueDate).toBe('2026-05-10');
+  });
+
+  // -------------------------------------------------------------------------
+  // Rule with no ownerId — produce nothing
+  // -------------------------------------------------------------------------
+
+  test('returns empty array when rule has no ownerId', async () => {
+    const rule = makeRule({ ownerId: null });
+    const tasks = await service.generateInstances(
+      rule,
+      new Date('2026-05-04T00:00:00Z'),
+      new Date('2026-05-10T23:59:59Z'),
+    );
+    expect(tasks).toHaveLength(0);
+  });
+});

--- a/apps/api_server/src/services/recurrence_service.ts
+++ b/apps/api_server/src/services/recurrence_service.ts
@@ -1,4 +1,4 @@
-import type { RecurringTaskRule } from '../models/recurring_task_rule';
+import type { RecurringTaskRule, RecurringTaskRuleStep } from '../models/recurring_task_rule';
 import type { Task } from '../models/task';
 import { TasksRepository } from '../repositories/tasks_repository';
 
@@ -8,6 +8,12 @@ export class RecurrenceService {
   /**
    * Generate concrete task instances for a recurring rule within [from, to].
    * Idempotent: skips dates where a task with matching source_type/source_id/due_date already exists.
+   *
+   * When a rule has workflow steps, each step gets its own due date computed from
+   * the step's per-step day fields (dayOfWeek / dayOfMonth / month), falling back
+   * to the rhythm-level fields when a step's field is null.
+   *
+   * When a rule has zero steps, behavior is unchanged: one task per occurrence date.
    */
   async generateInstances(
     rule: RecurringTaskRule,
@@ -16,43 +22,210 @@ export class RecurrenceService {
   ): Promise<Task[]> {
     if (rule.ownerId == null) return [];
 
-    const dates = this.computeDates(rule, from, to);
-    const created: Task[] = [];
     const hasWorkflowSteps = rule.steps.length > 0;
+    const created: Task[] = [];
 
-    for (const date of dates) {
-      const dateStr = toDateStr(date);
-      const steps = hasWorkflowSteps
-        ? rule.steps
-        : [{ id: rule.id, title: rule.title, assigneeId: rule.ownerId }];
-
-      for (const [index, step] of steps.entries()) {
-        const sourceId = hasWorkflowSteps ? `${rule.id}:${step.id}` : rule.id;
+    if (!hasWorkflowSteps) {
+      // Legacy / no-step path: one task per occurrence date using rhythm-level fields.
+      const dates = this.computeDates(rule, from, to);
+      for (const date of dates) {
+        const dateStr = toDateStr(date);
         const existing = await this.tasksRepo.findBySourceAndDueDateAsync(
           'recurring_rule',
-          sourceId,
+          rule.id,
           dateStr,
         );
-
         if (!existing) {
-          const locked = rule.sequential && hasWorkflowSteps && index > 0;
           const task = await this.tasksRepo.createAsync({
-            title: step.title,
+            title: rule.title,
             dueDate: dateStr,
             status: 'open',
             sourceType: 'recurring_rule',
-            sourceId,
-            ownerId: step.assigneeId ?? rule.ownerId,
-            scheduledOrder: hasWorkflowSteps ? (index + 1) * 10000 : null,
-            locked,
+            sourceId: rule.id,
+            ownerId: rule.ownerId,
+            scheduledOrder: null,
+            locked: false,
           });
           created.push(task);
         }
+      }
+      return created;
+    }
+
+    // Per-step path: iterate over periods (week/month/year) and compute each
+    // step's due date within that period.
+    switch (rule.frequency) {
+      case 'weekly':
+        created.push(...(await this.generateWeeklyPerStep(rule, from, to)));
+        break;
+      case 'monthly':
+        created.push(...(await this.generateMonthlyPerStep(rule, from, to)));
+        break;
+      case 'annual':
+        created.push(...(await this.generateAnnualPerStep(rule, from, to)));
+        break;
+    }
+
+    return created;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Per-step generation helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Weekly: iterate over each week in [from, to].
+   * For each step, compute its date in that week from step.dayOfWeek (fallback: rule.dayOfWeek).
+   * Week reference = Sunday of the week containing `from`.
+   */
+  private async generateWeeklyPerStep(
+    rule: RecurringTaskRule,
+    from: Date,
+    to: Date,
+  ): Promise<Task[]> {
+    const created: Task[] = [];
+    const fromMidnight = utcMidnight(from);
+
+    // Find the Sunday of the week that contains `from`.
+    const weekStart = new Date(fromMidnight);
+    weekStart.setUTCDate(weekStart.getUTCDate() - weekStart.getUTCDay());
+
+    while (weekStart <= to) {
+      for (const [index, step] of rule.steps.entries()) {
+        const targetDow = step.dayOfWeek ?? rule.dayOfWeek ?? 1; // default Monday
+        const date = new Date(weekStart);
+        date.setUTCDate(date.getUTCDate() + targetDow);
+
+        // Skip dates outside [from, to].
+        if (date < fromMidnight || date > to) continue;
+
+        const taskCreated = await this.createStepTaskIfMissing(
+          rule,
+          step,
+          index,
+          date,
+        );
+        if (taskCreated) created.push(taskCreated);
+      }
+      weekStart.setUTCDate(weekStart.getUTCDate() + 7);
+    }
+
+    return created;
+  }
+
+  /**
+   * Monthly: iterate over each month in [from, to].
+   * For each step, compute its date using resolveMonthDay with step.dayOfMonth (fallback: rule.dayOfMonth).
+   */
+  private async generateMonthlyPerStep(
+    rule: RecurringTaskRule,
+    from: Date,
+    to: Date,
+  ): Promise<Task[]> {
+    const created: Task[] = [];
+    const fromMidnight = utcMidnight(from);
+
+    let year = from.getUTCFullYear();
+    let month = from.getUTCMonth();
+
+    // Keep iterating months while there is any chance a step date falls in [from, to].
+    // We stop when the first possible date in the month (day 1) already exceeds `to`.
+    while (new Date(Date.UTC(year, month, 1)) <= to) {
+      for (const [index, step] of rule.steps.entries()) {
+        const dayOfMonth = step.dayOfMonth ?? rule.dayOfMonth ?? 1;
+        const date = resolveMonthDay(year, month, dayOfMonth);
+
+        if (date < fromMidnight || date > to) continue;
+
+        const taskCreated = await this.createStepTaskIfMissing(
+          rule,
+          step,
+          index,
+          date,
+        );
+        if (taskCreated) created.push(taskCreated);
+      }
+
+      month++;
+      if (month > 11) {
+        month = 0;
+        year++;
       }
     }
 
     return created;
   }
+
+  /**
+   * Annual: iterate over each year in [from, to].
+   * Each step may land on a DIFFERENT month because each step carries its own `month`.
+   * Date = resolveMonthDay(year, (step.month ?? rule.month) - 1, step.dayOfMonth ?? rule.dayOfMonth).
+   */
+  private async generateAnnualPerStep(
+    rule: RecurringTaskRule,
+    from: Date,
+    to: Date,
+  ): Promise<Task[]> {
+    const created: Task[] = [];
+    const fromMidnight = utcMidnight(from);
+
+    for (let year = from.getUTCFullYear(); year <= to.getUTCFullYear(); year++) {
+      for (const [index, step] of rule.steps.entries()) {
+        const stepMonth = (step.month ?? rule.month ?? 1) - 1; // 1-indexed → 0-indexed
+        const dayOfMonth = step.dayOfMonth ?? rule.dayOfMonth ?? 1;
+        const date = resolveMonthDay(year, stepMonth, dayOfMonth);
+
+        if (date < fromMidnight || date > to) continue;
+
+        const taskCreated = await this.createStepTaskIfMissing(
+          rule,
+          step,
+          index,
+          date,
+        );
+        if (taskCreated) created.push(taskCreated);
+      }
+    }
+
+    return created;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared helper: create one step task if it doesn't already exist.
+  // ---------------------------------------------------------------------------
+
+  private async createStepTaskIfMissing(
+    rule: RecurringTaskRule,
+    step: RecurringTaskRuleStep,
+    index: number,
+    date: Date,
+  ): Promise<Task | null> {
+    const sourceId = `${rule.id}:${step.id}`;
+    const dateStr = toDateStr(date);
+
+    const existing = await this.tasksRepo.findBySourceAndDueDateAsync(
+      'recurring_rule',
+      sourceId,
+      dateStr,
+    );
+    if (existing) return null;
+
+    const locked = rule.sequential && index > 0;
+    return this.tasksRepo.createAsync({
+      title: step.title,
+      dueDate: dateStr,
+      status: 'open',
+      sourceType: 'recurring_rule',
+      sourceId,
+      ownerId: step.assigneeId ?? rule.ownerId!,
+      scheduledOrder: (index + 1) * 10000,
+      locked,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Legacy single-occurrence date helpers (used by the no-step path)
+  // ---------------------------------------------------------------------------
 
   private computeDates(rule: RecurringTaskRule, from: Date, to: Date): Date[] {
     switch (rule.frequency) {
@@ -118,7 +291,7 @@ function utcMidnight(d: Date): Date {
   return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
 }
 
-function resolveMonthDay(year: number, month: number, day: number): Date {
+export function resolveMonthDay(year: number, month: number, day: number): Date {
   // Last day of the given month (handles month-end overflow and leap years)
   const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
   return new Date(Date.UTC(year, month, Math.min(day, lastDay)));

--- a/apps/desktop_flutter/lib/app/core/auth/auth_user.dart
+++ b/apps/desktop_flutter/lib/app/core/auth/auth_user.dart
@@ -8,6 +8,7 @@ class AuthUser {
     required this.role,
     this.isFacilitiesManager = false,
     this.photoUrl,
+    this.emailNotificationsEnabled = true,
   });
 
   final int id;
@@ -16,6 +17,7 @@ class AuthUser {
   final String role;
   final bool isFacilitiesManager;
   final String? photoUrl;
+  final bool emailNotificationsEnabled;
 
   bool get isAdmin => role == 'admin' || role == 'system';
 
@@ -29,6 +31,8 @@ class AuthUser {
           _asBool(json['is_facilities_manager']) ??
           false,
       photoUrl: _asString(json['photoUrl']) ?? _asString(json['photo_url']),
+      emailNotificationsEnabled:
+          json['emailNotificationsEnabled'] as bool? ?? true,
     );
   }
 }

--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -16,6 +16,7 @@ import '../../../features/integrations/models/integration_account.dart';
 import '../../../features/integrations/views/integrations_view.dart';
 import '../../../features/projects/views/projects_view.dart';
 import '../../../features/rhythms/views/rhythms_view.dart';
+import '../../../features/settings/controllers/settings_controller.dart';
 import '../../../features/settings/views/settings_view.dart';
 import '../../../features/tasks/views/automation_rules_view.dart';
 import '../../../features/messages/views/messages_view.dart';
@@ -706,6 +707,10 @@ class _AuthGateState extends State<_AuthGate> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         context.read<MessagesController>().loadThreads();
+        final user = context.read<AuthSessionService>().currentUser;
+        if (user != null) {
+          context.read<SettingsController>().initFromUser(user);
+        }
       });
     }
     if (!auth.isAuthenticated) {

--- a/apps/desktop_flutter/lib/features/rhythms/views/rhythms_view.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/views/rhythms_view.dart
@@ -318,12 +318,21 @@ class _RuleTile extends StatelessWidget {
 // ---------------------------------------------------------------------------
 
 class _StepEditorModel {
-  _StepEditorModel({required this.id, String? title, this.assigneeId})
-      : titleController = TextEditingController(text: title ?? '');
+  _StepEditorModel({
+    required this.id,
+    String? title,
+    this.assigneeId,
+    this.dayOfWeek,
+    this.dayOfMonth,
+    this.month,
+  }) : titleController = TextEditingController(text: title ?? '');
 
   final String id;
   final TextEditingController titleController;
   int? assigneeId;
+  int? dayOfWeek;
+  int? dayOfMonth;
+  int? month;
 
   void dispose() => titleController.dispose();
 
@@ -332,6 +341,9 @@ class _StepEditorModel {
       id: id,
       title: titleController.text.trim(),
       assigneeId: assigneeId,
+      dayOfWeek: dayOfWeek,
+      dayOfMonth: dayOfMonth,
+      month: month,
     );
   }
 }
@@ -537,8 +549,15 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
                     for (var i = 0; i < _steps.length; i++) ...[
                       _StepEditorRow(
                         step: _steps[i],
+                        frequency: _frequency,
                         onAssigneeChanged: (value) =>
                             setState(() => _steps[i].assigneeId = value),
+                        onDayOfWeekChanged: (value) =>
+                            setState(() => _steps[i].dayOfWeek = value),
+                        onDayOfMonthChanged: (value) =>
+                            setState(() => _steps[i].dayOfMonth = value),
+                        onMonthChanged: (value) =>
+                            setState(() => _steps[i].month = value),
                         onRemove: () {
                           setState(() {
                             _steps[i].dispose();
@@ -660,6 +679,9 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
           id: step.id,
           title: step.title,
           assigneeId: step.assigneeId,
+          dayOfWeek: step.dayOfWeek,
+          dayOfMonth: step.dayOfMonth,
+          month: step.month,
         ),
       ),
     );
@@ -822,8 +844,15 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
                     for (var i = 0; i < _steps.length; i++) ...[
                       _StepEditorRow(
                         step: _steps[i],
+                        frequency: _frequency,
                         onAssigneeChanged: (value) =>
                             setState(() => _steps[i].assigneeId = value),
+                        onDayOfWeekChanged: (value) =>
+                            setState(() => _steps[i].dayOfWeek = value),
+                        onDayOfMonthChanged: (value) =>
+                            setState(() => _steps[i].dayOfMonth = value),
+                        onMonthChanged: (value) =>
+                            setState(() => _steps[i].month = value),
                         onRemove: () {
                           setState(() {
                             _steps[i].dispose();
@@ -889,13 +918,46 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
 class _StepEditorRow extends StatelessWidget {
   const _StepEditorRow({
     required this.step,
+    required this.frequency,
     required this.onAssigneeChanged,
+    required this.onDayOfWeekChanged,
+    required this.onDayOfMonthChanged,
+    required this.onMonthChanged,
     required this.onRemove,
   });
 
   final _StepEditorModel step;
+  final String frequency;
   final ValueChanged<int?> onAssigneeChanged;
+  final ValueChanged<int> onDayOfWeekChanged;
+  final ValueChanged<int> onDayOfMonthChanged;
+  final ValueChanged<int> onMonthChanged;
   final VoidCallback onRemove;
+
+  static const _weekdays = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ];
+
+  static const _months = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
 
   @override
   Widget build(BuildContext context) {
@@ -941,6 +1003,50 @@ class _StepEditorRow extends StatelessWidget {
             selectedUserId: step.assigneeId,
             onChanged: onAssigneeChanged,
           ),
+          if (frequency == 'weekly') ...[
+            const SizedBox(height: 12),
+            DropdownButtonFormField<int>(
+              value: step.dayOfWeek,
+              decoration: const InputDecoration(
+                labelText: 'Day of Week',
+                border: OutlineInputBorder(),
+              ),
+              items: [
+                for (var i = 0; i < _weekdays.length; i++)
+                  DropdownMenuItem(value: i, child: Text(_weekdays[i])),
+              ],
+              onChanged: (v) {
+                if (v != null) onDayOfWeekChanged(v);
+              },
+            ),
+          ] else if (frequency == 'monthly') ...[
+            const SizedBox(height: 12),
+            _DayOfMonthField(
+              value: step.dayOfMonth ?? 1,
+              onChanged: onDayOfMonthChanged,
+            ),
+          ] else if (frequency == 'annual') ...[
+            const SizedBox(height: 12),
+            DropdownButtonFormField<int>(
+              value: step.month,
+              decoration: const InputDecoration(
+                labelText: 'Month',
+                border: OutlineInputBorder(),
+              ),
+              items: [
+                for (var i = 0; i < _months.length; i++)
+                  DropdownMenuItem(value: i + 1, child: Text(_months[i])),
+              ],
+              onChanged: (v) {
+                if (v != null) onMonthChanged(v);
+              },
+            ),
+            const SizedBox(height: 12),
+            _DayOfMonthField(
+              value: step.dayOfMonth ?? 1,
+              onChanged: onDayOfMonthChanged,
+            ),
+          ],
         ],
       ),
     );

--- a/apps/desktop_flutter/lib/features/rhythms/views/rhythms_view.dart
+++ b/apps/desktop_flutter/lib/features/rhythms/views/rhythms_view.dart
@@ -364,6 +364,7 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
   int _month = 1;
   bool _sequential = false;
   bool _saving = false;
+  String? _errorText;
   final List<_StepEditorModel> _steps = [];
 
   static const _weekdays = [
@@ -430,7 +431,23 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
                   DropdownMenuItem(value: 'monthly', child: Text('Monthly')),
                   DropdownMenuItem(value: 'annual', child: Text('Annual')),
                 ],
-                onChanged: (v) => setState(() => _frequency = v!),
+                onChanged: (v) {
+                  setState(() {
+                    _frequency = v!;
+                    _errorText = null;
+                    // Re-default any missing per-step fields for the new frequency.
+                    for (final step in _steps) {
+                      if (_frequency == 'weekly') {
+                        step.dayOfWeek ??= _dayOfWeek;
+                      } else if (_frequency == 'monthly') {
+                        step.dayOfMonth ??= _dayOfMonth;
+                      } else if (_frequency == 'annual') {
+                        step.month ??= _month;
+                        step.dayOfMonth ??= _dayOfMonth;
+                      }
+                    }
+                  });
+                },
               ),
               const SizedBox(height: 16),
               if (_frequency == 'weekly') ...[
@@ -447,11 +464,25 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
                   ),
                   onChanged: (v) => setState(() => _dayOfWeek = v!),
                 ),
+                const SizedBox(height: 6),
+                Text(
+                  'Used when this rhythm has no steps. Otherwise each step picks its own day.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.rhythm.textMuted,
+                      ),
+                ),
               ],
               if (_frequency == 'monthly') ...[
                 _DayOfMonthField(
                   value: _dayOfMonth,
                   onChanged: (v) => setState(() => _dayOfMonth = v),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  'Used when this rhythm has no steps. Otherwise each step picks its own day.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.rhythm.textMuted,
+                      ),
                 ),
               ],
               if (_frequency == 'annual') ...[
@@ -472,6 +503,13 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
                 _DayOfMonthField(
                   value: _dayOfMonth,
                   onChanged: (v) => setState(() => _dayOfMonth = v),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  'Used when this rhythm has no steps. Otherwise each step picks its own day.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.rhythm.textMuted,
+                      ),
                 ),
               ],
               const SizedBox(height: 18),
@@ -506,7 +544,16 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
                     onPressed: () {
                       setState(() {
                         _steps.add(
-                          _StepEditorModel(id: _newStepId(_steps.length)),
+                          _StepEditorModel(
+                            id: _newStepId(_steps.length),
+                            dayOfWeek:
+                                _frequency == 'weekly' ? _dayOfWeek : null,
+                            dayOfMonth: (_frequency == 'monthly' ||
+                                    _frequency == 'annual')
+                                ? _dayOfMonth
+                                : null,
+                            month: _frequency == 'annual' ? _month : null,
+                          ),
                         );
                       });
                     },
@@ -574,6 +621,17 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
         ),
       ),
       actions: [
+        if (_errorText != null)
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: Text(
+              _errorText!,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.error,
+                fontSize: 13,
+              ),
+            ),
+          ),
         TextButton(
           onPressed: _saving ? null : () => Navigator.pop(context),
           child: const Text('Cancel'),
@@ -596,6 +654,25 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
     return 'step-${DateTime.now().microsecondsSinceEpoch}-$index';
   }
 
+  bool _validateSteps() {
+    final nonEmpty = _steps.where(
+      (s) => s.titleController.text.trim().isNotEmpty,
+    );
+    for (final step in nonEmpty) {
+      if (_frequency == 'weekly' && step.dayOfWeek == null) {
+        return false;
+      }
+      if (_frequency == 'monthly' && step.dayOfMonth == null) {
+        return false;
+      }
+      if (_frequency == 'annual' &&
+          (step.month == null || step.dayOfMonth == null)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   Future<void> _save() async {
     final title = _titleController.text.trim();
     if (title.isEmpty) return;
@@ -605,7 +682,17 @@ class _CreateRuleDialogState extends State<_CreateRuleDialog> {
         .where((step) => step.title.trim().isNotEmpty)
         .toList();
 
-    setState(() => _saving = true);
+    if (steps.isNotEmpty && !_validateSteps()) {
+      setState(() {
+        _errorText = 'Each step must have the required day field(s) set.';
+      });
+      return;
+    }
+
+    setState(() {
+      _saving = true;
+      _errorText = null;
+    });
     await widget.controller.createRule(
       title: title,
       frequency: _frequency,
@@ -638,6 +725,7 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
   late int _month;
   late bool _sequential;
   bool _saving = false;
+  String? _errorText;
   final List<_StepEditorModel> _steps = [];
 
   static const _weekdays = [
@@ -679,9 +767,10 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
           id: step.id,
           title: step.title,
           assigneeId: step.assigneeId,
-          dayOfWeek: step.dayOfWeek,
-          dayOfMonth: step.dayOfMonth,
-          month: step.month,
+          // For legacy steps with null day fields, default from rhythm-level.
+          dayOfWeek: step.dayOfWeek ?? widget.rule.dayOfWeek,
+          dayOfMonth: step.dayOfMonth ?? widget.rule.dayOfMonth,
+          month: step.month ?? widget.rule.month,
         ),
       ),
     );
@@ -727,10 +816,26 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
                   DropdownMenuItem(value: 'monthly', child: Text('Monthly')),
                   DropdownMenuItem(value: 'annual', child: Text('Annual')),
                 ],
-                onChanged: (v) => setState(() => _frequency = v!),
+                onChanged: (v) {
+                  setState(() {
+                    _frequency = v!;
+                    _errorText = null;
+                    // Re-default any missing per-step fields for the new frequency.
+                    for (final step in _steps) {
+                      if (_frequency == 'weekly') {
+                        step.dayOfWeek ??= _dayOfWeek;
+                      } else if (_frequency == 'monthly') {
+                        step.dayOfMonth ??= _dayOfMonth;
+                      } else if (_frequency == 'annual') {
+                        step.month ??= _month;
+                        step.dayOfMonth ??= _dayOfMonth;
+                      }
+                    }
+                  });
+                },
               ),
               const SizedBox(height: 16),
-              if (_frequency == 'weekly')
+              if (_frequency == 'weekly') ...[
                 DropdownButtonFormField<int>(
                   value: _dayOfWeek,
                   decoration: const InputDecoration(
@@ -744,11 +849,27 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
                   ),
                   onChanged: (v) => setState(() => _dayOfWeek = v!),
                 ),
-              if (_frequency == 'monthly')
+                const SizedBox(height: 6),
+                Text(
+                  'Used when this rhythm has no steps. Otherwise each step picks its own day.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.rhythm.textMuted,
+                      ),
+                ),
+              ],
+              if (_frequency == 'monthly') ...[
                 _DayOfMonthField(
                   value: _dayOfMonth,
                   onChanged: (v) => setState(() => _dayOfMonth = v),
                 ),
+                const SizedBox(height: 6),
+                Text(
+                  'Used when this rhythm has no steps. Otherwise each step picks its own day.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.rhythm.textMuted,
+                      ),
+                ),
+              ],
               if (_frequency == 'annual') ...[
                 DropdownButtonFormField<int>(
                   value: _month,
@@ -767,6 +888,13 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
                 _DayOfMonthField(
                   value: _dayOfMonth,
                   onChanged: (v) => setState(() => _dayOfMonth = v),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  'Used when this rhythm has no steps. Otherwise each step picks its own day.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.rhythm.textMuted,
+                      ),
                 ),
               ],
               const SizedBox(height: 18),
@@ -801,7 +929,16 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
                     onPressed: () {
                       setState(() {
                         _steps.add(
-                          _StepEditorModel(id: _newStepId(_steps.length)),
+                          _StepEditorModel(
+                            id: _newStepId(_steps.length),
+                            dayOfWeek:
+                                _frequency == 'weekly' ? _dayOfWeek : null,
+                            dayOfMonth: (_frequency == 'monthly' ||
+                                    _frequency == 'annual')
+                                ? _dayOfMonth
+                                : null,
+                            month: _frequency == 'annual' ? _month : null,
+                          ),
                         );
                       });
                     },
@@ -869,6 +1006,17 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
         ),
       ),
       actions: [
+        if (_errorText != null)
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: Text(
+              _errorText!,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.error,
+                fontSize: 13,
+              ),
+            ),
+          ),
         TextButton(
           onPressed: _saving ? null : () => Navigator.pop(context),
           child: const Text('Cancel'),
@@ -891,6 +1039,25 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
     return 'step-${DateTime.now().microsecondsSinceEpoch}-$index';
   }
 
+  bool _validateSteps() {
+    final nonEmpty = _steps.where(
+      (s) => s.titleController.text.trim().isNotEmpty,
+    );
+    for (final step in nonEmpty) {
+      if (_frequency == 'weekly' && step.dayOfWeek == null) {
+        return false;
+      }
+      if (_frequency == 'monthly' && step.dayOfMonth == null) {
+        return false;
+      }
+      if (_frequency == 'annual' &&
+          (step.month == null || step.dayOfMonth == null)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   Future<void> _save() async {
     final title = _titleController.text.trim();
     if (title.isEmpty) return;
@@ -898,7 +1065,18 @@ class _EditRuleDialogState extends State<_EditRuleDialog> {
         .map((step) => step.toStep())
         .where((step) => step.title.trim().isNotEmpty)
         .toList();
-    setState(() => _saving = true);
+
+    if (steps.isNotEmpty && !_validateSteps()) {
+      setState(() {
+        _errorText = 'Each step must have the required day field(s) set.';
+      });
+      return;
+    }
+
+    setState(() {
+      _saving = true;
+      _errorText = null;
+    });
     await widget.controller.updateRule(
       widget.rule.id,
       title: title,

--- a/apps/desktop_flutter/lib/features/settings/controllers/settings_controller.dart
+++ b/apps/desktop_flutter/lib/features/settings/controllers/settings_controller.dart
@@ -15,6 +15,9 @@ class SettingsController extends ChangeNotifier {
   String? _usersErrorMessage;
   final Set<int> _savingUserIds = <int>{};
 
+  bool _emailNotificationsEnabled = true;
+  bool get emailNotificationsEnabled => _emailNotificationsEnabled;
+
   SettingsUsersStatus get usersStatus => _usersStatus;
   List<AuthUser> get users => _users;
   String? get usersErrorMessage => _usersErrorMessage;
@@ -74,6 +77,24 @@ class SettingsController extends ChangeNotifier {
     } finally {
       _savingUserIds.remove(userId);
       notifyListeners();
+    }
+  }
+
+  void initFromUser(AuthUser user) {
+    _emailNotificationsEnabled = user.emailNotificationsEnabled;
+    notifyListeners();
+  }
+
+  Future<void> setEmailNotifications(bool enabled) async {
+    final previous = _emailNotificationsEnabled;
+    _emailNotificationsEnabled = enabled;
+    notifyListeners();
+    try {
+      await _repository.updateEmailNotifications(enabled);
+    } catch (e) {
+      _emailNotificationsEnabled = previous;
+      notifyListeners();
+      rethrow;
     }
   }
 }

--- a/apps/desktop_flutter/lib/features/settings/data/user_preferences_data_source.dart
+++ b/apps/desktop_flutter/lib/features/settings/data/user_preferences_data_source.dart
@@ -1,0 +1,24 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../../../app/core/auth/auth_session_store.dart';
+import '../../../app/core/constants/app_constants.dart';
+import '../../../app/core/utils/http_utils.dart';
+
+class UserPreferencesDataSource {
+  UserPreferencesDataSource({String? baseUrl})
+      : _baseUrl = baseUrl ?? AppConstants.apiBaseUrl;
+
+  final String _baseUrl;
+
+  Future<Map<String, dynamic>> updateEmailNotifications(bool enabled) async {
+    final response = await http.patch(
+      Uri.parse('$_baseUrl/users/me/preferences'),
+      headers: AuthSessionStore.headers(json: true),
+      body: jsonEncode({'emailNotificationsEnabled': enabled}),
+    );
+    assertOk(response);
+    return jsonDecode(response.body) as Map<String, dynamic>;
+  }
+}

--- a/apps/desktop_flutter/lib/features/settings/repositories/settings_repository.dart
+++ b/apps/desktop_flutter/lib/features/settings/repositories/settings_repository.dart
@@ -1,10 +1,16 @@
 import '../../../app/core/auth/auth_user.dart';
 import '../data/settings_data_source.dart';
+import '../data/user_preferences_data_source.dart';
 
 class SettingsRepository {
-  SettingsRepository(this._dataSource);
+  SettingsRepository(
+    this._dataSource, {
+    UserPreferencesDataSource? userPreferencesDataSource,
+  }) : _userPreferencesDataSource =
+            userPreferencesDataSource ?? UserPreferencesDataSource();
 
   final SettingsDataSource _dataSource;
+  final UserPreferencesDataSource _userPreferencesDataSource;
 
   Future<List<AuthUser>> fetchUsers() => _dataSource.fetchUsers();
 
@@ -18,5 +24,9 @@ class SettingsRepository {
       role: role,
       isFacilitiesManager: isFacilitiesManager,
     );
+  }
+
+  Future<void> updateEmailNotifications(bool enabled) async {
+    await _userPreferencesDataSource.updateEmailNotifications(enabled);
   }
 }

--- a/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
+++ b/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
@@ -373,6 +373,56 @@ class _SettingsViewState extends State<SettingsView> {
               ],
             ),
           ),
+          const SizedBox(height: 24),
+          Text(
+            'NOTIFICATIONS',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: context.rhythm.textSecondary,
+              letterSpacing: 0.8,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Container(
+            decoration: BoxDecoration(
+              color: context.rhythm.surfaceRaised,
+              borderRadius: BorderRadius.circular(RhythmRadius.xl),
+              border: Border.all(color: context.rhythm.borderSubtle),
+              boxShadow: RhythmElevation.panel,
+            ),
+            child: SwitchListTile(
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 20,
+                vertical: 8,
+              ),
+              title: Text(
+                'Email notifications',
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: context.rhythm.textPrimary,
+                ),
+              ),
+              subtitle: Text(
+                "Get an email when you're assigned a task or added as a collaborator",
+                style: TextStyle(
+                  fontSize: 13,
+                  color: context.rhythm.textSecondary,
+                ),
+              ),
+              value: settingsController.emailNotificationsEnabled,
+              onChanged: (value) async {
+                try {
+                  await settingsController.setEmailNotifications(value);
+                } catch (e) {
+                  if (!mounted) return;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Failed to update: $e')),
+                  );
+                }
+              },
+            ),
+          ),
         ],
       ),
     );

--- a/apps/desktop_flutter/lib/features/tasks/models/recurring_task_rule.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/recurring_task_rule.dart
@@ -29,6 +29,9 @@ class RecurringTaskRuleStep {
     required this.title,
     this.assigneeId,
     this.assigneeName,
+    this.dayOfWeek,
+    this.dayOfMonth,
+    this.month,
   });
 
   factory RecurringTaskRuleStep.fromJson(Map<String, dynamic> json) {
@@ -37,6 +40,9 @@ class RecurringTaskRuleStep {
       title: asString(json['title']) ?? '',
       assigneeId: asInt(json['assigneeId']),
       assigneeName: asString(json['assigneeName']),
+      dayOfWeek: asInt(json['dayOfWeek']),
+      dayOfMonth: asInt(json['dayOfMonth']),
+      month: asInt(json['month']),
     );
   }
 
@@ -44,11 +50,17 @@ class RecurringTaskRuleStep {
   final String title;
   final int? assigneeId;
   final String? assigneeName;
+  final int? dayOfWeek;
+  final int? dayOfMonth;
+  final int? month;
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'title': title,
         'assigneeId': assigneeId,
+        'dayOfWeek': dayOfWeek,
+        'dayOfMonth': dayOfMonth,
+        'month': month,
       };
 }
 

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -41,6 +41,7 @@ import 'features/messages/data/messages_data_source.dart';
 import 'features/messages/repositories/messages_repository.dart';
 import 'features/settings/controllers/settings_controller.dart';
 import 'features/settings/data/settings_data_source.dart';
+import 'features/settings/data/user_preferences_data_source.dart';
 import 'features/settings/repositories/settings_repository.dart';
 import 'features/weekly_planner/controllers/weekly_planner_controller.dart';
 import 'features/weekly_planner/data/weekly_plan_data_source.dart';
@@ -177,7 +178,11 @@ class RhythmApp extends StatelessWidget {
         ),
         ChangeNotifierProvider(
           create: (_) => SettingsController(
-            SettingsRepository(SettingsDataSource(baseUrl: baseUrl)),
+            SettingsRepository(
+              SettingsDataSource(baseUrl: baseUrl),
+              userPreferencesDataSource:
+                  UserPreferencesDataSource(baseUrl: baseUrl),
+            ),
           ),
         ),
         ChangeNotifierProvider(


### PR DESCRIPTION
## Summary

- **#334** — Thread creation now accepts `task_id`; `GET /message-threads` supports `?task_id=` filtering (was already implemented in a prior commit — closed)
- **#353** — DB migration adds `email_notifications_enabled` column to `users` table (SQLite + Postgres, idempotent)
- **#354** — `User` model, `CreateUserDto`, `UpdateUserDto`, and `UsersRepository` updated to expose `emailNotificationsEnabled`
- **#355** — `resend` npm package installed; `RESEND_API_KEY` and `EMAIL_FROM_ADDRESS` wired into env config
- **#356** — `EmailService` created with `sendTaskAssignedEmailAsync` and `sendCollaboratorAddedEmailAsync`; guards opt-out, self-action, missing key, and Resend errors
- **#357** — `EmailService` wired into `TasksController.update()` (assignment) and `addCollaborator()`
- **#358** — New `PATCH /users/me/preferences` endpoint lets any authenticated user toggle their own `emailNotificationsEnabled`
- **#359** — Flutter: `UserPreferencesDataSource`, `AuthUser.emailNotificationsEnabled`, `SettingsRepository.updateEmailNotifications`, and `SettingsController` state/optimistic-update logic
- **#360** — Flutter Settings view gains a "NOTIFICATIONS" card with a `SwitchListTile` bound to `SettingsController.emailNotificationsEnabled`

## Test plan

- [ ] `cd apps/api_server && npm test` — all 125 tests pass
- [ ] `cd apps/desktop_flutter && flutter analyze --no-fatal-infos` — no errors
- [ ] Start API server locally; confirm existing users get `emailNotificationsEnabled: true` from `GET /users`
- [ ] `PATCH /users/me/preferences` with `{ "emailNotificationsEnabled": false }` — confirm 200 and value persists
- [ ] Open Flutter app → Settings → confirm "Email notifications" toggle appears and toggles correctly
- [ ] Assign a task to another user — confirm email fires (requires `RESEND_API_KEY` in `.env`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)