### PR TITLE
fix(release): sign node-pty spawn-helper binaries

### DIFF
--- a/tools/release/sign_and_notarize_macos.sh
+++ b/tools/release/sign_and_notarize_macos.sh
@@ -84,14 +84,15 @@ sed "s/\$(AppIdentifierPrefix)/${APPLE_TEAM_ID}./" "${ENTITLEMENTS_PATH}" > "${P
 # codesign --deep does NOT propagate --options runtime to nested items, so we
 # must sign each one explicitly before signing the top-level bundle.
 # This includes .node native addons (e.g. better_sqlite3.node, pty.node from
-# node-pty) bundled in Contents/Resources — Apple requires all native binaries
-# to be signed.
+# node-pty) and plain Mach-O helper executables (e.g. node-pty's spawn-helper)
+# bundled in Contents/Resources — Apple requires all native binaries to be
+# signed with Hardened Runtime and a secure timestamp.
 while IFS= read -r -d '' item; do
   codesign --force --options runtime --timestamp \
     --sign "${IDENTITY_SHA}" \
     "${item}"
 done < <(find "${APP_PATH}/Contents" \
-  \( -name "*.framework" -o -name "*.dylib" -o -name "*.so" -o -name "*.node" \) \
+  \( -name "*.framework" -o -name "*.dylib" -o -name "*.so" -o -name "*.node" -o -name "spawn-helper" \) \
   -print0 | sort -rz)
 
 codesign --force --options runtime --timestamp \


### PR DESCRIPTION
## Summary
- Latest [Desktop Release run](https://github.com/ajhochy/Rhythm/actions/runs/25521655243) failed at notarization with 6 errors against `node-pty/prebuilds/{darwin-x64,darwin-arm64}/spawn-helper`: not signed, no secure timestamp, no hardened runtime.
- The signing loop in `tools/release/sign_and_notarize_macos.sh` only matched `.framework/.dylib/.so/.node`, so node-pty's plain Mach-O helper executables slipped through.
- Added `spawn-helper` to the find expression so it gets the same `--options runtime --timestamp` signature as the other native binaries.

## Test plan
- [ ] Trigger Desktop Release workflow with an incremented tag and confirm notarization passes.
