### PR TITLE
Agent sessions on production API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ Three screens are planned as separate PRs. Nav placeholders exist in `app_shell.
 
 ```bash
 # API server (dev)
-cd apps/api_server && npm run dev      # Runs on :4000, hot-reloads with tsx
+cd apps/api_server && npm run dev      # Runs on :4000 by default; set PORT=4001 to match the agent server port
 
 # Flutter desktop app
 cd apps/desktop_flutter && flutter run -d macos
@@ -214,6 +214,43 @@ cd apps/web && npm run dev             # Runs on :5173
 ```
 
 **DB path (local):** `~/Library/Application Support/Rhythm/rhythm.db`
+
+---
+
+## Dual-Endpoint Architecture (Production + Local Agent Server)
+
+Rhythm runs two API servers simultaneously. They own separate data and must never be conflated.
+
+### Production API — `https://api.vcrcapps.com`
+
+- Owns all user-facing data: tasks, projects, rhythms, messages, facilities, users, and `claude-triggers`.
+- URL is user-configurable via Settings → Server URL and persisted by `ServerConfigService`.
+- Data source: production Postgres (hosted).
+- All feature data sources pass `serverConfigService.url` as their `baseUrl`.
+
+### Local Agent Server — `http://localhost:4001`
+
+- Always running; started on app launch by `AgentServerController` (file: `agent_server_controller.dart`).
+- Hosts agent-specific endpoints:
+  - `GET/POST /agent-sessions` — list and create agent sessions
+  - `GET/POST /agent-sessions/:id/messages` — messages within a session
+  - `GET /agents/capabilities` — which agents (`claude`, `codex`) are available
+  - `ws://localhost:4001/ws/agents` — WebSocket gateway for real-time agent I/O
+- Auth is bypassed when the server is started with `AGENT_LOCAL=true` in its environment.
+- Data source: local SQLite (never synced to production).
+- Port 4001 is intentional — port 4000 is reserved for CLIdeck on the same dev machines.
+
+### Capability Detection
+
+`AgentServerController` calls `GET /agents/capabilities` after the local server is ready. The server performs `which claude` / `which codex` via a login shell (same `/bin/zsh -l -c` strategy as `_findNode` in `ApiServerService`). Results are surfaced through `AgentServerController.isAgentAvailable(kind)`.
+
+### Trigger Polling
+
+`AgentTriggerWatcher` polls the **production** endpoint `GET /claude-triggers` every 10 seconds, authenticated with the user's session token. When a trigger arrives the watcher hands it to the local agent server and acknowledges it on production. This keeps trigger delivery on the production path while execution stays local.
+
+### Rule: do not couple agent traffic to `serverConfigService.url`
+
+Agent data sources hard-code `http://localhost:4001` (via `AppConstants.agentLocalBaseUrl`). Changing the production server URL in Settings must never affect the agent server address. This is the architectural intent that replaced the old "is URL localhost?" gating.
 
 ---
 
@@ -247,3 +284,4 @@ cd apps/desktop_flutter && flutter run -d macos
 - **`better-sqlite3` ABI** — Must be compiled with the same Node version the app will use at runtime. `prebuild-install` often downloads wrong binary. Use `node-gyp rebuild` if ABI mismatch.
 - **`dart format .`** — Always run before committing. CI fails on format violations (`--set-exit-if-changed`).
 - **`flutter analyze --no-fatal-infos`** — Must pass before opening a PR.
+- **Local agent server auth bypass** — The embedded `api_server` process is started with `AGENT_LOCAL=true` in its environment. This disables JWT validation on agent endpoints. Never expose port 4001 externally; the bypass is intentional and scoped to localhost-only traffic.

--- a/apps/api_server/src/__tests__/claude_triggers.test.ts
+++ b/apps/api_server/src/__tests__/claude_triggers.test.ts
@@ -52,20 +52,21 @@ describe('Claude triggers endpoints', () => {
     return { Authorization: `Bearer ${session.token}` };
   }
 
-  it('returns 403 for non-claude users', async () => {
+  it('returns 200 with empty array for any authenticated user with no triggers', async () => {
     const u = usersRepo.create({ name: 'U', email: 'u@x.com' });
     const headers = await authHeaderFor(u.id);
     const res = await fetch(`${baseUrl}/claude-triggers`, { headers });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
   });
 
-  it('returns the queue for claude user', async () => {
+  it('returns triggers scoped to the authenticated user', async () => {
     const owner = usersRepo.create({ name: 'O', email: 'o@x.com' });
     const task = tasksRepo.create({ title: 'Test task', ownerId: owner.id });
     getDb().prepare(`INSERT INTO pending_claude_triggers (task_id, triggered_by_user_id) VALUES (?, ?)`)
       .run(task.id, owner.id);
 
-    const headers = await authHeaderFor(claudeId);
+    const headers = await authHeaderFor(owner.id);
     const res = await fetch(`${baseUrl}/claude-triggers`, { headers });
     expect(res.status).toBe(200);
     const triggers = await res.json() as Array<{ taskId: string; taskTitle: string }>;
@@ -77,12 +78,12 @@ describe('Claude triggers endpoints', () => {
   it('deletes a trigger', async () => {
     const owner = usersRepo.create({ name: 'O', email: 'o2@x.com' });
     const task = tasksRepo.create({ title: 'T', ownerId: owner.id });
-    getDb().prepare(`INSERT INTO pending_claude_triggers (task_id) VALUES (?)`)
-      .run(task.id);
+    getDb().prepare(`INSERT INTO pending_claude_triggers (task_id, triggered_by_user_id) VALUES (?, ?)`)
+      .run(task.id, owner.id);
     const r = getDb().prepare(`SELECT id FROM pending_claude_triggers WHERE task_id = ?`)
       .get(task.id) as { id: number };
 
-    const headers = await authHeaderFor(claudeId);
+    const headers = await authHeaderFor(owner.id);
     const res = await fetch(`${baseUrl}/claude-triggers/${r.id}`, { method: 'DELETE', headers });
     expect(res.status).toBe(204);
 

--- a/apps/api_server/src/app.ts
+++ b/apps/api_server/src/app.ts
@@ -21,6 +21,7 @@ import { workspaceRouter } from './routes/workspace_routes';
 import { notificationsRouter } from './routes/notifications_routes';
 import claudeTriggersRouter from './routes/claude_triggers_routes';
 import { agentSessionsRouter } from './routes/agent_sessions_routes';
+import { agentsCapabilitiesRouter } from './routes/agents_capabilities_routes';
 
 export function createApp() {
   const app = express();
@@ -45,6 +46,8 @@ export function createApp() {
   app.use(express.json());
 
   app.use('/health', healthRouter);
+  // NOTE: /agents/capabilities is unauthenticated for now; Phase 3.1 will add the AGENT_LOCAL bypass.
+  app.use('/agents/capabilities', agentsCapabilitiesRouter);
   app.use('/dashboard', dashboardRouter);
   app.use('/auth', authRouter);
   app.use('/automation-catalog', automationCatalogRouter);

--- a/apps/api_server/src/config/env.ts
+++ b/apps/api_server/src/config/env.ts
@@ -77,4 +77,5 @@ export const env = {
   })(),
   resendApiKey: process.env.RESEND_API_KEY ?? '',
   emailFromAddress: process.env.EMAIL_FROM_ADDRESS ?? 'Rhythm <onboarding@resend.dev>',
+  agentLocal: process.env.AGENT_LOCAL === 'true',
 };

--- a/apps/api_server/src/controllers/agent_sessions_controller.ts
+++ b/apps/api_server/src/controllers/agent_sessions_controller.ts
@@ -2,7 +2,6 @@ import type { NextFunction, Request, Response } from 'express';
 import { AppError } from '../errors/app_error';
 import { AgentSessionsRepository } from '../repositories/agent_sessions_repository';
 import { AgentSessionMessagesRepository } from '../repositories/agent_session_messages_repository';
-import { getDb } from '../database/db';
 import type { AgentKind, CreateAgentSessionDto } from '../models/agent_session';
 import * as ptyRunner from '../services/pty_runner';
 
@@ -35,7 +34,7 @@ export class AgentSessionsController {
 
   create(req: Request, res: Response, next: NextFunction): void {
     try {
-      const { agentKind, taskId, cwd, name } = req.body as Record<string, unknown>;
+      const { agentKind, taskId, taskTitle, cwd, name } = req.body as Record<string, unknown>;
 
       if (!agentKind || typeof agentKind !== 'string') {
         throw AppError.badRequest('agentKind is required');
@@ -56,17 +55,16 @@ export class AgentSessionsController {
         if (typeof taskId !== 'string') {
           throw AppError.badRequest('taskId must be a string');
         }
-        const taskRow = getDb()
-          .prepare(`SELECT id FROM tasks WHERE id = ?`)
-          .get(taskId);
-        if (!taskRow) {
-          throw AppError.badRequest(`Task with id '${taskId}' does not exist`);
-        }
+      }
+
+      if (taskTitle !== undefined && taskTitle !== null && typeof taskTitle !== 'string') {
+        throw AppError.badRequest('taskTitle must be a string');
       }
 
       const dto: CreateAgentSessionDto = {
         agentKind: agentKind as AgentKind,
         taskId: taskId != null ? (taskId as string) : null,
+        taskTitle: taskTitle != null ? (taskTitle as string) : null,
         cwd: cwd.trim(),
         name: name.trim(),
       };

--- a/apps/api_server/src/controllers/claude_triggers_controller.ts
+++ b/apps/api_server/src/controllers/claude_triggers_controller.ts
@@ -5,9 +5,10 @@ import { ClaudeTriggersRepository } from '../repositories/claude_triggers_reposi
 const repo = new ClaudeTriggersRepository();
 
 export class ClaudeTriggersController {
-  async list(_req: Request, res: Response, next: NextFunction) {
+  async list(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(await repo.listAllAsync());
+      const userId = req.auth!.user.id;
+      res.json(await repo.listForUser(userId));
     } catch (err) { next(err); }
   }
 
@@ -15,8 +16,10 @@ export class ClaudeTriggersController {
     try {
       const id = Number(req.params.id);
       if (!Number.isFinite(id)) throw AppError.badRequest('id must be a number');
-      const ok = await repo.deleteAsync(id);
-      if (!ok) throw AppError.notFound('Trigger');
+      const userId = req.auth!.user.id;
+      const trigger = await repo.findByIdAndUser(id, userId);
+      if (!trigger) throw AppError.notFound('Trigger');
+      await repo.deleteAsync(id);
       res.status(204).end();
     } catch (err) { next(err); }
   }

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -781,4 +781,11 @@ export function runMigrations(db: Database.Database): void {
   if (!taskColsAgentSession.includes('preferred_agent')) {
     db.exec(`ALTER TABLE tasks ADD COLUMN preferred_agent TEXT`);
   }
+
+  // agent_sessions.task_title — store display title alongside task_id so the local server
+  // can show meaningful session names without round-tripping to production for the task record.
+  const agentSessionCols = (db.pragma('table_info(agent_sessions)') as { name: string }[]).map((c) => c.name);
+  if (!agentSessionCols.includes('task_title')) {
+    db.exec(`ALTER TABLE agent_sessions ADD COLUMN task_title TEXT`);
+  }
 }

--- a/apps/api_server/src/models/agent_session.ts
+++ b/apps/api_server/src/models/agent_session.ts
@@ -4,6 +4,7 @@ export type AgentSessionStatus = 'starting' | 'working' | 'idle' | 'resumable' |
 export interface AgentSession {
   id: string;
   taskId: string | null;
+  taskTitle: string | null;
   agentKind: AgentKind;
   status: AgentSessionStatus;
   sessionToken: string | null;
@@ -27,6 +28,7 @@ export interface AgentSessionMessage {
 export interface CreateAgentSessionDto {
   agentKind: AgentKind;
   taskId: string | null;
+  taskTitle?: string | null;
   cwd: string;
   name: string;
 }

--- a/apps/api_server/src/repositories/agent_sessions_repository.ts
+++ b/apps/api_server/src/repositories/agent_sessions_repository.ts
@@ -8,6 +8,7 @@ import type {
 interface AgentSessionRow {
   id: string;
   task_id: string | null;
+  task_title: string | null;
   agent_kind: string;
   status: string;
   session_token: string | null;
@@ -23,6 +24,7 @@ function rowToModel(row: AgentSessionRow): AgentSession {
   return {
     id: row.id,
     taskId: row.task_id,
+    taskTitle: row.task_title ?? null,
     agentKind: row.agent_kind as AgentSession['agentKind'],
     status: row.status as AgentSessionStatus,
     sessionToken: row.session_token,
@@ -41,10 +43,10 @@ export class AgentSessionsRepository {
     const now = new Date().toISOString();
     getDb()
       .prepare(
-        `INSERT INTO agent_sessions (id, task_id, agent_kind, status, cwd, name, created_at, updated_at)
-         VALUES (?, ?, ?, 'starting', ?, ?, ?, ?)`,
+        `INSERT INTO agent_sessions (id, task_id, task_title, agent_kind, status, cwd, name, created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'starting', ?, ?, ?, ?)`,
       )
-      .run(id, dto.taskId ?? null, dto.agentKind, dto.cwd, dto.name, now, now);
+      .run(id, dto.taskId ?? null, dto.taskTitle ?? null, dto.agentKind, dto.cwd, dto.name, now, now);
     return this.findById(id)!;
   }
 

--- a/apps/api_server/src/repositories/claude_triggers_repository.ts
+++ b/apps/api_server/src/repositories/claude_triggers_repository.ts
@@ -45,6 +45,41 @@ export class ClaudeTriggersRepository {
     return rows.map(this.rowToModel);
   }
 
+  async listForUser(userId: number): Promise<PendingClaudeTrigger[]> {
+    const sql = `
+      SELECT pct.id, pct.task_id, pct.triggered_by_user_id, pct.created_at,
+             t.title AS task_title, t.notes AS task_notes, t.owner_id AS task_owner_id
+      FROM pending_claude_triggers pct
+      JOIN tasks t ON t.id = pct.task_id
+      WHERE pct.triggered_by_user_id = $1
+      ORDER BY pct.created_at ASC
+    `;
+    if (env.dbClient === 'postgres') {
+      const r = await getPostgresPool().query(sql, [userId]);
+      return r.rows.map(this.rowToModel);
+    }
+    const sqliteSql = sql.replace('$1', '?');
+    const rows = getDb().prepare(sqliteSql).all(userId) as any[];
+    return rows.map(this.rowToModel);
+  }
+
+  async findByIdAndUser(id: number, userId: number): Promise<PendingClaudeTrigger | null> {
+    const sql = `
+      SELECT pct.id, pct.task_id, pct.triggered_by_user_id, pct.created_at,
+             t.title AS task_title, t.notes AS task_notes, t.owner_id AS task_owner_id
+      FROM pending_claude_triggers pct
+      JOIN tasks t ON t.id = pct.task_id
+      WHERE pct.id = $1 AND pct.triggered_by_user_id = $2
+    `;
+    if (env.dbClient === 'postgres') {
+      const r = await getPostgresPool().query(sql, [id, userId]);
+      return r.rows.length > 0 ? this.rowToModel(r.rows[0]) : null;
+    }
+    const sqliteSql = sql.replace('$1', '?').replace('$2', '?');
+    const row = getDb().prepare(sqliteSql).get(id, userId) as any | undefined;
+    return row ? this.rowToModel(row) : null;
+  }
+
   async deleteAsync(id: number): Promise<boolean> {
     if (env.dbClient === 'postgres') {
       const r = await getPostgresPool().query(

--- a/apps/api_server/src/routes/agent_sessions_routes.ts
+++ b/apps/api_server/src/routes/agent_sessions_routes.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth_middleware';
 import { AgentSessionsController } from '../controllers/agent_sessions_controller';
+import { env } from '../config/env';
 
 const controller = new AgentSessionsController();
 export const agentSessionsRouter = Router();
 
-agentSessionsRouter.use(requireAuth);
+if (!env.agentLocal) agentSessionsRouter.use(requireAuth);
 
 agentSessionsRouter.get('/', controller.list.bind(controller));
 agentSessionsRouter.get('/:id', controller.getOne.bind(controller));

--- a/apps/api_server/src/routes/agents_capabilities_routes.ts
+++ b/apps/api_server/src/routes/agents_capabilities_routes.ts
@@ -1,7 +1,11 @@
 import { exec } from 'child_process';
 import { Router, Request, Response } from 'express';
+import { requireAuth } from '../middleware/auth_middleware';
+import { env } from '../config/env';
 
 export const agentsCapabilitiesRouter = Router();
+
+if (!env.agentLocal) agentsCapabilitiesRouter.use(requireAuth);
 
 function detectBinary(name: string): Promise<boolean> {
   return new Promise((resolve) => {

--- a/apps/api_server/src/routes/agents_capabilities_routes.ts
+++ b/apps/api_server/src/routes/agents_capabilities_routes.ts
@@ -1,0 +1,29 @@
+import { exec } from 'child_process';
+import { Router, Request, Response } from 'express';
+
+export const agentsCapabilitiesRouter = Router();
+
+function detectBinary(name: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    exec(`/bin/zsh -l -c "which ${name}"`, (error, stdout) => {
+      if (error || !stdout.trim()) {
+        resolve(false);
+      } else {
+        resolve(true);
+      }
+    });
+  });
+}
+
+agentsCapabilitiesRouter.get('/', async (_req: Request, res: Response) => {
+  try {
+    const [claude, codex] = await Promise.all([
+      detectBinary('claude'),
+      detectBinary('codex'),
+    ]);
+    res.json({ claude, codex });
+  } catch (err) {
+    console.error('[agents/capabilities] Unexpected error during detection:', err);
+    res.json({ claude: false, codex: false });
+  }
+});

--- a/apps/api_server/src/routes/claude_triggers_routes.ts
+++ b/apps/api_server/src/routes/claude_triggers_routes.ts
@@ -1,13 +1,11 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth_middleware';
-import { requireClaudeUser } from '../middleware/require_claude_user';
 import { ClaudeTriggersController } from '../controllers/claude_triggers_controller';
 
 const router = Router();
 const controller = new ClaudeTriggersController();
 
 router.use(requireAuth);
-router.use(requireClaudeUser);
 
 router.get('/', (req, res, next) => controller.list(req, res, next));
 router.delete('/:id', (req, res, next) => controller.remove(req, res, next));

--- a/apps/desktop_flutter/lib/app/core/agents/agent_bubble_overlay.dart
+++ b/apps/desktop_flutter/lib/app/core/agents/agent_bubble_overlay.dart
@@ -6,6 +6,7 @@ import '../../../features/agents/models/agent_session.dart';
 import '../../../features/agents/models/agent_session_message.dart';
 import '../constants/app_constants.dart';
 import '../ui/tokens/rhythm_theme.dart';
+import 'agent_server_controller.dart';
 import 'overlay_controller.dart';
 
 // ---------------------------------------------------------------------------
@@ -18,10 +19,13 @@ class AgentBubbleOverlayLayer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final overlay = context.watch<OverlayController>();
-    final agents = context.watch<AgentsController>();
+    final agentServerController = context.watch<AgentServerController>();
 
-    // Capability gate: only show when using local server.
-    if (!agents.isLocalServer) return const SizedBox.shrink();
+    // Capability gate: only show when the agent server is ready and at least
+    // one supported CLI is installed.
+    if (!agentServerController.isReady || !agentServerController.hasAnyAgent) {
+      return const SizedBox.shrink();
+    }
     if (overlay.totalCount == 0) return const SizedBox.shrink();
 
     return Positioned(

--- a/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
+++ b/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+
+import '../server/api_server_service.dart';
+
+enum AgentServerStatus { starting, ready, failed }
+
+class AgentServerController extends ChangeNotifier {
+  AgentServerController(this._service);
+
+  final ApiServerService _service;
+  AgentServerStatus _status = AgentServerStatus.starting;
+  String? _errorMessage;
+
+  AgentServerStatus get status => _status;
+  bool get isReady => _status == AgentServerStatus.ready;
+  String? get errorMessage => _errorMessage;
+
+  Future<void> initialize() async {
+    _status = AgentServerStatus.starting;
+    _errorMessage = null;
+    notifyListeners();
+
+    final ok = await _service.start();
+
+    _status = ok ? AgentServerStatus.ready : AgentServerStatus.failed;
+    if (!ok) {
+      _errorMessage = 'Could not start the local agent server.';
+    }
+    notifyListeners();
+  }
+
+  Future<void> retry() => initialize();
+
+  @override
+  void dispose() {
+    _service.stop();
+    super.dispose();
+  }
+}

--- a/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
+++ b/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
@@ -1,4 +1,9 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 
 import '../server/api_server_service.dart';
 
@@ -10,14 +15,20 @@ class AgentServerController extends ChangeNotifier {
   final ApiServerService _service;
   AgentServerStatus _status = AgentServerStatus.starting;
   String? _errorMessage;
+  Map<String, bool> _capabilities = const {};
 
   AgentServerStatus get status => _status;
   bool get isReady => _status == AgentServerStatus.ready;
   String? get errorMessage => _errorMessage;
+  Map<String, bool> get capabilities => _capabilities;
+
+  bool isAgentAvailable(String kind) => _capabilities[kind] == true;
+  bool get hasAnyAgent => _capabilities.values.any((v) => v);
 
   Future<void> initialize() async {
     _status = AgentServerStatus.starting;
     _errorMessage = null;
+    _capabilities = const {};
     notifyListeners();
 
     final ok = await _service.start();
@@ -27,6 +38,43 @@ class AgentServerController extends ChangeNotifier {
       _errorMessage = 'Could not start the local agent server.';
     }
     notifyListeners();
+
+    if (ok) {
+      // Fire-and-forget; failures are non-fatal.
+      unawaited(refreshCapabilities());
+    }
+  }
+
+  Future<void> refreshCapabilities() async {
+    try {
+      final response = await http.get(
+        Uri.parse('http://localhost:4001/agents/capabilities'),
+      );
+      if (response.statusCode != 200) {
+        stderr.writeln(
+          '[AgentServerController] capabilities fetch returned '
+          'HTTP ${response.statusCode}; leaving capabilities empty.',
+        );
+        return;
+      }
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map<String, dynamic>) {
+        stderr.writeln(
+          '[AgentServerController] capabilities response was not a JSON object; '
+          'leaving capabilities empty.',
+        );
+        return;
+      }
+      _capabilities = decoded.map(
+        (key, value) => MapEntry(key, value == true),
+      );
+      notifyListeners();
+    } catch (e) {
+      stderr.writeln(
+        '[AgentServerController] failed to fetch capabilities: $e',
+      );
+      // _capabilities stays empty; status is unchanged.
+    }
   }
 
   Future<void> retry() => initialize();

--- a/apps/desktop_flutter/lib/app/core/agents/agent_trigger_watcher.dart
+++ b/apps/desktop_flutter/lib/app/core/agents/agent_trigger_watcher.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import '../../core/agents/agent_server_controller.dart';
+import '../../core/auth/auth_session_service.dart';
+import '../../core/services/server_config_service.dart';
+import '../../../features/agents/controllers/agents_controller.dart';
+
+/// Polls `GET /claude-triggers` on the production server every [interval]
+/// (default 10 s) when the user is authenticated and the local agent server
+/// is ready.
+///
+/// On each successful poll:
+/// 1. Hands each trigger to [AgentsController.handleIncomingTrigger].
+/// 2. Deletes the trigger from production via `DELETE /claude-triggers/:id`.
+///
+/// Failures (network errors, 4xx, 5xx) are logged to stderr and silently
+/// skipped — the next tick will retry.
+class AgentTriggerWatcher extends ChangeNotifier {
+  AgentTriggerWatcher({
+    required ServerConfigService serverConfigService,
+    required AuthSessionService authSessionService,
+    required AgentServerController agentServerController,
+    required AgentsController agentsController,
+    Duration interval = const Duration(seconds: 10),
+    http.Client? httpClient,
+  })  : _serverConfigService = serverConfigService,
+        _authSessionService = authSessionService,
+        _agentServerController = agentServerController,
+        _agentsController = agentsController,
+        _interval = interval,
+        _httpClient = httpClient ?? http.Client();
+
+  final ServerConfigService _serverConfigService;
+  final AuthSessionService _authSessionService;
+  final AgentServerController _agentServerController;
+  final AgentsController _agentsController;
+  final Duration _interval;
+  final http.Client _httpClient;
+
+  Timer? _timer;
+  bool _isPolling = false;
+
+  /// Whether the polling timer is currently active.
+  bool get isPolling => _isPolling;
+
+  // --------------------------------------------------------------------------
+  // Lifecycle
+  // --------------------------------------------------------------------------
+
+  /// Starts the periodic polling timer. Safe to call multiple times; an
+  /// existing timer is cancelled before the new one is created.
+  void start() {
+    _timer?.cancel();
+    _isPolling = true;
+    notifyListeners();
+    // Fire immediately, then on each tick.
+    unawaited(_poll());
+    _timer = Timer.periodic(_interval, (_) => unawaited(_poll()));
+  }
+
+  /// Cancels the polling timer.
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+    _isPolling = false;
+    notifyListeners();
+  }
+
+  // --------------------------------------------------------------------------
+  // Internal
+  // --------------------------------------------------------------------------
+
+  Future<void> _poll() async {
+    final token = _authSessionService.sessionToken;
+    if (token == null) {
+      // Not authenticated — skip this tick.
+      return;
+    }
+    if (!_agentServerController.isReady) {
+      // Local agent server not ready — no point surfacing a trigger.
+      return;
+    }
+
+    final baseUrl = _serverConfigService.url;
+
+    try {
+      final getResponse = await _httpClient.get(
+        Uri.parse('$baseUrl/claude-triggers'),
+        headers: {
+          'Authorization': 'Bearer $token',
+          'Content-Type': 'application/json',
+        },
+      );
+
+      if (getResponse.statusCode != 200) {
+        stderr.writeln(
+          '[AgentTriggerWatcher] GET /claude-triggers returned '
+          'HTTP ${getResponse.statusCode}; skipping tick.',
+        );
+        return;
+      }
+
+      final decoded = jsonDecode(getResponse.body);
+      if (decoded is! List) {
+        stderr.writeln(
+          '[AgentTriggerWatcher] GET /claude-triggers did not return a JSON '
+          'array; skipping tick.',
+        );
+        return;
+      }
+
+      for (final item in decoded) {
+        if (item is! Map<String, dynamic>) continue;
+        final id = item['id'];
+        if (id == null) continue;
+
+        try {
+          await _agentsController.handleIncomingTrigger(item);
+        } catch (e) {
+          stderr.writeln(
+            '[AgentTriggerWatcher] handleIncomingTrigger failed for trigger '
+            '$id: $e — skipping DELETE.',
+          );
+          continue;
+        }
+
+        // Delete the trigger so it is not re-delivered on the next poll.
+        try {
+          final deleteResponse = await _httpClient.delete(
+            Uri.parse('$baseUrl/claude-triggers/$id'),
+            headers: {'Authorization': 'Bearer $token'},
+          );
+          if (deleteResponse.statusCode != 200 &&
+              deleteResponse.statusCode != 204) {
+            stderr.writeln(
+              '[AgentTriggerWatcher] DELETE /claude-triggers/$id returned '
+              'HTTP ${deleteResponse.statusCode}; trigger will be retried.',
+            );
+          }
+        } catch (e) {
+          stderr.writeln(
+            '[AgentTriggerWatcher] DELETE /claude-triggers/$id failed: $e; '
+            'trigger will be retried.',
+          );
+        }
+      }
+    } catch (e) {
+      stderr.writeln('[AgentTriggerWatcher] poll error: $e');
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Dispose
+  // --------------------------------------------------------------------------
+
+  @override
+  void dispose() {
+    stop();
+    _httpClient.close();
+    super.dispose();
+  }
+}

--- a/apps/desktop_flutter/lib/app/core/constants/app_constants.dart
+++ b/apps/desktop_flutter/lib/app/core/constants/app_constants.dart
@@ -14,6 +14,6 @@ class AppConstants {
   static const int navIntegrations = 8;
   static const int navAgents = 9;
 
-  static const String agentLocalBaseUrl = 'http://localhost:4000';
-  static const String agentLocalWsUrl = 'ws://localhost:4000/ws/agents';
+  static const String agentLocalBaseUrl = 'http://localhost:4001';
+  static const String agentLocalWsUrl = 'ws://localhost:4001/ws/agents';
 }

--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -20,6 +20,8 @@ import '../../../features/settings/controllers/settings_controller.dart';
 import '../../../features/settings/views/settings_view.dart';
 import '../../../features/agents/views/agents_view.dart';
 import '../agents/agent_bubble_overlay.dart';
+import '../agents/agent_server_controller.dart';
+import '../agents/agent_trigger_watcher.dart';
 import '../agents/overlay_controller.dart';
 import '../../../features/tasks/views/automation_rules_view.dart';
 import '../../../features/messages/views/messages_view.dart';
@@ -69,13 +71,16 @@ class _AppShellState extends State<AppShell> with WindowListener {
   @override
   Widget build(BuildContext context) {
     final serverStatus = context.watch<ApiServerController>().status;
+    final agentServerController = context.watch<AgentServerController>();
     final authStatus = context.watch<AuthSessionService>().status;
     final messagesController = context.read<MessagesController>();
     final notifController = context.watch<NotificationsController>();
+    final triggerWatcher = context.read<AgentTriggerWatcher>();
     // Watch OverlayController so we react to pendingNavIndex changes.
     context.watch<OverlayController>();
     final enablePolling = serverStatus == ServerStatus.ready &&
         authStatus == AuthStatus.authenticated;
+    final enableAgentWatcher = enablePolling && agentServerController.isReady;
     final isMessagesScreenActive = enablePolling && _selectedIndex == 5;
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -86,6 +91,11 @@ class _AppShellState extends State<AppShell> with WindowListener {
         notifController.startPolling();
       } else {
         notifController.stopPolling();
+      }
+      if (enableAgentWatcher) {
+        triggerWatcher.start();
+      } else {
+        triggerWatcher.stop();
       }
 
       // Handle pending navigation from tapping a notification

--- a/apps/desktop_flutter/lib/app/core/server/api_server_service.dart
+++ b/apps/desktop_flutter/lib/app/core/server/api_server_service.dart
@@ -52,7 +52,12 @@ class ApiServerService {
       serverInfo.executable,
       serverInfo.args,
       workingDirectory: serverInfo.workingDir,
-      environment: {...Platform.environment, 'PORT': '4001', 'DB_PATH': dbPath},
+      environment: {
+        ...Platform.environment,
+        'PORT': '4001',
+        'DB_PATH': dbPath,
+        'AGENT_LOCAL': 'true',
+      },
     );
 
     _process!.stdout

--- a/apps/desktop_flutter/lib/app/core/server/api_server_service.dart
+++ b/apps/desktop_flutter/lib/app/core/server/api_server_service.dart
@@ -26,7 +26,7 @@ class ApiServerService {
   Future<bool> start() async {
     final existing = await _isServerReady();
     if (existing) {
-      stdout.writeln('[ApiServerService] Reusing existing server on :4000.');
+      stdout.writeln('[ApiServerService] Reusing existing server on :4001.');
       return true;
     }
 
@@ -52,7 +52,7 @@ class ApiServerService {
       serverInfo.executable,
       serverInfo.args,
       workingDirectory: serverInfo.workingDir,
-      environment: {...Platform.environment, 'PORT': '4000', 'DB_PATH': dbPath},
+      environment: {...Platform.environment, 'PORT': '4001', 'DB_PATH': dbPath},
     );
 
     _process!.stdout
@@ -97,7 +97,7 @@ class ApiServerService {
   }
 
   Future<bool> _isServerReady() async {
-    return checkHealth('http://localhost:4000');
+    return checkHealth('http://localhost:4001');
   }
 
   Future<String?> _findNode() async {

--- a/apps/desktop_flutter/lib/app/core/services/server_config_service.dart
+++ b/apps/desktop_flutter/lib/app/core/services/server_config_service.dart
@@ -4,7 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 class ServerConfigService extends ChangeNotifier {
   static const _key = 'server_url';
   static const _cloudUrl = 'https://api.vcrcapps.com';
-  static const _legacyLocalUrl = 'http://localhost:4001';
+  static const _legacyLocalUrl = 'http://localhost:4000';
   static const _definedDefaultUrl = String.fromEnvironment(
     'RHYTHM_SERVER_URL',
     defaultValue: _cloudUrl,

--- a/apps/desktop_flutter/lib/app/core/services/server_config_service.dart
+++ b/apps/desktop_flutter/lib/app/core/services/server_config_service.dart
@@ -4,7 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 class ServerConfigService extends ChangeNotifier {
   static const _key = 'server_url';
   static const _cloudUrl = 'https://api.vcrcapps.com';
-  static const _legacyLocalUrl = 'http://localhost:4000';
+  static const _legacyLocalUrl = 'http://localhost:4001';
   static const _definedDefaultUrl = String.fromEnvironment(
     'RHYTHM_SERVER_URL',
     defaultValue: _cloudUrl,

--- a/apps/desktop_flutter/lib/app/core/services/server_config_service.dart
+++ b/apps/desktop_flutter/lib/app/core/services/server_config_service.dart
@@ -5,6 +5,7 @@ class ServerConfigService extends ChangeNotifier {
   static const _key = 'server_url';
   static const _cloudUrl = 'https://api.vcrcapps.com';
   static const _legacyLocalUrl = 'http://localhost:4000';
+  static const _legacyAgentLocalUrl = 'http://localhost:4001';
   static const _definedDefaultUrl = String.fromEnvironment(
     'RHYTHM_SERVER_URL',
     defaultValue: _cloudUrl,
@@ -18,8 +19,10 @@ class ServerConfigService extends ChangeNotifier {
   Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
     final savedUrl = prefs.getString(_key);
+    final isLegacyLocalhost =
+        savedUrl == _legacyLocalUrl || savedUrl == _legacyAgentLocalUrl;
     final shouldMigrateLegacyLocalhost =
-        savedUrl == _legacyLocalUrl && defaultUrl != _legacyLocalUrl;
+        isLegacyLocalhost && defaultUrl != savedUrl;
     if (savedUrl == null || shouldMigrateLegacyLocalhost) {
       _url = defaultUrl;
       await prefs.setString(_key, _url);

--- a/apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart
+++ b/apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart
@@ -205,6 +205,33 @@ class AgentsController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Handles an incoming trigger received from production polling.
+  ///
+  /// The trigger [map] must contain at least `taskId` and `taskTitle` keys.
+  /// If a trigger with the same `taskId` is already pending it is ignored so
+  /// that a failed DELETE does not create duplicate bubbles.
+  Future<void> handleIncomingTrigger(Map<String, dynamic> trigger) async {
+    final taskId = trigger['taskId'] as String? ??
+        trigger['task_id'] as String? ??
+        trigger['id']?.toString();
+    final taskTitle = trigger['taskTitle'] as String? ??
+        trigger['task_title'] as String? ??
+        trigger['title'] as String? ??
+        '';
+
+    if (taskId == null || taskId.isEmpty) return;
+
+    // Deduplicate — if the trigger is already pending, skip.
+    if (_pendingTriggers.any((t) => t.taskId == taskId)) return;
+
+    _pendingTriggers.add(PendingTrigger(
+      taskId: taskId,
+      taskTitle: taskTitle,
+      arrivedAt: DateTime.now(),
+    ));
+    notifyListeners();
+  }
+
   // --------------------------------------------------------------------------
   // WebSocket message handler
   // --------------------------------------------------------------------------

--- a/apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart
+++ b/apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../../../app/core/agents/agent_server_controller.dart';
 import '../models/agent_session.dart';
 import '../models/agent_session_message.dart';
 import '../models/agent_ws_message.dart';
@@ -22,14 +23,10 @@ class PendingTrigger {
 }
 
 class AgentsController extends ChangeNotifier {
-  AgentsController(this._repository, {required this.isLocalServer});
+  AgentsController(this._repository, this._agentServerController);
 
   final AgentsRepository _repository;
-
-  /// Whether the app is pointed at a local server.
-  /// When false the UI shows a "local server required" notice instead of trying
-  /// to connect.
-  final bool isLocalServer;
+  final AgentServerController _agentServerController;
 
   AgentsLoadStatus _status = AgentsLoadStatus.idle;
   String? _error;
@@ -78,8 +75,10 @@ class AgentsController extends ChangeNotifier {
   // --------------------------------------------------------------------------
 
   Future<void> initialize() async {
-    if (!isLocalServer) {
-      // No local server → skip WebSocket connect; UI guard handles display.
+    if (!_agentServerController.isReady ||
+        !_agentServerController.hasAnyAgent) {
+      // Agent server not ready or no CLI installed → skip WebSocket connect;
+      // UI guard handles display.
       return;
     }
     await _repository.connect();

--- a/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
+++ b/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../app/core/agents/agent_server_controller.dart';
 import '../../../app/core/ui/tokens/rhythm_theme.dart';
 import '../../tasks/controllers/tasks_controller.dart';
 import '../../tasks/models/task.dart';
@@ -22,13 +23,21 @@ class _AgentsViewState extends State<AgentsView> {
 
   @override
   Widget build(BuildContext context) {
-    final controller = context.watch<AgentsController>();
+    // Watch AgentsController so the view rebuilds when session state changes.
+    context.watch<AgentsController>();
+    final agentServerController = context.watch<AgentServerController>();
 
-    // Capability guard — no local server.
-    if (!controller.isLocalServer) {
-      return _LocalServerRequired();
+    // Capability guard — server failed.
+    if (agentServerController.status == AgentServerStatus.failed) {
+      return const _AgentServerUnavailable();
     }
 
+    // Capability guard — server ok but no CLI installed.
+    if (agentServerController.isReady && !agentServerController.hasAnyAgent) {
+      return const _NoCLIDetected();
+    }
+
+    // Still starting — show the main view (sessions will be empty).
     return Scaffold(
       backgroundColor: context.rhythm.canvas,
       body: Container(
@@ -65,10 +74,65 @@ class _AgentsViewState extends State<AgentsView> {
 }
 
 // ---------------------------------------------------------------------------
-// Capability guard card
+// Capability guard cards
 // ---------------------------------------------------------------------------
 
-class _LocalServerRequired extends StatelessWidget {
+class _AgentServerUnavailable extends StatelessWidget {
+  const _AgentServerUnavailable();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: context.rhythm.canvas,
+      body: Center(
+        child: Container(
+          width: 440,
+          padding: const EdgeInsets.all(32),
+          decoration: BoxDecoration(
+            color: context.rhythm.surfaceRaised,
+            borderRadius: BorderRadius.circular(RhythmRadius.xl),
+            border: Border.all(color: context.rhythm.border),
+            boxShadow: RhythmElevation.panel,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.error_outline,
+                size: 40,
+                color: context.rhythm.danger,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Agent server unavailable',
+                style: TextStyle(
+                  fontSize: 17,
+                  fontWeight: FontWeight.w700,
+                  color: context.rhythm.textPrimary,
+                ),
+              ),
+              const SizedBox(height: 10),
+              Text(
+                'The agent server failed to start. Check Settings → Agent Server '
+                'to diagnose the issue.',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 13,
+                  color: context.rhythm.textSecondary,
+                  height: 1.45,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NoCLIDetected extends StatelessWidget {
+  const _NoCLIDetected();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -93,7 +157,7 @@ class _LocalServerRequired extends StatelessWidget {
               ),
               const SizedBox(height: 16),
               Text(
-                'Local server required',
+                'No supported AI CLI detected',
                 style: TextStyle(
                   fontSize: 17,
                   fontWeight: FontWeight.w700,
@@ -102,8 +166,7 @@ class _LocalServerRequired extends StatelessWidget {
               ),
               const SizedBox(height: 10),
               Text(
-                'Agent sessions require the local Rhythm server. Switch to the '
-                'local server in Settings to use this feature.',
+                'Install Claude Code or Codex CLI to use agent sessions.',
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   fontSize: 13,
@@ -135,6 +198,9 @@ class _SessionListPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final controller = context.watch<AgentsController>();
+    final agentServerController = context.watch<AgentServerController>();
+    final canStartSession =
+        agentServerController.isReady && agentServerController.hasAnyAgent;
 
     return Container(
       width: 320,
@@ -148,7 +214,8 @@ class _SessionListPanel extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _SessionListHeader(
-            onNewSession: () => _showNewSessionDialog(context),
+            onNewSession:
+                canStartSession ? () => _showNewSessionDialog(context) : null,
           ),
           Divider(height: 1, color: context.rhythm.borderSubtle),
           Expanded(
@@ -234,7 +301,10 @@ class _SessionListPanel extends StatelessWidget {
         value: context.read<AgentsController>(),
         child: ChangeNotifierProvider.value(
           value: context.read<TasksController>(),
-          child: const _NewSessionDialog(),
+          child: ChangeNotifierProvider.value(
+            value: context.read<AgentServerController>(),
+            child: const _NewSessionDialog(),
+          ),
         ),
       ),
     );
@@ -244,7 +314,7 @@ class _SessionListPanel extends StatelessWidget {
 class _SessionListHeader extends StatelessWidget {
   const _SessionListHeader({required this.onNewSession});
 
-  final VoidCallback onNewSession;
+  final VoidCallback? onNewSession;
 
   @override
   Widget build(BuildContext context) {
@@ -275,29 +345,31 @@ class _SessionListHeader extends StatelessWidget {
               ],
             ),
           ),
-          FilledButton.tonal(
-            onPressed: onNewSession,
-            style: FilledButton.styleFrom(
-              backgroundColor: context.rhythm.accentMuted,
-              foregroundColor: context.rhythm.accent,
-              elevation: 0,
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(RhythmRadius.md),
+          if (onNewSession != null)
+            FilledButton.tonal(
+              onPressed: onNewSession,
+              style: FilledButton.styleFrom(
+                backgroundColor: context.rhythm.accentMuted,
+                foregroundColor: context.rhythm.accent,
+                elevation: 0,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(RhythmRadius.md),
+                ),
+              ),
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.add, size: 16),
+                  SizedBox(width: 4),
+                  Text(
+                    'New',
+                    style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                  ),
+                ],
               ),
             ),
-            child: const Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.add, size: 16),
-                SizedBox(width: 4),
-                Text(
-                  'New',
-                  style: TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
-                ),
-              ],
-            ),
-          ),
         ],
       ),
     );
@@ -1280,9 +1352,26 @@ class _NewSessionDialogState extends State<_NewSessionDialog> {
   @override
   Widget build(BuildContext context) {
     final tasksController = context.watch<TasksController>();
+    final agentServerController = context.watch<AgentServerController>();
     final tasks = tasksController.tasks
         .where((t) => t.status != TaskStatus.done)
         .toList();
+
+    final claudeAvailable =
+        agentServerController.isAgentAvailable('claude-code');
+    final codexAvailable = agentServerController.isAgentAvailable('codex');
+
+    // If the currently selected kind becomes unavailable, fall back to
+    // whichever is available.
+    if (_agentKind == AgentKind.claudeCode &&
+        !claudeAvailable &&
+        codexAvailable) {
+      _agentKind = AgentKind.codex;
+    } else if (_agentKind == AgentKind.codex &&
+        !codexAvailable &&
+        claudeAvailable) {
+      _agentKind = AgentKind.claudeCode;
+    }
 
     return AlertDialog(
       backgroundColor: context.rhythm.surfaceRaised,
@@ -1332,45 +1421,50 @@ class _NewSessionDialogState extends State<_NewSessionDialog> {
             ),
             const SizedBox(height: 14),
 
-            // Agent kind
-            Text(
-              'Agent',
-              style: TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
-                color: context.rhythm.textSecondary,
+            // Agent kind — only show available options
+            if (claudeAvailable || codexAvailable) ...[
+              Text(
+                'Agent',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: context.rhythm.textSecondary,
+                ),
               ),
-            ),
-            const SizedBox(height: 6),
-            Container(
-              decoration: BoxDecoration(
-                color: context.rhythm.surfaceMuted,
-                borderRadius: BorderRadius.circular(RhythmRadius.md),
-                border: Border.all(color: context.rhythm.borderSubtle),
+              const SizedBox(height: 6),
+              Container(
+                decoration: BoxDecoration(
+                  color: context.rhythm.surfaceMuted,
+                  borderRadius: BorderRadius.circular(RhythmRadius.md),
+                  border: Border.all(color: context.rhythm.borderSubtle),
+                ),
+                child: Row(
+                  children: [
+                    if (claudeAvailable)
+                      Expanded(
+                        child: _AgentToggleButton(
+                          label: 'Claude Code',
+                          selected: _agentKind == AgentKind.claudeCode,
+                          color: const Color(0xFF6B46C1),
+                          onTap: () =>
+                              setState(() => _agentKind = AgentKind.claudeCode),
+                        ),
+                      ),
+                    if (codexAvailable)
+                      Expanded(
+                        child: _AgentToggleButton(
+                          label: 'Codex',
+                          selected: _agentKind == AgentKind.codex,
+                          color: const Color(0xFF059669),
+                          onTap: () =>
+                              setState(() => _agentKind = AgentKind.codex),
+                        ),
+                      ),
+                  ],
+                ),
               ),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: _AgentToggleButton(
-                      label: 'Claude Code',
-                      selected: _agentKind == AgentKind.claudeCode,
-                      color: const Color(0xFF6B46C1),
-                      onTap: () =>
-                          setState(() => _agentKind = AgentKind.claudeCode),
-                    ),
-                  ),
-                  Expanded(
-                    child: _AgentToggleButton(
-                      label: 'Codex',
-                      selected: _agentKind == AgentKind.codex,
-                      color: const Color(0xFF059669),
-                      onTap: () => setState(() => _agentKind = AgentKind.codex),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 14),
+              const SizedBox(height: 14),
+            ],
 
             // Task selector (optional)
             Text(

--- a/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
+++ b/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
@@ -339,7 +339,7 @@ class _SettingsViewState extends State<SettingsView> {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'Use http://localhost:4000 for local, or your hosted server URL.',
+                  'Use http://localhost:4001 for local, or your hosted server URL.',
                   style: TextStyle(
                     fontSize: 13,
                     color: context.rhythm.textSecondary,
@@ -349,7 +349,7 @@ class _SettingsViewState extends State<SettingsView> {
                 TextFormField(
                   controller: _urlController,
                   decoration: const InputDecoration(
-                    hintText: 'http://localhost:4000',
+                    hintText: 'http://localhost:4001',
                     isDense: true,
                   ),
                   keyboardType: TextInputType.url,

--- a/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
+++ b/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
+import '../../../app/core/agents/agent_server_controller.dart';
 import '../../../app/core/auth/auth_session_service.dart';
 import '../../../app/core/auth/auth_user.dart';
 import '../../../app/core/services/server_config_service.dart';
@@ -209,6 +211,8 @@ class _SettingsViewState extends State<SettingsView> {
           const SizedBox(height: 24),
           const _ClaudeIntegrationSection(),
           const SizedBox(height: 24),
+          const _AgentServerSection(),
+          const SizedBox(height: 24),
           const _WorkspaceSectionWidget(),
           Text(
             'UPDATES',
@@ -339,7 +343,7 @@ class _SettingsViewState extends State<SettingsView> {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'Use http://localhost:4001 for local, or your hosted server URL.',
+                  'Your Rhythm production server URL (e.g. https://api.vcrcapps.com).',
                   style: TextStyle(
                     fontSize: 13,
                     color: context.rhythm.textSecondary,
@@ -859,6 +863,257 @@ class _ClaudeIntegrationSectionState extends State<_ClaudeIntegrationSection> {
                 ),
               ],
             ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Agent Server status
+// ---------------------------------------------------------------------------
+
+class _AgentServerSection extends StatelessWidget {
+  const _AgentServerSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<AgentServerController>();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'AGENT SERVER',
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: context.rhythm.textSecondary,
+            letterSpacing: 0.8,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(
+            color: context.rhythm.surfaceRaised,
+            borderRadius: BorderRadius.circular(RhythmRadius.xl),
+            border: Border.all(color: context.rhythm.borderSubtle),
+            boxShadow: RhythmElevation.panel,
+          ),
+          child: switch (controller.status) {
+            AgentServerStatus.starting => const _AgentServerStarting(),
+            AgentServerStatus.failed => _AgentServerFailed(
+                errorMessage: controller.errorMessage,
+                onRetry: controller.retry,
+              ),
+            AgentServerStatus.ready => _AgentServerReady(
+                capabilities: controller.capabilities,
+                hasAnyAgent: controller.hasAnyAgent,
+                isAgentAvailable: controller.isAgentAvailable,
+                onRefresh: controller.refreshCapabilities,
+              ),
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _AgentServerStarting extends StatelessWidget {
+  const _AgentServerStarting();
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const SizedBox(
+          width: 16,
+          height: 16,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+        const SizedBox(width: 12),
+        Text(
+          'Starting agent server on :4001...',
+          style: TextStyle(
+            fontSize: 13,
+            color: context.rhythm.textSecondary,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AgentServerFailed extends StatelessWidget {
+  const _AgentServerFailed({
+    required this.errorMessage,
+    required this.onRetry,
+  });
+
+  final String? errorMessage;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.circle, size: 10, color: context.rhythm.danger),
+            const SizedBox(width: 8),
+            Text(
+              'Agent server failed to start',
+              style: TextStyle(
+                fontWeight: FontWeight.w600,
+                color: context.rhythm.textPrimary,
+              ),
+            ),
+          ],
+        ),
+        if (errorMessage != null) ...[
+          const SizedBox(height: 6),
+          Text(
+            errorMessage!,
+            style: TextStyle(fontSize: 13, color: context.rhythm.danger),
+          ),
+        ],
+        const SizedBox(height: 12),
+        OutlinedButton(
+          onPressed: onRetry,
+          child: const Text('Retry'),
+        ),
+      ],
+    );
+  }
+}
+
+class _AgentServerReady extends StatelessWidget {
+  const _AgentServerReady({
+    required this.capabilities,
+    required this.hasAnyAgent,
+    required this.isAgentAvailable,
+    required this.onRefresh,
+  });
+
+  final Map<String, bool> capabilities;
+  final bool hasAnyAgent;
+  final bool Function(String) isAgentAvailable;
+  final VoidCallback onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.circle, size: 10, color: context.rhythm.success),
+            const SizedBox(width: 8),
+            Text(
+              'Running on localhost:4001',
+              style: TextStyle(
+                fontWeight: FontWeight.w600,
+                color: context.rhythm.textPrimary,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        _AgentCliRow(
+          label: 'Claude Code CLI',
+          available: isAgentAvailable('claude'),
+        ),
+        const SizedBox(height: 8),
+        _AgentCliRow(
+          label: 'Codex CLI',
+          available: isAgentAvailable('codex'),
+        ),
+        if (!hasAnyAgent) ...[
+          const SizedBox(height: 12),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: context.rhythm.warning.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(RhythmRadius.md),
+              border: Border.all(color: context.rhythm.warning),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  Icons.warning_amber_rounded,
+                  size: 16,
+                  color: context.rhythm.warning,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'No supported AI CLI detected. Install Claude Code or Codex CLI to use agent sessions.',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: context.rhythm.textPrimary,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      GestureDetector(
+                        onTap: () => launchUrl(
+                          Uri.parse('https://claude.ai/code'),
+                          mode: LaunchMode.externalApplication,
+                        ),
+                        child: Text(
+                          'Install Claude Code',
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: context.rhythm.accent,
+                            decoration: TextDecoration.underline,
+                            decorationColor: context.rhythm.accent,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+        const SizedBox(height: 12),
+        OutlinedButton(
+          onPressed: onRefresh,
+          child: const Text('Refresh'),
+        ),
+      ],
+    );
+  }
+}
+
+class _AgentCliRow extends StatelessWidget {
+  const _AgentCliRow({required this.label, required this.available});
+
+  final String label;
+  final bool available;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(
+          available ? Icons.check_circle_outline : Icons.cancel_outlined,
+          size: 16,
+          color: available ? context.rhythm.success : context.rhythm.danger,
+        ),
+        const SizedBox(width: 8),
+        Text(
+          '$label: ${available ? 'installed' : 'not installed'}',
+          style: TextStyle(
+            fontSize: 13,
+            color: context.rhythm.textSecondary,
           ),
         ),
       ],

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -208,12 +208,9 @@ class RhythmApp extends StatelessWidget {
         ),
         ChangeNotifierProvider(
           create: (_) {
-            final isLocal =
-                serverConfigService.url.startsWith('http://localhost') ||
-                    serverConfigService.url.startsWith('http://127.0.0.1');
             final ds = AgentsDataSource();
             final repo = AgentsRepository(ds);
-            return AgentsController(repo, isLocalServer: isLocal)..initialize();
+            return AgentsController(repo, agentServerController)..initialize();
           },
         ),
         ChangeNotifierProvider(

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -55,6 +55,7 @@ import 'features/notifications/repositories/notifications_repository.dart';
 import 'features/agents/controllers/agents_controller.dart';
 import 'features/agents/data/agents_data_source.dart';
 import 'features/agents/repositories/agents_repository.dart';
+import 'app/core/agents/agent_server_controller.dart';
 import 'app/core/agents/overlay_controller.dart';
 
 void main() async {
@@ -85,6 +86,8 @@ void main() async {
     ApiServerService(),
     serverUrl: serverConfigService.url,
   )..initialize();
+  final agentServerController = AgentServerController(ApiServerService())
+    ..initialize();
   final authSessionService = AuthSessionService(
     AuthDataSource(baseUrl: serverConfigService.url),
     googleClient: DesktopGoogleOAuthClient(baseUrl: serverConfigService.url),
@@ -97,6 +100,7 @@ void main() async {
       authSessionService: authSessionService,
       localNotificationService: localNotificationService,
       serverController: serverController,
+      agentServerController: agentServerController,
       serverConfigService: serverConfigService,
       themeModeService: themeModeService,
     ),
@@ -109,6 +113,7 @@ class RhythmApp extends StatelessWidget {
     required this.authSessionService,
     required this.localNotificationService,
     required this.serverController,
+    required this.agentServerController,
     required this.serverConfigService,
     required this.themeModeService,
   });
@@ -116,6 +121,7 @@ class RhythmApp extends StatelessWidget {
   final AuthSessionService authSessionService;
   final LocalNotificationService localNotificationService;
   final ApiServerController serverController;
+  final AgentServerController agentServerController;
   final ServerConfigService serverConfigService;
   final ThemeModeService themeModeService;
 
@@ -125,6 +131,7 @@ class RhythmApp extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider.value(value: serverController),
+        ChangeNotifierProvider.value(value: agentServerController),
         ChangeNotifierProvider.value(value: serverConfigService),
         ChangeNotifierProvider.value(value: authSessionService),
         ChangeNotifierProvider.value(value: themeModeService),

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -56,6 +56,7 @@ import 'features/agents/controllers/agents_controller.dart';
 import 'features/agents/data/agents_data_source.dart';
 import 'features/agents/repositories/agents_repository.dart';
 import 'app/core/agents/agent_server_controller.dart';
+import 'app/core/agents/agent_trigger_watcher.dart';
 import 'app/core/agents/overlay_controller.dart';
 
 void main() async {
@@ -215,6 +216,18 @@ class RhythmApp extends StatelessWidget {
         ),
         ChangeNotifierProvider(
           create: (ctx) => OverlayController(ctx.read<AgentsController>()),
+        ),
+        ChangeNotifierProvider(
+          create: (ctx) {
+            final watcher = AgentTriggerWatcher(
+              serverConfigService: serverConfigService,
+              authSessionService: authSessionService,
+              agentServerController: agentServerController,
+              agentsController: ctx.read<AgentsController>(),
+            );
+            watcher.start();
+            return watcher;
+          },
         ),
       ],
       child: Consumer<ThemeModeService>(

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -218,16 +218,12 @@ class RhythmApp extends StatelessWidget {
           create: (ctx) => OverlayController(ctx.read<AgentsController>()),
         ),
         ChangeNotifierProvider(
-          create: (ctx) {
-            final watcher = AgentTriggerWatcher(
-              serverConfigService: serverConfigService,
-              authSessionService: authSessionService,
-              agentServerController: agentServerController,
-              agentsController: ctx.read<AgentsController>(),
-            );
-            watcher.start();
-            return watcher;
-          },
+          create: (ctx) => AgentTriggerWatcher(
+            serverConfigService: serverConfigService,
+            authSessionService: authSessionService,
+            agentServerController: agentServerController,
+            agentsController: ctx.read<AgentsController>(),
+          ),
         ),
       ],
       child: Consumer<ThemeModeService>(

--- a/apps/desktop_flutter/test/features/agents/agent_trigger_watcher_test.dart
+++ b/apps/desktop_flutter/test/features/agents/agent_trigger_watcher_test.dart
@@ -1,0 +1,402 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:rhythm_desktop/app/core/agents/agent_server_controller.dart';
+import 'package:rhythm_desktop/app/core/agents/agent_trigger_watcher.dart';
+import 'package:rhythm_desktop/app/core/auth/auth_data_source.dart';
+import 'package:rhythm_desktop/app/core/auth/auth_session_service.dart';
+import 'package:rhythm_desktop/app/core/server/api_server_service.dart';
+import 'package:rhythm_desktop/app/core/services/server_config_service.dart';
+import 'package:rhythm_desktop/features/agents/controllers/agents_controller.dart';
+import 'package:rhythm_desktop/features/agents/models/agent_session.dart';
+import 'package:rhythm_desktop/features/agents/models/agent_session_message.dart';
+import 'package:rhythm_desktop/features/agents/models/agent_ws_message.dart';
+import 'package:rhythm_desktop/features/agents/repositories/agents_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes / stubs
+// ---------------------------------------------------------------------------
+
+class _FakeApiServerService extends ApiServerService {
+  @override
+  Future<bool> start() async => true;
+  @override
+  Future<void> stop() async {}
+}
+
+class _FakeAgentServerController extends AgentServerController {
+  _FakeAgentServerController({required bool ready})
+      : _ready = ready,
+        super(_FakeApiServerService());
+
+  final bool _ready;
+
+  @override
+  bool get isReady => _ready;
+
+  @override
+  bool get hasAnyAgent => _ready;
+
+  @override
+  Future<void> initialize() async {}
+}
+
+class _FakeAgentsRepository implements AgentsRepository {
+  _FakeAgentsRepository()
+      : _msgController = StreamController<AgentWsMessage>.broadcast();
+
+  final StreamController<AgentWsMessage> _msgController;
+
+  @override
+  Stream<AgentWsMessage> get messages => _msgController.stream;
+
+  @override
+  bool get isConnected => false;
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> dispose() async {
+    await _msgController.close();
+  }
+
+  @override
+  void send(Map<String, dynamic> msg) {}
+
+  @override
+  Future<List<AgentSession>> listSessions() async => [];
+
+  @override
+  Future<({AgentSession session, List<AgentSessionMessage> messages})>
+      getSession(String id) async {
+    final now = DateTime.now();
+    return (
+      session: AgentSession(
+        id: id,
+        agentKind: AgentKind.claudeCode,
+        status: AgentSessionStatus.idle,
+        cwd: '/tmp',
+        name: 'Fake',
+        createdAt: now,
+        updatedAt: now,
+      ),
+      messages: <AgentSessionMessage>[],
+    );
+  }
+
+  @override
+  Future<AgentSession> createSession({
+    required AgentKind agentKind,
+    String? taskId,
+    required String cwd,
+    required String name,
+  }) async {
+    final now = DateTime.now();
+    return AgentSession(
+      id: 'new',
+      agentKind: agentKind,
+      status: AgentSessionStatus.starting,
+      cwd: cwd,
+      name: name,
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  @override
+  Future<void> closeSession(String id) async {}
+
+  @override
+  Future<AgentSession> resumeSession(String id) async {
+    final now = DateTime.now();
+    return AgentSession(
+      id: id,
+      agentKind: AgentKind.claudeCode,
+      status: AgentSessionStatus.idle,
+      cwd: '/tmp',
+      name: 'Resumed',
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  @override
+  Future<List<AgentSessionMessage>> getMessages(String id, {int? limit}) async {
+    return [];
+  }
+}
+
+/// A stub [AuthDataSource] that does nothing (prevents real network calls).
+class _FakeAuthDataSource extends AuthDataSource {
+  _FakeAuthDataSource() : super(baseUrl: 'http://localhost:4000');
+}
+
+/// A stub [AuthSessionService] that returns a configurable session token
+/// without touching [SharedPreferences] or making network calls.
+class _StubAuthSessionService extends AuthSessionService {
+  _StubAuthSessionService({String? token})
+      : _token = token,
+        super(_FakeAuthDataSource());
+
+  final String? _token;
+
+  @override
+  String? get sessionToken => _token;
+
+  @override
+  bool get isAuthenticated => _token != null;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  late AgentsController agentsController;
+  late _FakeAgentServerController agentServerController;
+  late ServerConfigService serverConfigService;
+
+  setUp(() {
+    agentServerController = _FakeAgentServerController(ready: true);
+    agentsController = AgentsController(
+      _FakeAgentsRepository(),
+      agentServerController,
+    );
+    serverConfigService = ServerConfigService();
+  });
+
+  tearDown(() {
+    agentsController.dispose();
+  });
+
+  // --------------------------------------------------------------------------
+  // No-auth guard
+  // --------------------------------------------------------------------------
+
+  group('without authentication', () {
+    test('does not make any HTTP requests when sessionToken is null', () async {
+      var requestCount = 0;
+      final client = MockClient((_) async {
+        requestCount++;
+        return http.Response('[]', 200);
+      });
+
+      final watcher = AgentTriggerWatcher(
+        serverConfigService: serverConfigService,
+        authSessionService: _StubAuthSessionService(token: null),
+        agentServerController: agentServerController,
+        agentsController: agentsController,
+        interval: const Duration(milliseconds: 50),
+        httpClient: client,
+      );
+      addTearDown(watcher.dispose);
+
+      watcher.start();
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(requestCount, 0);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Polling when authenticated and agent server ready
+  // --------------------------------------------------------------------------
+
+  group('when authenticated and agent server is ready', () {
+    test('polls GET /claude-triggers and adds pending trigger', () async {
+      final trigger = {
+        'id': 'tr-1',
+        'taskId': 'task-99',
+        'taskTitle': 'Ship it',
+      };
+
+      var getCount = 0;
+      var deleteCount = 0;
+
+      final client = MockClient((request) async {
+        if (request.method == 'GET' &&
+            request.url.path.endsWith('/claude-triggers')) {
+          getCount++;
+          return http.Response(jsonEncode([trigger]), 200);
+        }
+        if (request.method == 'DELETE' &&
+            request.url.path.contains('/claude-triggers/')) {
+          deleteCount++;
+          return http.Response('', 204);
+        }
+        return http.Response('not found', 404);
+      });
+
+      final watcher = AgentTriggerWatcher(
+        serverConfigService: serverConfigService,
+        authSessionService: _StubAuthSessionService(token: 'tok-abc'),
+        agentServerController: agentServerController,
+        agentsController: agentsController,
+        interval: const Duration(milliseconds: 50),
+        httpClient: client,
+      );
+      addTearDown(watcher.dispose);
+
+      watcher.start();
+      // Allow an immediate poll to complete.
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(getCount, greaterThan(0));
+      // Trigger was added exactly once (deduplication in AgentsController).
+      expect(agentsController.pendingTriggers, hasLength(1));
+      expect(agentsController.pendingTriggers.first.taskId, 'task-99');
+      expect(agentsController.pendingTriggers.first.taskTitle, 'Ship it');
+      // DELETE was called at least once.
+      expect(deleteCount, greaterThan(0));
+    });
+
+    test('deduplicates: same trigger polled twice does not create two bubbles',
+        () async {
+      final trigger = {
+        'id': 'tr-dup',
+        'taskId': 'task-dup',
+        'taskTitle': 'Duplicate',
+      };
+
+      // Simulate DELETE failing so the trigger keeps reappearing.
+      final client = MockClient((request) async {
+        if (request.method == 'GET') {
+          return http.Response(jsonEncode([trigger]), 200);
+        }
+        // DELETE returns 500 — trigger is not consumed.
+        return http.Response('error', 500);
+      });
+
+      final watcher = AgentTriggerWatcher(
+        serverConfigService: serverConfigService,
+        authSessionService: _StubAuthSessionService(token: 'tok-abc'),
+        agentServerController: agentServerController,
+        agentsController: agentsController,
+        interval: const Duration(milliseconds: 50),
+        httpClient: client,
+      );
+      addTearDown(watcher.dispose);
+
+      watcher.start();
+      // Allow several ticks to fire.
+      await Future<void>.delayed(const Duration(milliseconds: 250));
+
+      // Despite multiple polls, the trigger should only appear once.
+      expect(
+        agentsController.pendingTriggers
+            .where((t) => t.taskId == 'task-dup')
+            .length,
+        1,
+      );
+    });
+
+    test('calls DELETE after a successful handoff', () async {
+      final trigger = {
+        'id': 'tr-del',
+        'taskId': 'task-del',
+        'taskTitle': 'Delete me',
+      };
+
+      final deletedIds = <String>[];
+
+      final client = MockClient((request) async {
+        if (request.method == 'GET') {
+          return http.Response(jsonEncode([trigger]), 200);
+        }
+        if (request.method == 'DELETE') {
+          final id = request.url.pathSegments.last;
+          deletedIds.add(id);
+          return http.Response('', 204);
+        }
+        return http.Response('', 404);
+      });
+
+      final watcher = AgentTriggerWatcher(
+        serverConfigService: serverConfigService,
+        authSessionService: _StubAuthSessionService(token: 'tok-abc'),
+        agentServerController: agentServerController,
+        agentsController: agentsController,
+        interval: const Duration(milliseconds: 50),
+        httpClient: client,
+      );
+      addTearDown(watcher.dispose);
+
+      watcher.start();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      expect(deletedIds, contains('tr-del'));
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Agent server not ready
+  // --------------------------------------------------------------------------
+
+  group('when agent server is not ready', () {
+    test('does not poll even if authenticated', () async {
+      var requestCount = 0;
+      final client = MockClient((_) async {
+        requestCount++;
+        return http.Response('[]', 200);
+      });
+
+      final notReadyController = _FakeAgentServerController(ready: false);
+
+      final watcher = AgentTriggerWatcher(
+        serverConfigService: serverConfigService,
+        authSessionService: _StubAuthSessionService(token: 'tok-abc'),
+        agentServerController: notReadyController,
+        agentsController: agentsController,
+        interval: const Duration(milliseconds: 50),
+        httpClient: client,
+      );
+      addTearDown(watcher.dispose);
+
+      watcher.start();
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(requestCount, 0);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // isPolling flag
+  // --------------------------------------------------------------------------
+
+  group('isPolling', () {
+    test('is false before start()', () {
+      final watcher = AgentTriggerWatcher(
+        serverConfigService: serverConfigService,
+        authSessionService: _StubAuthSessionService(token: 'tok'),
+        agentServerController: agentServerController,
+        agentsController: agentsController,
+      );
+      addTearDown(watcher.dispose);
+
+      expect(watcher.isPolling, isFalse);
+    });
+
+    test('is true after start() and false after stop()', () async {
+      final client = MockClient((_) async => http.Response('[]', 200));
+
+      final watcher = AgentTriggerWatcher(
+        serverConfigService: serverConfigService,
+        authSessionService: _StubAuthSessionService(token: 'tok'),
+        agentServerController: agentServerController,
+        agentsController: agentsController,
+        httpClient: client,
+      );
+      addTearDown(watcher.dispose);
+
+      watcher.start();
+      expect(watcher.isPolling, isTrue);
+
+      watcher.stop();
+      expect(watcher.isPolling, isFalse);
+    });
+  });
+}

--- a/apps/desktop_flutter/test/features/agents/agents_controller_test.dart
+++ b/apps/desktop_flutter/test/features/agents/agents_controller_test.dart
@@ -1,11 +1,51 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:rhythm_desktop/app/core/agents/agent_server_controller.dart';
+import 'package:rhythm_desktop/app/core/server/api_server_service.dart';
 import 'package:rhythm_desktop/features/agents/controllers/agents_controller.dart';
 import 'package:rhythm_desktop/features/agents/models/agent_session.dart';
 import 'package:rhythm_desktop/features/agents/models/agent_session_message.dart';
 import 'package:rhythm_desktop/features/agents/models/agent_ws_message.dart';
 import 'package:rhythm_desktop/features/agents/repositories/agents_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Fake AgentServerController
+// ---------------------------------------------------------------------------
+
+class _FakeApiServerService extends ApiServerService {
+  @override
+  Future<bool> start() async => true;
+
+  @override
+  Future<void> stop() async {}
+}
+
+/// A minimal stub of [AgentServerController] that exposes configurable
+/// [isReady] / [hasAnyAgent] so tests can control the capability gate without
+/// spinning up a real server process.
+class _FakeAgentServerController extends AgentServerController {
+  _FakeAgentServerController({
+    required bool ready,
+    required bool anyAgent,
+  })  : _ready = ready,
+        _anyAgent = anyAgent,
+        super(_FakeApiServerService());
+
+  final bool _ready;
+  final bool _anyAgent;
+
+  @override
+  bool get isReady => _ready;
+
+  @override
+  bool get hasAnyAgent => _anyAgent;
+
+  @override
+  Future<void> initialize() async {
+    // No-op — do not actually spawn a server process.
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Fake repository
@@ -106,7 +146,10 @@ void main() {
 
   setUp(() {
     fakeRepo = _FakeAgentsRepository();
-    controller = AgentsController(fakeRepo, isLocalServer: true);
+    controller = AgentsController(
+      fakeRepo,
+      _FakeAgentServerController(ready: true, anyAgent: true),
+    );
   });
 
   tearDown(() {
@@ -150,11 +193,14 @@ void main() {
       expect(controller.resumable.first.id, 'resumable');
     });
 
-    test('does not connect when isLocalServer is false', () async {
-      final remoteController = AgentsController(fakeRepo, isLocalServer: false);
-      addTearDown(remoteController.dispose);
+    test('does not connect when agent server is not ready', () async {
+      final notReadyController = AgentsController(
+        fakeRepo,
+        _FakeAgentServerController(ready: false, anyAgent: false),
+      );
+      addTearDown(notReadyController.dispose);
 
-      await remoteController.initialize();
+      await notReadyController.initialize();
 
       expect(fakeRepo.connectCalled, isFalse);
     });

--- a/docs/release/agent_sessions_verification_matrix.md
+++ b/docs/release/agent_sessions_verification_matrix.md
@@ -1,0 +1,118 @@
+# Agent Sessions — Manual Verification Matrix
+
+This checklist covers the five canonical scenarios for the dual-endpoint architecture
+(local agent server on port 4001 + production API at api.vcrcapps.com). Work through
+every scenario on a real macOS machine before merging the `agent-on-production` PR.
+
+**Before you start:**
+- Use a test account or clean workspace — do NOT run scenario 5 against real users' data.
+- Have the latest dev build running (`flutter run -d macos` from `apps/desktop_flutter`).
+- If any scenario fails, file a follow-up issue with reproduction steps and link it here.
+
+---
+
+## Scenario 1 — Happy path on production
+
+**Setup:** User signed in to api.vcrcapps.com. Local agent server running on 4001. Both
+`claude` and `codex` binaries are installed and on PATH.
+
+- [ ] App launches and production data loads normally (tasks, projects, rhythms visible).
+- [ ] Settings → Agent Server row shows **green / running**.
+- [ ] Settings shows `claude`: **installed**, `codex`: **installed**.
+- [ ] Agents view is visible in the sidebar and accessible.
+- [ ] "New Session" dialog lists both **Claude** and **Codex** as options.
+- [ ] Creating a session with Claude spawns a real PTY (terminal output appears in the session panel).
+- [ ] Bubble overlay appears for the active session.
+
+**Expected behavior:** Full feature set available. Both CLIs detected. Sessions create and
+stream output successfully. Bubble overlay is visible for active sessions.
+
+---
+
+## Scenario 2 — Port 4001 already in use
+
+**Setup:** Before launching Rhythm, occupy port 4001:
+```bash
+nc -l 4001 &
+```
+Then launch Rhythm.
+
+- [ ] Production data loads normally (tasks, projects, rhythms visible — confirms production endpoint is unaffected).
+- [ ] Settings → Agent Server row shows **red / failed** with a message indicating the port is in use (e.g. "port in use", "address already in use", or similar).
+- [ ] Bubble overlay is hidden / not visible.
+- [ ] Agents view shows **"Agent server unavailable"** with a link or button to open Settings.
+- [ ] Kill the `nc` process (`kill %1` or find the PID) and click **Retry** in Settings.
+- [ ] After retry, Agent Server row transitions to **green / running** without restarting the app.
+- [ ] Agents view becomes accessible after the server starts.
+
+**Expected behavior:** Production features degrade gracefully when the local agent server
+cannot start. A clear error is surfaced and recovery via Retry works without an app restart.
+
+---
+
+## Scenario 3 — Only Claude installed
+
+**Setup:** Ensure `codex` is not on PATH (uninstall via `brew uninstall codex` or
+temporarily rename the binary). `claude` must still be installed and on PATH.
+
+- [ ] App launches; production data loads normally.
+- [ ] Settings → Agent Server row shows **green / running**.
+- [ ] Settings shows `claude`: **installed**, `codex`: **not installed**.
+- [ ] "New Session" dialog shows **only Claude** as an option (Codex option absent or disabled).
+- [ ] Creating a Claude session spawns a real PTY and streams output.
+- [ ] Bubble overlay works correctly for active Claude sessions.
+
+**Expected behavior:** App gracefully handles a single CLI. No crash or error banner for the
+missing `codex` binary. Session creation and streaming still work for the available CLI.
+
+---
+
+## Scenario 4 — Neither CLI installed
+
+**Setup:** Ensure both `claude` and `codex` are absent from PATH (uninstall or rename both
+binaries).
+
+- [ ] App launches; production data loads normally.
+- [ ] Settings → Agent Server row shows **green / running** (server itself starts fine).
+- [ ] Settings shows `claude`: **not installed**, `codex`: **not installed**.
+- [ ] Settings displays a **warning banner** indicating no supported AI CLI is detected.
+- [ ] Agents view shows the **"No supported AI CLI detected"** empty state (not a crash or blank screen).
+- [ ] Bubble overlay is hidden / not visible (no sessions can be created).
+- [ ] "New Session" button is disabled or absent, or shows an appropriate error if tapped.
+
+**Expected behavior:** The app remains stable and fully functional for non-agent features.
+A clear, actionable empty state guides the user to install a supported CLI.
+
+---
+
+## Scenario 5 — Trigger from production task
+
+**Setup:** User signed in to api.vcrcapps.com with the local agent server running (scenario 1
+conditions). Use a test account so no real user data is affected.
+
+- [ ] Write a row directly to the production `pending_claude_triggers` table, either via SQL
+  (`INSERT INTO pending_claude_triggers ...`) or by triggering a task action in the UI that
+  creates a trigger entry.
+- [ ] Within approximately **10 seconds**, the bubble overlay surfaces the trigger as a
+  **"trigger.fired"** bubble without any manual refresh.
+- [ ] The bubble contains the expected trigger payload / task reference.
+- [ ] After the bubble appears, confirm the corresponding row is **deleted** from the
+  `pending_claude_triggers` table in production (verify via SQL or API query).
+- [ ] No duplicate bubbles appear for the same trigger.
+
+**Expected behavior:** The polling/push mechanism detects new triggers promptly, surfaces
+them in the overlay, and cleans up the source row to prevent redelivery.
+
+---
+
+## Sign-off
+
+| Scenario | Result | Notes / Follow-up issues |
+|----------|--------|--------------------------|
+| 1 — Happy path | | |
+| 2 — Port 4001 in use | | |
+| 3 — Only Claude installed | | |
+| 4 — Neither CLI installed | | |
+| 5 — Trigger from production task | | |
+
+Once all five rows are marked **Pass**, the PR is ready to merge.

--- a/docs/release/hosted_deployment_synology_cloudflare.md
+++ b/docs/release/hosted_deployment_synology_cloudflare.md
@@ -164,6 +164,57 @@ Synology-side requirement:
 
 - a one-time `docker login ghcr.io` with a token that can read the package
 
+## Schema migrations
+
+### How migrations are applied on production
+
+The API server runs `runPostgresBootstrap()` at startup
+(`apps/api_server/src/database/postgres_bootstrap.ts`). Every `ALTER TABLE … ADD
+COLUMN IF NOT EXISTS` statement in that file is idempotent — it is safe to restart
+the container and re-run it against an existing database. New columns are added
+automatically the next time the container starts.
+
+No manual `psql` intervention is required for columns added via `postgres_bootstrap.ts`.
+Simply deploy the new image (follow **Routine update summary** above) and restart.
+
+### Columns added by milestone
+
+| Column | Table | SQL | Added in |
+|--------|-------|-----|----------|
+| `preferred_agent` | `tasks` | `ALTER TABLE tasks ADD COLUMN IF NOT EXISTS preferred_agent TEXT;` | Phase 5 — issue #405 |
+
+#### Applying `preferred_agent` to an existing production database manually
+
+If the container was not restarted after the image containing issue #405 was
+deployed, run the following once via `docker exec`:
+
+```bash
+ssh <user>@<synology-ip>
+sudo docker exec -it rhythm-api psql "$DATABASE_URL" \
+  -c "ALTER TABLE tasks ADD COLUMN IF NOT EXISTS preferred_agent TEXT;"
+```
+
+Or, if using SQLite (legacy single-node deploys):
+
+```bash
+sudo docker exec -it rhythm-api sqlite3 /data/rhythm.db \
+  "ALTER TABLE tasks ADD COLUMN preferred_agent TEXT;"
+```
+
+Verify:
+
+```bash
+# Postgres
+sudo docker exec -it rhythm-api psql "$DATABASE_URL" -c "\d tasks"
+
+# SQLite
+sudo docker exec -it rhythm-api sqlite3 /data/rhythm.db ".schema tasks"
+```
+
+Existing rows will have `preferred_agent = NULL` after the migration. PATCHing a
+task with `{ "preferredAgent": "claude" }` against `https://api.vcrcapps.com`
+should return 200 and persist the value.
+
 ## Notes
 
 - The current production-ready deployment path still assumes SQLite.


### PR DESCRIPTION
## Summary

Six-phase implementation (milestones 51-56) enabling Rhythm's built-in AI agent sessions feature to work while the app points at production (https://api.vcrcapps.com). The local agent server now always runs on localhost:4001 alongside the production API, independent of the user-configured server URL.

## Issues implemented

| # | Title | Commit |
|---|-------|--------|
| #392 | Phase 1.1: Bump local agent server port from 4000 to 4001 | 5b13ad3 |
| #395 | Phase 1.4: Migrate legacy localhost:4001 in ServerConfigService | 4bd8058 |
| #396 | Phase 2.1: Add GET /agents/capabilities endpoint | 0c0a79b |
| #399 | Phase 3.1: AGENT_LOCAL env var bypasses requireAuth on agent routes | 1476604 |
| #400 | Phase 3.2: Drop task FK validation; accept optional taskTitle | 58ec602 |
| #402 | Phase 4.1: Scope claude-triggers by user instead of requireClaudeUser | 2274611 |
| #393 | Phase 1.2: Create AgentServerController | bae2554 |
| #394 | Phase 1.3: Wire AgentServerController and ungate startup splash | 90541ab |
| #401 | Phase 3.3: Spawn local agent server with AGENT_LOCAL=true | f4786d0 |
| #397 | Phase 2.2: AgentServerController fetches and exposes capabilities | 64ddd2c |
| #398 | Phase 2.3: Refactor agent UI capability guards | 59bee81 |
| #405 | Phase 5.1: Apply preferred_agent migration on production Postgres | 4abdca0 |
| #403 | Phase 4.2: Create AgentTriggerWatcher service | 1cb3926 |
| #404 | Phase 4.3: Wire AgentTriggerWatcher into lifecycle | 12dc79a |
| #406 | Phase 5.2: Settings - Agent Server status row + URL hint clarification | b9aa1c7 |
| #407 | Phase 6.1: Manual verification matrix | da43ad5 |
| #408 | Phase 6.2: Update CLAUDE.md with dual-endpoint model | 4442a1f |

## Architecture

**Before:** Agent sessions were gated by serverConfigService.url.startsWith('http://localhost') - only worked when the production URL was set to localhost.

**After:** Two independent servers:
- **Production** (https://api.vcrcapps.com): all app data (tasks, projects, messages, etc.). User-configurable.
- **Local agent server** (http://localhost:4001): always running, managed by AgentServerController. Hosts /agent-sessions, /agents/capabilities, WebSocket gateway. Auth bypassed via AGENT_LOCAL=true. Never touches production data directly.

## Manual Verification Checklist

See docs/release/agent_sessions_verification_matrix.md for the full matrix. Scenarios to test before merging:

- [ ] **Happy path**: Signed in to production, both CLIs installed - Settings shows green, New Session offers Claude + Codex, PTY spawns
- [ ] **Port collision**: nc -l 4001 before launch - production loads, Settings shows red/failed, Retry works
- [ ] **Claude only**: Codex removed - Settings shows claude=installed/codex=not, dialog offers only Claude
- [ ] **No CLIs**: Both removed - Settings green/running, 'No supported AI CLI detected' empty state, no crash
- [ ] **Trigger from production**: Insert row in pending_claude_triggers - bubble surfaces within ~10s, row deleted

## Manual Setup Required

### Production database
The preferred_agent column migration applies **automatically** on next container restart. To apply immediately:

```bash
sudo docker exec -it rhythm-api psql "$DATABASE_URL" \
  -c "ALTER TABLE tasks ADD COLUMN IF NOT EXISTS preferred_agent TEXT;"
```

Generated with Claude Code