### PR TITLE
vbeta.18.25 hotfix: CLI server bundling, cleanup, and diagnostics

### DIFF
--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -122,6 +122,73 @@ jobs:
           test -d "$DEST/node_modules"
           test -f "$DEST/node_modules/better-sqlite3/package.json"
 
+      - name: Smoke-test bundled CLI server
+        shell: bash
+        run: |
+          set -u
+          SCRIPT="apps/desktop_flutter/build/macos/Build/Products/Release/Rhythm.app/Contents/Resources/api_server/dist/server.js"
+          if [ ! -f "$SCRIPT" ]; then
+            echo "::error::Bundled CLI server not found at $SCRIPT"
+            exit 1
+          fi
+          AGENT_LOCAL=true PORT=4002 DB_PATH="$RUNNER_TEMP/smoke.db" NODE_ENV=test node "$SCRIPT" &
+          PID=$!
+          cleanup() {
+            kill $PID 2>/dev/null || true
+            sleep 2
+            kill -9 $PID 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          HEALTH_OK=0
+          HEALTH_BODY=""
+          for i in $(seq 1 60); do
+            if ! kill -0 $PID 2>/dev/null; then
+              echo "::error::Bundled CLI server process exited before /health responded"
+              exit 1
+            fi
+            if HEALTH_BODY=$(curl -fsS http://localhost:4002/health 2>/dev/null); then
+              HEALTH_OK=1
+              break
+            fi
+            perl -e 'select(undef,undef,undef,0.25)'
+          done
+
+          if [ "$HEALTH_OK" -ne 1 ]; then
+            echo "::error::Timed out waiting for /health (15s window)"
+            exit 1
+          fi
+          echo "/health 200: $HEALTH_BODY"
+
+          CAPS_BODY=$(curl -fsS http://localhost:4002/agents/capabilities)
+          CAPS_STATUS=$?
+          if [ $CAPS_STATUS -ne 0 ]; then
+            echo "::error::/agents/capabilities did not return 200"
+            exit 1
+          fi
+          echo "/agents/capabilities 200: $CAPS_BODY"
+
+          printf '%s' "$CAPS_BODY" | node -e '
+            let data = "";
+            process.stdin.on("data", (c) => data += c);
+            process.stdin.on("end", () => {
+              let parsed;
+              try { parsed = JSON.parse(data); } catch (e) {
+                console.error("Response is not valid JSON:", e.message);
+                process.exit(1);
+              }
+              if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+                console.error("Response is not a JSON object");
+                process.exit(1);
+              }
+              if (typeof parsed.claude !== "boolean" || typeof parsed.codex !== "boolean") {
+                console.error("Response missing boolean claude/codex keys:", JSON.stringify(parsed));
+                process.exit(1);
+              }
+              console.log("capabilities OK:", JSON.stringify(parsed));
+            });
+          '
+
       - name: Package macOS artifacts
         working-directory: apps/desktop_flutter
         run: ../../tools/release/package_macos.sh

--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -12,11 +12,6 @@ on:
         required: true
         default: true
         type: boolean
-      use_embedded_api:
-        description: 'Bundle and use the embedded local API instead of the hosted shared API'
-        required: true
-        default: false
-        type: boolean
       release_notes:
         description: 'Optional release notes override'
         required: false
@@ -45,8 +40,6 @@ jobs:
       PCO_APPLICATION_ID: ${{ secrets.PCO_APPLICATION_ID }}
       PCO_SECRET: ${{ secrets.PCO_SECRET }}
       PCO_REDIRECT_URI: ${{ secrets.PCO_REDIRECT_URI }}
-      RHYTHM_SERVER_URL: ${{ inputs.use_embedded_api && 'http://localhost:4000' || 'https://api.vcrcapps.com' }}
-      RHYTHM_USE_EMBEDDED_API: ${{ inputs.use_embedded_api && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -65,8 +58,7 @@ jobs:
           flutter analyze --no-fatal-infos
           flutter test
 
-      - name: Build API server
-        if: ${{ inputs.use_embedded_api }}
+      - name: Build CLI server
         working-directory: apps/api_server
         run: |
           npm install
@@ -80,9 +72,7 @@ jobs:
           flutter build macos --release --config-only \
             --build-name="$RELEASE_VERSION" \
             --build-number="${{ github.run_number }}" \
-            --dart-define=GOOGLE_DESKTOP_CLIENT_ID="$GOOGLE_DESKTOP_CLIENT_ID" \
-            --dart-define=RHYTHM_SERVER_URL="$RHYTHM_SERVER_URL" \
-            --dart-define=RHYTHM_USE_EMBEDDED_API="$RHYTHM_USE_EMBEDDED_API"
+            --dart-define=GOOGLE_DESKTOP_CLIENT_ID="$GOOGLE_DESKTOP_CLIENT_ID"
 
       - name: Build macOS release
         working-directory: apps/desktop_flutter/macos
@@ -102,8 +92,7 @@ jobs:
           tools/release/verify_desktop_oauth_build.sh \
             apps/desktop_flutter/build/macos/Build/Products/Release/Rhythm.app
 
-      - name: Bundle API server into app
-        if: ${{ inputs.use_embedded_api }}
+      - name: Bundle CLI server into app
         working-directory: apps/desktop_flutter
         run: |
           APP="build/macos/Build/Products/Release/Rhythm.app"
@@ -116,14 +105,13 @@ jobs:
             cd "$DEST"
             npm install --omit=dev
           )
-          # Write OAuth secrets into a .env file loaded by the server at runtime
+          # Write OAuth secrets into a .env file loaded by the CLI server at runtime
           printf 'GOOGLE_CLIENT_ID=%s\nGOOGLE_AUTH_CLIENT_ID=%s\nGOOGLE_AUTH_CLIENT_SECRET=%s\nGOOGLE_CLIENT_SECRET=%s\nGOOGLE_REDIRECT_URI=%s\nPCO_APPLICATION_ID=%s\nPCO_SECRET=%s\nPCO_REDIRECT_URI=%s\n' \
             "$GOOGLE_CLIENT_ID" "$GOOGLE_AUTH_CLIENT_ID" "$GOOGLE_AUTH_CLIENT_SECRET" "$GOOGLE_CLIENT_SECRET" "$GOOGLE_REDIRECT_URI" \
             "$PCO_APPLICATION_ID" "$PCO_SECRET" "$PCO_REDIRECT_URI" \
             > "$DEST/.env"
 
-      - name: Verify bundled API payload
-        if: ${{ inputs.use_embedded_api }}
+      - name: Verify bundled CLI server payload
         working-directory: apps/desktop_flutter
         run: |
           DEST="build/macos/Build/Products/Release/Rhythm.app/Contents/Resources/api_server"

--- a/apps/desktop_flutter/README.md
+++ b/apps/desktop_flutter/README.md
@@ -33,31 +33,23 @@ runtime database each time.
 
 For Google Sign-In, the desktop app now expects `GOOGLE_DESKTOP_CLIENT_ID` as a Dart define. The packaged API must trust the same Firebase Apple client ID through `GOOGLE_AUTH_CLIENT_ID`.
 
-## Hosted vs local runtime
+## Runtime architecture
 
-Desktop builds default to hosted API mode and can choose between:
+The desktop app talks to two API servers:
 
-- local embedded API mode
-- hosted API mode
+- **Production API** (hosted at `https://api.vcrcapps.com`) — owns all user-facing data: tasks, projects, rhythms, messages, facilities, users. The URL is configurable at runtime via Settings → Server URL and persisted by `ServerConfigService`.
+- **Local CLI server** (`http://localhost:4001`) — a Node process bundled into the `.app` and spawned at launch by `AgentServerController`. Hosts agent endpoints (`/agent-sessions`, `/agents/capabilities`, `ws://localhost:4001/ws/agents`) and uses local SQLite. Always running; never points at production.
 
-Useful Dart defines:
+There is no longer an "embedded production API" build mode — the previous `RHYTHM_USE_EMBEDDED_API` / `RHYTHM_SERVER_URL` Dart defines have been removed.
 
-- `RHYTHM_SERVER_URL`
-- `RHYTHM_USE_EMBEDDED_API`
-
-Examples:
+Example:
 
 ```bash
-# Hosted/shared environment (default)
 flutter run -d macos \
   --dart-define=GOOGLE_DESKTOP_CLIENT_ID=<desktop-google-client-id>
-
-# Local development
-flutter run -d macos \
-  --dart-define=GOOGLE_DESKTOP_CLIENT_ID=<desktop-google-client-id> \
-  --dart-define=RHYTHM_SERVER_URL=http://localhost:4000 \
-  --dart-define=RHYTHM_USE_EMBEDDED_API=true
 ```
+
+To point at a different production API host during local dev, change it in Settings → Server URL inside the running app.
 
 ## Beta Distribution
 - Use the `Desktop Release` GitHub Actions workflow to build downloadable tester artifacts.

--- a/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
+++ b/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
@@ -31,7 +31,8 @@ class AgentServerController extends ChangeNotifier {
     _capabilities = const {};
     notifyListeners();
 
-    final ok = await _service.start();
+    final result = await _service.start();
+    final ok = result.ok;
 
     _status = ok ? AgentServerStatus.ready : AgentServerStatus.failed;
     if (!ok) {

--- a/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
+++ b/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
@@ -14,12 +14,34 @@ class AgentServerController extends ChangeNotifier {
 
   final ApiServerService _service;
   AgentServerStatus _status = AgentServerStatus.starting;
-  String? _errorMessage;
+  AgentServerFailureReason? _failureReason;
+  String? _stderrTail;
   Map<String, bool> _capabilities = const {};
 
   AgentServerStatus get status => _status;
   bool get isReady => _status == AgentServerStatus.ready;
-  String? get errorMessage => _errorMessage;
+  AgentServerFailureReason? get failureReason => _failureReason;
+  String? get stderrTail => _stderrTail;
+
+  String? get errorMessage {
+    switch (_failureReason) {
+      case AgentServerFailureReason.nodeNotFound:
+        return "Couldn't find Node.js on this Mac. Install Node 20 or newer "
+            'from nodejs.org and click Retry.';
+      case AgentServerFailureReason.bundleNotFound:
+        return 'The CLI server bundle is missing from this Rhythm install. '
+            'Please reinstall Rhythm from the latest release.';
+      case AgentServerFailureReason.spawnThrew:
+        return "Couldn't start the CLI server process. See technical details "
+            'below.';
+      case AgentServerFailureReason.healthCheckTimeout:
+        return "The CLI server started but didn't respond in time. See "
+            'technical details below.';
+      case null:
+        return null;
+    }
+  }
+
   Map<String, bool> get capabilities => _capabilities;
 
   bool isAgentAvailable(String kind) => _capabilities[kind] == true;
@@ -27,20 +49,18 @@ class AgentServerController extends ChangeNotifier {
 
   Future<void> initialize() async {
     _status = AgentServerStatus.starting;
-    _errorMessage = null;
+    _failureReason = null;
+    _stderrTail = null;
     _capabilities = const {};
     notifyListeners();
 
     final result = await _service.start();
-    final ok = result.ok;
-
-    _status = ok ? AgentServerStatus.ready : AgentServerStatus.failed;
-    if (!ok) {
-      _errorMessage = 'Could not start the local agent server.';
-    }
+    _status = result.ok ? AgentServerStatus.ready : AgentServerStatus.failed;
+    _failureReason = result.reason;
+    _stderrTail = result.stderrTail;
     notifyListeners();
 
-    if (ok) {
+    if (result.ok) {
       // Fire-and-forget; failures are non-fatal.
       unawaited(refreshCapabilities());
     }

--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -62,6 +62,7 @@ class _AppShellState extends State<AppShell> with WindowListener {
 
   @override
   void onWindowClose() async {
+    context.read<AgentServerController>().dispose();
     await windowManager.destroy();
   }
 

--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -62,9 +62,6 @@ class _AppShellState extends State<AppShell> with WindowListener {
 
   @override
   void onWindowClose() async {
-    if (ApiServerController.useEmbeddedServer) {
-      context.read<ApiServerController>().dispose();
-    }
     await windowManager.destroy();
   }
 

--- a/apps/desktop_flutter/lib/app/core/server/api_server_controller.dart
+++ b/apps/desktop_flutter/lib/app/core/server/api_server_controller.dart
@@ -9,10 +9,6 @@ class ApiServerController extends ChangeNotifier {
 
   final ApiServerService _service;
   final String serverUrl;
-  static const useEmbeddedServer = bool.fromEnvironment(
-    'RHYTHM_USE_EMBEDDED_API',
-    defaultValue: false,
-  );
   ServerStatus _status = ServerStatus.starting;
   String? _errorMessage;
 
@@ -25,22 +21,11 @@ class ApiServerController extends ChangeNotifier {
     _errorMessage = null;
     notifyListeners();
 
-    if (!useEmbeddedServer) {
-      final ok = await _service.checkHealth(serverUrl);
-      _status = ok ? ServerStatus.ready : ServerStatus.failed;
-      if (!ok) {
-        _errorMessage =
-            'Could not reach the Rhythm server at $serverUrl. Check the hosted API URL and try again.';
-      }
-      notifyListeners();
-      return;
-    }
-
-    final ok = await _service.start();
-
+    final ok = await _service.checkHealth(serverUrl);
     _status = ok ? ServerStatus.ready : ServerStatus.failed;
     if (!ok) {
-      _errorMessage = 'Could not start the embedded Rhythm server.';
+      _errorMessage =
+          'Could not reach the Rhythm server at $serverUrl. Check the hosted API URL and try again.';
     }
     notifyListeners();
   }
@@ -49,9 +34,6 @@ class ApiServerController extends ChangeNotifier {
 
   @override
   void dispose() {
-    if (useEmbeddedServer) {
-      _service.stop();
-    }
     super.dispose();
   }
 }

--- a/apps/desktop_flutter/lib/app/core/server/api_server_service.dart
+++ b/apps/desktop_flutter/lib/app/core/server/api_server_service.dart
@@ -2,11 +2,49 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 
+/// Distinct failure modes for [ApiServerService.start].
+enum AgentServerFailureReason {
+  nodeNotFound,
+  bundleNotFound,
+  spawnThrew,
+  healthCheckTimeout,
+}
+
+/// Result of attempting to start the local agent server.
+typedef AgentServerStartResult = ({
+  bool ok,
+  AgentServerFailureReason? reason,
+  String? stderrTail,
+});
+
 /// Manages the lifecycle of the local Node.js API server process.
 class ApiServerService {
   Process? _process;
 
+  /// Rolling buffer of recent stderr lines from the spawned server process.
+  /// Capped at 20 lines x 200 chars (~4 KB) to bound memory.
+  static const int _stderrBufferMaxLines = 20;
+  static const int _stderrBufferMaxLineChars = 200;
+  final List<String> _stderrBuffer = <String>[];
+
   bool get isRunning => _process != null;
+
+  void _appendStderr(String line) {
+    final trimmed =
+        line.endsWith('\n') ? line.substring(0, line.length - 1) : line;
+    final capped = trimmed.length > _stderrBufferMaxLineChars
+        ? trimmed.substring(0, _stderrBufferMaxLineChars)
+        : trimmed;
+    _stderrBuffer.add(capped);
+    if (_stderrBuffer.length > _stderrBufferMaxLines) {
+      _stderrBuffer.removeRange(
+        0,
+        _stderrBuffer.length - _stderrBufferMaxLines,
+      );
+    }
+  }
+
+  String _stderrTail() => _stderrBuffer.join('\n');
 
   Future<bool> checkHealth(String baseUrl) async {
     final normalized = baseUrl.trimRight().replaceAll(RegExp(r'/$'), '');
@@ -22,24 +60,35 @@ class ApiServerService {
   }
 
   /// Finds the node binary, starts the server process, and waits for it to
-  /// become healthy. Returns true if the server started successfully.
-  Future<bool> start() async {
+  /// become healthy. Returns a structured result describing success or the
+  /// specific failure mode encountered.
+  Future<AgentServerStartResult> start() async {
+    _stderrBuffer.clear();
+
     final existing = await _isServerReady();
     if (existing) {
       stdout.writeln('[ApiServerService] Reusing existing server on :4001.');
-      return true;
+      return (ok: true, reason: null, stderrTail: null);
     }
 
     final node = await _findNode();
     if (node == null) {
       stderr.writeln('[ApiServerService] Could not find node binary.');
-      return false;
+      return (
+        ok: false,
+        reason: AgentServerFailureReason.nodeNotFound,
+        stderrTail: null,
+      );
     }
 
     final serverInfo = await _findServer(node);
     if (serverInfo == null) {
       stderr.writeln('[ApiServerService] Could not locate api_server.');
-      return false;
+      return (
+        ok: false,
+        reason: AgentServerFailureReason.bundleNotFound,
+        stderrTail: null,
+      );
     }
 
     final dbPath = _dbPath();
@@ -48,31 +97,49 @@ class ApiServerService {
     );
     stdout.writeln('[ApiServerService] DB path: $dbPath');
 
-    _process = await Process.start(
-      serverInfo.executable,
-      serverInfo.args,
-      workingDirectory: serverInfo.workingDir,
-      environment: {
-        ...Platform.environment,
-        'PORT': '4001',
-        'DB_PATH': dbPath,
-        'AGENT_LOCAL': 'true',
-      },
-    );
+    try {
+      _process = await Process.start(
+        serverInfo.executable,
+        serverInfo.args,
+        workingDirectory: serverInfo.workingDir,
+        environment: {
+          ...Platform.environment,
+          'PORT': '4001',
+          'DB_PATH': dbPath,
+          'AGENT_LOCAL': 'true',
+        },
+      );
+    } catch (e) {
+      stderr.writeln('[ApiServerService] Process.start threw: $e');
+      return (
+        ok: false,
+        reason: AgentServerFailureReason.spawnThrew,
+        stderrTail: e.toString(),
+      );
+    }
 
     _process!.stdout
         .transform(const SystemEncoding().decoder)
         .listen((line) => stdout.write('[api_server] $line'));
-    _process!.stderr
-        .transform(const SystemEncoding().decoder)
-        .listen((line) => stderr.write('[api_server] $line'));
+    _process!.stderr.transform(const SystemEncoding().decoder).listen((line) {
+      stderr.write('[api_server] $line');
+      _appendStderr(line);
+    });
 
     _process!.exitCode.then((code) {
       stdout.writeln('[ApiServerService] Server exited with code $code');
       _process = null;
     });
 
-    return _waitForReady();
+    final ready = await _waitForReady();
+    if (ready) {
+      return (ok: true, reason: null, stderrTail: null);
+    }
+    return (
+      ok: false,
+      reason: AgentServerFailureReason.healthCheckTimeout,
+      stderrTail: _stderrTail(),
+    );
   }
 
   /// Terminates the server process.

--- a/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
+++ b/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
@@ -29,7 +29,7 @@ class _AgentsViewState extends State<AgentsView> {
 
     // Capability guard — server failed.
     if (agentServerController.status == AgentServerStatus.failed) {
-      return const _AgentServerUnavailable();
+      return const AgentServerUnavailable();
     }
 
     // Capability guard — server ok but no CLI installed.
@@ -77,11 +77,14 @@ class _AgentsViewState extends State<AgentsView> {
 // Capability guard cards
 // ---------------------------------------------------------------------------
 
-class _AgentServerUnavailable extends StatelessWidget {
-  const _AgentServerUnavailable();
+class AgentServerUnavailable extends StatelessWidget {
+  const AgentServerUnavailable({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final controller = context.watch<AgentServerController>();
+    final isStarting = controller.status == AgentServerStatus.starting;
+
     return Scaffold(
       backgroundColor: context.rhythm.canvas,
       body: Center(
@@ -120,6 +123,46 @@ class _AgentServerUnavailable extends StatelessWidget {
                   fontSize: 13,
                   color: context.rhythm.textSecondary,
                   height: 1.45,
+                ),
+              ),
+              const SizedBox(height: 16),
+              OutlinedButton(
+                onPressed: isStarting
+                    ? null
+                    : () => context.read<AgentServerController>().retry(),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: context.rhythm.accent,
+                  side: BorderSide(color: context.rhythm.border),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 18,
+                    vertical: 10,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(RhythmRadius.md),
+                  ),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (isStarting) ...[
+                      SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: context.rhythm.accent,
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                    ],
+                    const Text(
+                      'Retry',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],

--- a/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
+++ b/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
@@ -1,9 +1,13 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../app/core/agents/agent_server_controller.dart';
+import '../../../app/core/server/api_server_service.dart';
 import '../../../app/core/auth/auth_session_service.dart';
 import '../../../app/core/auth/auth_user.dart';
 import '../../../app/core/services/server_config_service.dart';
@@ -904,8 +908,10 @@ class _AgentServerSection extends StatelessWidget {
           ),
           child: switch (controller.status) {
             AgentServerStatus.starting => const _AgentServerStarting(),
-            AgentServerStatus.failed => _AgentServerFailed(
+            AgentServerStatus.failed => AgentServerFailed(
                 errorMessage: controller.errorMessage,
+                failureReason: controller.failureReason,
+                stderrTail: controller.stderrTail,
                 onRetry: controller.retry,
               ),
             AgentServerStatus.ready => _AgentServerReady(
@@ -946,17 +952,59 @@ class _AgentServerStarting extends StatelessWidget {
   }
 }
 
-class _AgentServerFailed extends StatelessWidget {
-  const _AgentServerFailed({
+class AgentServerFailed extends StatefulWidget {
+  const AgentServerFailed({
+    super.key,
     required this.errorMessage,
     required this.onRetry,
+    this.failureReason,
+    this.stderrTail,
   });
 
   final String? errorMessage;
   final VoidCallback onRetry;
+  final AgentServerFailureReason? failureReason;
+  final String? stderrTail;
+
+  @override
+  State<AgentServerFailed> createState() => AgentServerFailedState();
+}
+
+class AgentServerFailedState extends State<AgentServerFailed> {
+  Future<void> _copyDiagnostics(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
+    String version = 'unknown';
+    try {
+      final info = await PackageInfo.fromPlatform();
+      version = '${info.version}+${info.buildNumber}';
+    } catch (_) {
+      // PackageInfo can fail in tests; fall back to "unknown".
+    }
+    final reason = widget.failureReason?.name ?? 'unknown';
+    final body = StringBuffer()
+      ..writeln('Rhythm CLI server diagnostics')
+      ..writeln('----------------------------')
+      ..writeln('Reason: $reason')
+      ..writeln('Message: ${widget.errorMessage ?? ''}')
+      ..writeln('App version: $version')
+      ..writeln('macOS: ${Platform.operatingSystemVersion}')
+      ..writeln('Time: ${DateTime.now().toIso8601String()}')
+      ..writeln()
+      ..writeln('Stderr tail:')
+      ..writeln(widget.stderrTail ?? '(none)');
+    await Clipboard.setData(ClipboardData(text: body.toString()));
+    if (!mounted) return;
+    messenger.showSnackBar(
+      const SnackBar(
+        content: Text('Diagnostics copied to clipboard'),
+        duration: Duration(seconds: 2),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
+    final tail = widget.stderrTail;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -973,17 +1021,70 @@ class _AgentServerFailed extends StatelessWidget {
             ),
           ],
         ),
-        if (errorMessage != null) ...[
+        if (widget.errorMessage != null) ...[
           const SizedBox(height: 6),
           Text(
-            errorMessage!,
+            widget.errorMessage!,
             style: TextStyle(fontSize: 13, color: context.rhythm.danger),
           ),
         ],
+        if (tail != null) ...[
+          const SizedBox(height: 8),
+          Theme(
+            data: Theme.of(context).copyWith(
+              dividerColor: Colors.transparent,
+            ),
+            child: ExpansionTile(
+              tilePadding: EdgeInsets.zero,
+              childrenPadding: const EdgeInsets.only(top: 4, bottom: 4),
+              title: Text(
+                'Show technical details',
+                style: TextStyle(
+                  fontSize: 13,
+                  color: context.rhythm.textSecondary,
+                ),
+              ),
+              children: [
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(10),
+                  decoration: BoxDecoration(
+                    color: context.rhythm.surfaceMuted,
+                    borderRadius: BorderRadius.circular(RhythmRadius.md),
+                    border: Border.all(color: context.rhythm.borderSubtle),
+                  ),
+                  child: SelectableText(
+                    tail,
+                    style: TextStyle(
+                      fontFamily: 'monospace',
+                      fontFamilyFallback: const [
+                        'Menlo',
+                        'Monaco',
+                        'Courier',
+                      ],
+                      fontSize: 12,
+                      color: context.rhythm.textPrimary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
         const SizedBox(height: 12),
-        OutlinedButton(
-          onPressed: onRetry,
-          child: const Text('Retry'),
+        Row(
+          children: [
+            OutlinedButton(
+              onPressed: widget.onRetry,
+              child: const Text('Retry'),
+            ),
+            const SizedBox(width: 8),
+            OutlinedButton.icon(
+              onPressed: () => _copyDiagnostics(context),
+              icon: const Icon(Icons.copy, size: 16),
+              label: const Text('Copy diagnostics'),
+            ),
+          ],
         ),
       ],
     );

--- a/apps/desktop_flutter/test/agent_server_failed_test.dart
+++ b/apps/desktop_flutter/test/agent_server_failed_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:rhythm_desktop/app/core/server/api_server_service.dart';
+import 'package:rhythm_desktop/features/settings/views/settings_view.dart';
+
+Widget _wrap(Widget child) {
+  return MaterialApp(home: Scaffold(body: child));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  PackageInfo.setMockInitialValues(
+    appName: 'Rhythm',
+    packageName: 'com.example.rhythm',
+    version: '1.2.3',
+    buildNumber: '42',
+    buildSignature: '',
+  );
+
+  group('AgentServerFailed widget', () {
+    testWidgets('renders header and message with no failure reason',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        AgentServerFailed(
+          errorMessage: 'Generic failure',
+          onRetry: () {},
+        ),
+      ));
+
+      expect(find.text('Agent server failed to start'), findsOneWidget);
+      expect(find.text('Generic failure'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+      expect(find.text('Copy diagnostics'), findsOneWidget);
+      expect(find.text('Show technical details'), findsNothing);
+    });
+
+    for (final reason in AgentServerFailureReason.values) {
+      testWidgets('renders for reason ${reason.name}', (tester) async {
+        final hasTail = reason == AgentServerFailureReason.healthCheckTimeout ||
+            reason == AgentServerFailureReason.spawnThrew;
+        await tester.pumpWidget(_wrap(
+          AgentServerFailed(
+            errorMessage: 'msg-${reason.name}',
+            failureReason: reason,
+            stderrTail: hasTail ? 'STDERR_TAIL_FOR_${reason.name}' : null,
+            onRetry: () {},
+          ),
+        ));
+
+        expect(find.text('Agent server failed to start'), findsOneWidget);
+        expect(find.text('msg-${reason.name}'), findsOneWidget);
+        expect(find.text('Retry'), findsOneWidget);
+        expect(find.text('Copy diagnostics'), findsOneWidget);
+
+        if (hasTail) {
+          expect(find.text('Show technical details'), findsOneWidget);
+          // Default collapsed: stderr text should not be visible yet.
+          expect(find.text('STDERR_TAIL_FOR_${reason.name}'), findsNothing);
+          await tester.tap(find.text('Show technical details'));
+          await tester.pumpAndSettle();
+          expect(find.text('STDERR_TAIL_FOR_${reason.name}'), findsOneWidget);
+        } else {
+          expect(find.text('Show technical details'), findsNothing);
+        }
+      });
+    }
+
+    testWidgets('Copy diagnostics writes documented multi-line block',
+        (tester) async {
+      String? captured;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          captured = (call.arguments as Map)['text'] as String?;
+        }
+        return null;
+      });
+
+      await tester.pumpWidget(_wrap(
+        AgentServerFailed(
+          errorMessage: 'health check timeout',
+          failureReason: AgentServerFailureReason.healthCheckTimeout,
+          stderrTail: 'EADDRINUSE :4001',
+          onRetry: () {},
+        ),
+      ));
+
+      await tester.tap(find.text('Copy diagnostics'));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      final text = captured!;
+      expect(text, contains('Rhythm CLI server diagnostics'));
+      expect(text, contains('----------------------------'));
+      expect(text, contains('Reason: healthCheckTimeout'));
+      expect(text, contains('Message: health check timeout'));
+      expect(text, contains('App version: '));
+      expect(text, contains('macOS: '));
+      expect(text, contains('Time: '));
+      expect(text, contains('Stderr tail:'));
+      expect(text, contains('EADDRINUSE :4001'));
+
+      // Snackbar appears.
+      expect(find.text('Diagnostics copied to clipboard'), findsOneWidget);
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    testWidgets('Copy diagnostics writes "(none)" when stderr is null',
+        (tester) async {
+      String? captured;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          captured = (call.arguments as Map)['text'] as String?;
+        }
+        return null;
+      });
+
+      await tester.pumpWidget(_wrap(
+        AgentServerFailed(
+          errorMessage: 'bundle missing',
+          failureReason: AgentServerFailureReason.bundleNotFound,
+          stderrTail: null,
+          onRetry: () {},
+        ),
+      ));
+
+      await tester.tap(find.text('Copy diagnostics'));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!, contains('Reason: bundleNotFound'));
+      expect(captured!, contains('Stderr tail:'));
+      expect(captured!, contains('(none)'));
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+  });
+}

--- a/apps/desktop_flutter/test/features/agents/agent_server_controller_test.dart
+++ b/apps/desktop_flutter/test/features/agents/agent_server_controller_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rhythm_desktop/app/core/agents/agent_server_controller.dart';
+import 'package:rhythm_desktop/app/core/server/api_server_service.dart';
+
+/// Fake [ApiServerService] that returns a pre-canned [AgentServerStartResult].
+class _FakeApiServerService implements ApiServerService {
+  _FakeApiServerService(this._result);
+
+  final AgentServerStartResult _result;
+
+  @override
+  Future<AgentServerStartResult> start() async => _result;
+
+  @override
+  void stop() {}
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('AgentServerController failure surfacing', () {
+    test('success path leaves failureReason, stderrTail, errorMessage null',
+        () async {
+      final controller = AgentServerController(
+        _FakeApiServerService(
+          (ok: true, reason: null, stderrTail: null),
+        ),
+      );
+
+      await controller.initialize();
+      // Capability fetch happens fire-and-forget against localhost:4001;
+      // since this test is unit-only, the network call may fail silently.
+      // We only assert the failure-related fields here.
+
+      expect(controller.failureReason, isNull);
+      expect(controller.stderrTail, isNull);
+      expect(controller.errorMessage, isNull);
+      expect(controller.status, AgentServerStatus.ready);
+    });
+
+    test('nodeNotFound maps to install-Node guidance', () async {
+      final controller = AgentServerController(
+        _FakeApiServerService(
+          (
+            ok: false,
+            reason: AgentServerFailureReason.nodeNotFound,
+            stderrTail: null,
+          ),
+        ),
+      );
+      await controller.initialize();
+
+      expect(controller.failureReason, AgentServerFailureReason.nodeNotFound);
+      expect(controller.stderrTail, isNull);
+      expect(
+        controller.errorMessage,
+        "Couldn't find Node.js on this Mac. Install Node 20 or newer "
+        'from nodejs.org and click Retry.',
+      );
+      expect(controller.status, AgentServerStatus.failed);
+    });
+
+    test('bundleNotFound maps to reinstall guidance', () async {
+      final controller = AgentServerController(
+        _FakeApiServerService(
+          (
+            ok: false,
+            reason: AgentServerFailureReason.bundleNotFound,
+            stderrTail: null,
+          ),
+        ),
+      );
+      await controller.initialize();
+
+      expect(controller.failureReason, AgentServerFailureReason.bundleNotFound);
+      expect(
+        controller.errorMessage,
+        'The CLI server bundle is missing from this Rhythm install. '
+        'Please reinstall Rhythm from the latest release.',
+      );
+    });
+
+    test('spawnThrew exposes stderrTail and technical-details message',
+        () async {
+      final controller = AgentServerController(
+        _FakeApiServerService(
+          (
+            ok: false,
+            reason: AgentServerFailureReason.spawnThrew,
+            stderrTail: 'spawn EACCES',
+          ),
+        ),
+      );
+      await controller.initialize();
+
+      expect(controller.failureReason, AgentServerFailureReason.spawnThrew);
+      expect(controller.stderrTail, 'spawn EACCES');
+      expect(
+        controller.errorMessage,
+        "Couldn't start the CLI server process. See technical details below.",
+      );
+    });
+
+    test('healthCheckTimeout exposes stderrTail and timeout message', () async {
+      final controller = AgentServerController(
+        _FakeApiServerService(
+          (
+            ok: false,
+            reason: AgentServerFailureReason.healthCheckTimeout,
+            stderrTail: 'listening on :4001',
+          ),
+        ),
+      );
+      await controller.initialize();
+
+      expect(
+        controller.failureReason,
+        AgentServerFailureReason.healthCheckTimeout,
+      );
+      expect(controller.stderrTail, 'listening on :4001');
+      expect(
+        controller.errorMessage,
+        "The CLI server started but didn't respond in time. See technical "
+        'details below.',
+      );
+    });
+  });
+}

--- a/apps/desktop_flutter/test/features/agents/agent_server_unavailable_test.dart
+++ b/apps/desktop_flutter/test/features/agents/agent_server_unavailable_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:rhythm_desktop/app/core/agents/agent_server_controller.dart';
+import 'package:rhythm_desktop/app/core/server/api_server_service.dart';
+import 'package:rhythm_desktop/features/agents/views/agents_view.dart';
+
+/// Fake [ApiServerService] used to construct an [AgentServerController]
+/// without spawning real processes.
+class _FakeApiServerService implements ApiServerService {
+  @override
+  Future<AgentServerStartResult> start() async =>
+      (ok: false, reason: null, stderrTail: null);
+
+  @override
+  void stop() {}
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Subclass of [AgentServerController] that lets tests drive `status` and
+/// counts calls to `retry()` without going through `initialize()`'s real
+/// network/process work.
+class _FakeAgentServerController extends AgentServerController {
+  _FakeAgentServerController(super.service, AgentServerStatus initialStatus)
+      : _fakeStatus = initialStatus;
+
+  AgentServerStatus _fakeStatus;
+  int retryCalls = 0;
+
+  @override
+  AgentServerStatus get status => _fakeStatus;
+
+  void setStatus(AgentServerStatus next) {
+    _fakeStatus = next;
+    notifyListeners();
+  }
+
+  @override
+  Future<void> retry() async {
+    retryCalls += 1;
+    setStatus(AgentServerStatus.starting);
+  }
+
+  @override
+  void dispose() {
+    // Skip super.dispose() — it would call _service.stop(), which is fine
+    // for the fake but we also avoid touching the real teardown path.
+    super.dispose();
+  }
+}
+
+Widget _wrap(AgentServerController controller) {
+  return ChangeNotifierProvider<AgentServerController>.value(
+    value: controller,
+    child: const MaterialApp(home: AgentServerUnavailable()),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AgentServerUnavailable', () {
+    testWidgets('renders Retry button and check-Settings copy', (tester) async {
+      final controller = _FakeAgentServerController(
+        _FakeApiServerService(),
+        AgentServerStatus.failed,
+      );
+      await tester.pumpWidget(_wrap(controller));
+
+      expect(find.text('Agent server unavailable'), findsOneWidget);
+      expect(
+        find.textContaining('Settings'),
+        findsOneWidget,
+      );
+      expect(find.text('Retry'), findsOneWidget);
+      // Copy diagnostics belongs to Settings; must NOT appear here.
+      expect(find.text('Copy diagnostics'), findsNothing);
+    });
+
+    testWidgets('tapping Retry invokes controller.retry()', (tester) async {
+      final controller = _FakeAgentServerController(
+        _FakeApiServerService(),
+        AgentServerStatus.failed,
+      );
+      await tester.pumpWidget(_wrap(controller));
+
+      expect(controller.retryCalls, 0);
+      await tester.tap(find.text('Retry'));
+      await tester.pump();
+
+      expect(controller.retryCalls, 1);
+    });
+
+    testWidgets('disables button and shows spinner during starting',
+        (tester) async {
+      final controller = _FakeAgentServerController(
+        _FakeApiServerService(),
+        AgentServerStatus.starting,
+      );
+      await tester.pumpWidget(_wrap(controller));
+
+      // Spinner is present.
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      // Button is disabled — onPressed is null.
+      final button = tester.widget<OutlinedButton>(find.byType(OutlinedButton));
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('reactively transitions when controller status changes',
+        (tester) async {
+      final controller = _FakeAgentServerController(
+        _FakeApiServerService(),
+        AgentServerStatus.failed,
+      );
+      await tester.pumpWidget(_wrap(controller));
+
+      // Initially failed — button is enabled, no spinner.
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      var button = tester.widget<OutlinedButton>(find.byType(OutlinedButton));
+      expect(button.onPressed, isNotNull);
+
+      // Flip to starting.
+      controller.setStatus(AgentServerStatus.starting);
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      button = tester.widget<OutlinedButton>(find.byType(OutlinedButton));
+      expect(button.onPressed, isNull);
+    });
+  });
+}

--- a/apps/desktop_flutter/test/features/agents/agent_trigger_watcher_test.dart
+++ b/apps/desktop_flutter/test/features/agents/agent_trigger_watcher_test.dart
@@ -22,7 +22,8 @@ import 'package:rhythm_desktop/features/agents/repositories/agents_repository.da
 
 class _FakeApiServerService extends ApiServerService {
   @override
-  Future<bool> start() async => true;
+  Future<AgentServerStartResult> start() async =>
+      (ok: true, reason: null, stderrTail: null);
   @override
   Future<void> stop() async {}
 }

--- a/apps/desktop_flutter/test/features/agents/agents_controller_test.dart
+++ b/apps/desktop_flutter/test/features/agents/agents_controller_test.dart
@@ -15,7 +15,8 @@ import 'package:rhythm_desktop/features/agents/repositories/agents_repository.da
 
 class _FakeApiServerService extends ApiServerService {
   @override
-  Future<bool> start() async => true;
+  Future<AgentServerStartResult> start() async =>
+      (ok: true, reason: null, stderrTail: null);
 
   @override
   Future<void> stop() async {}

--- a/docs/release/agent_sessions_verification_matrix.md
+++ b/docs/release/agent_sessions_verification_matrix.md
@@ -1,20 +1,52 @@
 # Agent Sessions — Manual Verification Matrix
 
 This checklist covers the five canonical scenarios for the dual-endpoint architecture
-(local agent server on port 4001 + production API at api.vcrcapps.com). Work through
-every scenario on a real macOS machine before merging the `agent-on-production` PR.
+(the bundled **CLI server** — the local Node process on port 4001 that talks to
+`claude`/`codex` — plus the hosted production API on Synology at api.vcrcapps.com).
+The bundled CLI server is a separate artifact from the hosted production API and
+must be verified inside the packaged `.app`, not from a dev checkout. Work through
+every scenario on a real macOS machine before publishing each release.
 
 **Before you start:**
 - Use a test account or clean workspace — do NOT run scenario 5 against real users' data.
-- Have the latest dev build running (`flutter run -d macos` from `apps/desktop_flutter`).
+- Download the **signed DMG** from the GitHub Release draft (or the local artifact
+  produced by `tools/release/sign_and_notarize_macos.sh`). Do not verify against
+  `flutter run -d macos` — `flutter run` resolves `apps/api_server` from the source
+  tree and will mask bundling regressions that only appear in the packaged `.app`.
+- Install `Rhythm.app` to `/Applications/` on a **clean macOS account** — not the
+  developer account that built the app. Gatekeeper attestation differs between the
+  signing account and a fresh user, so a clean account is the only honest test.
+- Launch `Rhythm.app` from `/Applications/` (Finder → Applications → Rhythm). Do
+  not launch from the DMG mount or a build directory.
 - If any scenario fails, file a follow-up issue with reproduction steps and link it here.
+
+---
+
+## Bundle existence pre-check
+
+Before working through any scenario, confirm the CLI server actually shipped inside
+the `.app`:
+
+```bash
+ls /Applications/Rhythm.app/Contents/Resources/api_server/dist/server.js
+```
+
+- [ ] The file exists and `ls` returns a path (not an error).
+
+**If the file is missing: STOP.** Do not publish this release. The CI smoke test
+should have caught this; the bundling workflow is broken. File a release-blocking
+issue, link it to this run, and halt verification until the bundle is fixed and a
+new DMG is produced.
 
 ---
 
 ## Scenario 1 — Happy path on production
 
 **Setup:** User signed in to api.vcrcapps.com. Local agent server running on 4001. Both
-`claude` and `codex` binaries are installed and on PATH.
+`claude` and `codex` binaries are installed and on PATH. On first launch, Settings →
+Agent Server should reach the green/running state within 5 seconds. If it's still
+spinning after 10 seconds or shows red, capture the **Copy diagnostics** output
+before retrying.
 
 - [ ] App launches and production data loads normally (tasks, projects, rhythms visible).
 - [ ] Settings → Agent Server row shows **green / running**.


### PR DESCRIPTION
## Summary

Restores the bundled CLI server in macOS releases (regression in vbeta.18.24), removes vestigial `useEmbeddedServer` plumbing, and adds structured failure diagnostics so future server-startup bugs are debuggable from the app itself.

## Issues closed

| # | Title | Commit |
|---|-------|--------|
| #419 | CI: always bundle CLI server, drop `use_embedded_api` gates | db15727 |
| #420 | CI: smoke-test bundled CLI server before publishing release | c5db75e |
| #421 | Flutter: remove vestigial `useEmbeddedServer` dead code | 98b4e3d |
| #422 | Flutter: dispose `AgentServerController` on window close | 7cec8e2 |
| #423 | `ApiServerService`: structured failure reasons + stderr capture | 8765259 |
| #424 | `AgentServerController`: expose `failureReason` and `stderrTail` | e043166 |
| #425 | Settings: structured failure UI + Copy diagnostics on failed card | f1ef3ea |
| #426 | Agents view: inline Retry on agent-server-unavailable card | 2950b75 |
| #427 | Docs: verification matrix uses signed DMG | 1949212 |

#428 (release cut) is intentionally deferred — per `CLAUDE.md`, the release is triggered after the user merges and confirms testing on the signed DMG.

## Test plan

- [ ] `flutter run -d macos` from `apps/desktop_flutter` — app launches, Settings → Agent Server reaches green
- [ ] Force a failure (rename `apps/api_server/dist/server.js` in a built `.app`) — Settings → Agent Server shows the new structured message + Copy diagnostics button writes the documented multi-line block
- [ ] Agents view: when server is unavailable, the inline Retry button works and disables/spins during `starting`
- [ ] Close window — `pgrep -f 'api_server/dist/server.js'` empty within 2s
- [ ] Trigger `desktop_release.yml` for vbeta.18.25 — new `Smoke-test bundled CLI server` step passes
- [ ] Walk through the verification matrix using the signed DMG (per docs/release/agent_sessions_verification_matrix.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)