### PR TITLE
Calendar → Reservation flow (#412–#417) + agent notifications

### DIFF
--- a/apps/api_server/src/__tests__/facilities_automation_cleanup.test.ts
+++ b/apps/api_server/src/__tests__/facilities_automation_cleanup.test.ts
@@ -1,0 +1,199 @@
+import Database from 'better-sqlite3';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { setDb } from '../database/db';
+import { runMigrations } from '../database/migrations';
+import { FacilitiesController } from '../controllers/facilities_controller';
+import { FacilitiesRepository } from '../repositories/facilities_repository';
+import { UsersRepository } from '../repositories/users_repository';
+import type { Request, Response, NextFunction } from 'express';
+
+describe('Automation reservation cleanup', () => {
+  let repo: FacilitiesRepository;
+  let usersRepo: UsersRepository;
+  let ownerId: number;
+
+  beforeEach(async () => {
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    db.pragma('journal_mode = WAL');
+    runMigrations(db);
+    setDb(db);
+    repo = new FacilitiesRepository();
+    usersRepo = new UsersRepository();
+    const owner = usersRepo.create({ name: 'Alice', email: 'a@example.com' });
+    ownerId = owner.id;
+  });
+
+  async function makeAutomationReservation(
+    facilityId: number,
+    eventId: string,
+    startTime: string,
+    endTime: string,
+  ) {
+    return repo.insertSingleReservationAsync({
+      facility_id: facilityId,
+      title: `Auto ${eventId}`,
+      requester_name: 'Alice',
+      requester_user_id: ownerId,
+      created_by_user_id: ownerId,
+      start_time: startTime,
+      end_time: endTime,
+      external_event_id: eventId,
+      external_source: 'automation_rule',
+    });
+  }
+
+  test('previewAutomationReservationsAsync groups by facility', async () => {
+    const f1 = await repo.createAsync({ name: 'Workroom' });
+    const f2 = await repo.createAsync({ name: 'Conf B' });
+    await makeAutomationReservation(f1.id, 'e1', '2026-05-15T14:00:00Z', '2026-05-15T15:00:00Z');
+    await makeAutomationReservation(f1.id, 'e2', '2026-05-16T14:00:00Z', '2026-05-16T15:00:00Z');
+    await makeAutomationReservation(f2.id, 'e3', '2026-05-17T14:00:00Z', '2026-05-17T15:00:00Z');
+
+    const preview = await repo.previewAutomationReservationsAsync({});
+    expect(preview.total).toBe(3);
+    expect(preview.byFacility).toHaveLength(2);
+    const work = preview.byFacility.find((x) => x.facilityName === 'Workroom');
+    expect(work?.count).toBe(2);
+  });
+
+  test('deleteAutomationReservationsAsync deletes only automation_rule rows', async () => {
+    const f1 = await repo.createAsync({ name: 'Workroom' });
+    await makeAutomationReservation(f1.id, 'e1', '2026-05-15T14:00:00Z', '2026-05-15T15:00:00Z');
+    // a manual reservation that should survive
+    await repo.insertSingleReservationAsync({
+      facility_id: f1.id,
+      title: 'Manual booking',
+      requester_name: 'Alice',
+      requester_user_id: ownerId,
+      created_by_user_id: ownerId,
+      start_time: '2026-05-20T14:00:00Z',
+      end_time: '2026-05-20T15:00:00Z',
+      external_event_id: 'manual-1',
+      external_source: 'manual',
+    });
+
+    const result = await repo.deleteAutomationReservationsAsync({});
+    expect(result.deleted).toBe(1);
+
+    const remaining = await repo.findReservationsByFacilityAsync(f1.id);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].title).toBe('Manual booking');
+  });
+
+  test('deleteAutomationReservationsAsync respects facilityId filter', async () => {
+    const f1 = await repo.createAsync({ name: 'A' });
+    const f2 = await repo.createAsync({ name: 'B' });
+    await makeAutomationReservation(f1.id, 'e1', '2026-05-15T14:00:00Z', '2026-05-15T15:00:00Z');
+    await makeAutomationReservation(f2.id, 'e2', '2026-05-15T14:00:00Z', '2026-05-15T15:00:00Z');
+
+    const result = await repo.deleteAutomationReservationsAsync({ facilityId: f1.id });
+    expect(result.deleted).toBe(1);
+
+    const remaining = await repo.previewAutomationReservationsAsync({});
+    expect(remaining.total).toBe(1);
+    expect(remaining.byFacility[0].facilityName).toBe('B');
+  });
+
+  test('deleteAutomationReservationsAsync respects time range filters', async () => {
+    const f1 = await repo.createAsync({ name: 'A' });
+    await makeAutomationReservation(f1.id, 'past', '2026-04-01T14:00:00Z', '2026-04-01T15:00:00Z');
+    await makeAutomationReservation(f1.id, 'mid', '2026-05-15T14:00:00Z', '2026-05-15T15:00:00Z');
+    await makeAutomationReservation(f1.id, 'future', '2026-06-15T14:00:00Z', '2026-06-15T15:00:00Z');
+
+    const result = await repo.deleteAutomationReservationsAsync({
+      startAfter: '2026-05-01T00:00:00Z',
+      endBefore: '2026-06-01T00:00:00Z',
+    });
+    expect(result.deleted).toBe(1);
+  });
+
+  test('previewAutomationReservationsAsync returns empty result when no automation rows exist', async () => {
+    const preview = await repo.previewAutomationReservationsAsync({});
+    expect(preview.total).toBe(0);
+    expect(preview.byFacility).toHaveLength(0);
+  });
+
+  test('deleteAutomationReservations controller method requires facilities manager', async () => {
+    const controller = new FacilitiesController();
+    const member = usersRepo.create({
+      name: 'Team Member',
+      email: 'member@example.com',
+      isFacilitiesManager: false,
+    });
+
+    const req = {
+      query: {},
+      auth: { user: member },
+    } as unknown as Request;
+
+    let forwardedError: unknown;
+    const res = {
+      json(_value: unknown) { return this; },
+    } as unknown as Response;
+    const next: NextFunction = (err?: unknown) => { forwardedError = err; };
+
+    await controller.deleteAutomationReservations(req, res, next);
+
+    expect(forwardedError).toBeDefined();
+    // Should be a forbidden AppError
+    const err = forwardedError as { statusCode?: number };
+    expect(err.statusCode).toBe(403);
+  });
+
+  test('deleteAutomationReservations controller method succeeds for facilities manager', async () => {
+    const manager = usersRepo.create({
+      name: 'Facilities Manager',
+      email: 'fm@example.com',
+      isFacilitiesManager: true,
+    });
+    const f1 = await repo.createAsync({ name: 'Workroom' });
+    await makeAutomationReservation(f1.id, 'e1', '2026-05-15T14:00:00Z', '2026-05-15T15:00:00Z');
+
+    const controller = new FacilitiesController();
+    const req = {
+      query: {},
+      auth: { user: manager },
+    } as unknown as Request;
+
+    let responsePayload: unknown;
+    const res = {
+      json(value: unknown) { responsePayload = value; return this; },
+    } as unknown as Response;
+    let forwardedError: unknown;
+    const next: NextFunction = (err?: unknown) => { forwardedError = err; };
+
+    await controller.deleteAutomationReservations(req, res, next);
+
+    expect(forwardedError).toBeUndefined();
+    expect(responsePayload).toMatchObject({ deleted: 1 });
+  });
+
+  test('previewAutomationReservations controller method is accessible to non-managers', async () => {
+    const member = usersRepo.create({
+      name: 'Team Member',
+      email: 'member@example.com',
+      isFacilitiesManager: false,
+    });
+    const f1 = await repo.createAsync({ name: 'Workroom' });
+    await makeAutomationReservation(f1.id, 'e1', '2026-05-15T14:00:00Z', '2026-05-15T15:00:00Z');
+
+    const controller = new FacilitiesController();
+    const req = {
+      query: {},
+      auth: { user: member },
+    } as unknown as Request;
+
+    let responsePayload: unknown;
+    const res = {
+      json(value: unknown) { responsePayload = value; return this; },
+    } as unknown as Response;
+    let forwardedError: unknown;
+    const next: NextFunction = (err?: unknown) => { forwardedError = err; };
+
+    await controller.previewAutomationReservations(req, res, next);
+
+    expect(forwardedError).toBeUndefined();
+    expect(responsePayload).toMatchObject({ total: 1 });
+  });
+});

--- a/apps/api_server/src/__tests__/notifications_agent.test.ts
+++ b/apps/api_server/src/__tests__/notifications_agent.test.ts
@@ -1,0 +1,117 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { AddressInfo } from 'node:net';
+import Database from 'better-sqlite3';
+import { createApp } from '../app';
+import { runMigrations } from '../database/migrations';
+import { setDb } from '../database/db';
+import { UsersRepository } from '../repositories/users_repository';
+import { SessionsRepository } from '../repositories/sessions_repository';
+
+// Prevent real WS broadcast in tests
+vi.mock('../services/ws_gateway', () => ({
+  broadcast: vi.fn(),
+  attachWsGateway: vi.fn(),
+}));
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  return db;
+}
+
+describe('POST /notifications/agent', () => {
+  let baseUrl: string;
+  let closeServer: () => Promise<void>;
+  let authHeaders: Record<string, string>;
+
+  beforeEach(async () => {
+    setDb(makeDb());
+
+    const usersRepo = new UsersRepository();
+    const sessionsRepo = new SessionsRepository();
+    const user = usersRepo.create({ name: 'Test User', email: 'test@example.com' });
+    const session = await sessionsRepo.createAsync(user.id);
+    authHeaders = {
+      Authorization: `Bearer ${session.token}`,
+      'Content-Type': 'application/json',
+    };
+
+    const server = createApp().listen(0);
+    await new Promise<void>((r) => server.once('listening', () => r()));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    closeServer = () =>
+      new Promise<void>((res, rej) =>
+        server.close((e) => (e ? rej(e) : res())),
+      );
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await closeServer();
+  });
+
+  it('returns 401 without auth', async () => {
+    const res = await fetch(`${baseUrl}/notifications/agent`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Done', body: 'Task complete' }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 201 and id with valid payload', async () => {
+    const res = await fetch(`${baseUrl}/notifications/agent`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ title: 'Done', body: 'Refactor complete' }),
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as { id: number };
+    expect(typeof data.id).toBe('number');
+    expect(data.id).toBeGreaterThan(0);
+  });
+
+  it('broadcasts notification.push via WebSocket', async () => {
+    const { broadcast } = await import('../services/ws_gateway');
+    await fetch(`${baseUrl}/notifications/agent`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ title: 'Claude done', body: 'All tests pass' }),
+    });
+    expect(broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'notification.push',
+        title: 'Claude done',
+        body: 'All tests pass',
+      }),
+    );
+  });
+
+  it('returns 400 when title is missing', async () => {
+    const res = await fetch(`${baseUrl}/notifications/agent`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ body: 'No title here' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when body is missing', async () => {
+    const res = await fetch(`${baseUrl}/notifications/agent`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ title: 'Done' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when title exceeds 200 chars', async () => {
+    const res = await fetch(`${baseUrl}/notifications/agent`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ title: 'x'.repeat(201), body: 'ok' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api_server/src/app.ts
+++ b/apps/api_server/src/app.ts
@@ -23,6 +23,7 @@ import claudeTriggersRouter from './routes/claude_triggers_routes';
 import { agentConfigsRouter } from './routes/agent_configs_routes';
 import { agentSessionsRouter } from './routes/agent_sessions_routes';
 import { agentsCapabilitiesRouter } from './routes/agents_capabilities_routes';
+import { notificationsAgentRouter } from './routes/notifications_agent_routes';
 
 export function createApp() {
   const app = express();
@@ -67,6 +68,7 @@ export function createApp() {
   app.use('/claude-triggers', claudeTriggersRouter);
   app.use('/agent-configs', agentConfigsRouter);
   app.use('/agent-sessions', agentSessionsRouter);
+  app.use('/notifications/agent', notificationsAgentRouter);
 
   app.use(errorHandler);
 

--- a/apps/api_server/src/controllers/facilities_controller.ts
+++ b/apps/api_server/src/controllers/facilities_controller.ts
@@ -677,4 +677,47 @@ export class FacilitiesController {
       next(err);
     }
   }
+
+  private parseAutomationFilters(req: Request): {
+    facilityId?: number;
+    startAfter?: string;
+    endBefore?: string;
+  } {
+    const filters: { facilityId?: number; startAfter?: string; endBefore?: string } = {};
+    const facilityIdRaw = req.query.facilityId;
+    if (typeof facilityIdRaw === 'string' && facilityIdRaw.trim().length > 0) {
+      const parsed = Number(facilityIdRaw);
+      if (Number.isFinite(parsed)) filters.facilityId = parsed;
+    }
+    const startAfterRaw = req.query.startAfter;
+    if (typeof startAfterRaw === 'string' && startAfterRaw.trim().length > 0) {
+      filters.startAfter = startAfterRaw;
+    }
+    const endBeforeRaw = req.query.endBefore;
+    if (typeof endBeforeRaw === 'string' && endBeforeRaw.trim().length > 0) {
+      filters.endBefore = endBeforeRaw;
+    }
+    return filters;
+  }
+
+  async previewAutomationReservations(req: Request, res: Response, next: NextFunction) {
+    try {
+      const filters = this.parseAutomationFilters(req);
+      const preview = await repo.previewAutomationReservationsAsync(filters);
+      res.json(preview);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  async deleteAutomationReservations(req: Request, res: Response, next: NextFunction) {
+    try {
+      this.assertFacilitiesManager(req);
+      const filters = this.parseAutomationFilters(req);
+      const result = await repo.deleteAutomationReservationsAsync(filters);
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  }
 }

--- a/apps/api_server/src/controllers/notifications_agent_controller.ts
+++ b/apps/api_server/src/controllers/notifications_agent_controller.ts
@@ -1,0 +1,37 @@
+import type { NextFunction, Request, Response } from 'express';
+import { AppError } from '../errors/app_error';
+import { getDb } from '../database/db';
+import { broadcast } from '../services/ws_gateway';
+
+export class NotificationsAgentController {
+  post(req: Request, res: Response, next: NextFunction): void {
+    try {
+      const { title, body } = req.body as { title?: unknown; body?: unknown };
+
+      if (typeof title !== 'string' || title.trim().length === 0) {
+        throw AppError.badRequest('title is required');
+      }
+      if (typeof body !== 'string' || body.trim().length === 0) {
+        throw AppError.badRequest('body is required');
+      }
+      if (title.length > 200) {
+        throw AppError.badRequest('title must be 200 characters or fewer');
+      }
+      if (body.length > 200) {
+        throw AppError.badRequest('body must be 200 characters or fewer');
+      }
+
+      const result = getDb()
+        .prepare(
+          `INSERT INTO agent_notifications (title, body) VALUES (?, ?) RETURNING id`,
+        )
+        .get(title.trim(), body.trim()) as { id: number };
+
+      broadcast({ v: 1, type: 'notification.push', id: result.id, title: title.trim(), body: body.trim() });
+
+      res.status(201).json({ id: result.id });
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -958,4 +958,15 @@ export function runMigrations(db: Database.Database): void {
       updated_at         = datetime('now')
     WHERE id = 'opencode';
   `);
+
+  // agent_notifications — local delivery store for MCP-initiated push notifications
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS agent_notifications (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      read_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
 }

--- a/apps/api_server/src/models/automation_rule.ts
+++ b/apps/api_server/src/models/automation_rule.ts
@@ -17,7 +17,8 @@ export type AutomationActionType =
   | 'create_project_from_template'
   | 'auto_schedule'
   | 'send_notification'
-  | 'tag_task';
+  | 'tag_task'
+  | 'create_reservation';
 
 export type AutomationRuleSource =
   | 'rhythm'

--- a/apps/api_server/src/repositories/facilities_repository.test.ts
+++ b/apps/api_server/src/repositories/facilities_repository.test.ts
@@ -1,0 +1,93 @@
+import Database from 'better-sqlite3';
+import { beforeEach, describe, expect, test } from 'vitest';
+import { setDb } from '../database/db';
+import { runMigrations } from '../database/migrations';
+import { FacilitiesRepository } from './facilities_repository';
+import { UsersRepository } from './users_repository';
+
+describe('FacilitiesRepository — automation reservation methods', () => {
+  beforeEach(() => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    setDb(db);
+  });
+
+  test('insertSingleReservationAsync creates a reservation with external_source set', async () => {
+    const repo = new FacilitiesRepository();
+    const usersRepo = new UsersRepository();
+    const owner = usersRepo.create({ name: 'Alice', email: 'a@example.com' });
+    const facility = await repo.createAsync({ name: 'Office Staff Workroom' });
+
+    const created = await repo.insertSingleReservationAsync({
+      facility_id: facility.id,
+      title: 'Worship Committee Meeting',
+      requester_name: 'Alice',
+      requester_user_id: owner.id,
+      created_by_user_id: owner.id,
+      start_time: '2026-05-15T14:00:00.000Z',
+      end_time: '2026-05-15T15:00:00.000Z',
+      notes: null,
+      external_event_id: 'rule-1:cal-1:event-1',
+      external_source: 'automation_rule',
+    });
+
+    expect(created.title).toBe('Worship Committee Meeting');
+    expect(created.externalEventId).toBe('rule-1:cal-1:event-1');
+    expect(created.externalSource).toBe('automation_rule');
+    expect(created.createdByRhythm).toBe(true);
+    expect(created.facilityId).toBe(facility.id);
+  });
+
+  test('insertSingleReservationAsync sets group_id and series_id to null', async () => {
+    const repo = new FacilitiesRepository();
+    const usersRepo = new UsersRepository();
+    const owner = usersRepo.create({ name: 'Bob', email: 'b@example.com' });
+    const facility = await repo.createAsync({ name: 'Fellowship Hall' });
+
+    const created = await repo.insertSingleReservationAsync({
+      facility_id: facility.id,
+      title: 'Board Meeting',
+      requester_name: 'Bob',
+      requester_user_id: owner.id,
+      created_by_user_id: owner.id,
+      start_time: '2026-06-01T09:00:00.000Z',
+      end_time: '2026-06-01T10:00:00.000Z',
+      external_event_id: 'rule-2:cal-1:event-2',
+      external_source: 'automation_rule',
+    });
+
+    expect(created.groupId).toBeNull();
+    expect(created.seriesId).toBeNull();
+    expect(created.isConflicted).toBe(false);
+    expect(created.conflictReason).toBeNull();
+  });
+
+  test('findByExternalEventIdAsync returns null when no match', async () => {
+    const repo = new FacilitiesRepository();
+    const result = await repo.findByExternalEventIdAsync('nonexistent');
+    expect(result).toBeNull();
+  });
+
+  test('findByExternalEventIdAsync returns the reservation when match exists', async () => {
+    const repo = new FacilitiesRepository();
+    const usersRepo = new UsersRepository();
+    const owner = usersRepo.create({ name: 'Alice', email: 'a@example.com' });
+    const facility = await repo.createAsync({ name: 'Conf Room A' });
+
+    await repo.insertSingleReservationAsync({
+      facility_id: facility.id,
+      title: 'Test',
+      requester_name: 'Alice',
+      requester_user_id: owner.id,
+      created_by_user_id: owner.id,
+      start_time: '2026-05-15T14:00:00.000Z',
+      end_time: '2026-05-15T15:00:00.000Z',
+      external_event_id: 'rule-1:event-abc',
+      external_source: 'automation_rule',
+    });
+
+    const found = await repo.findByExternalEventIdAsync('rule-1:event-abc');
+    expect(found).not.toBeNull();
+    expect(found!.title).toBe('Test');
+  });
+});

--- a/apps/api_server/src/repositories/facilities_repository.ts
+++ b/apps/api_server/src/repositories/facilities_repository.ts
@@ -380,6 +380,20 @@ export class FacilitiesRepository {
     );
   }
 
+  async findByExternalEventIdAsync(externalEventId: string): Promise<Reservation | null> {
+    if (env.dbClient === 'postgres') {
+      const result = await getPostgresPool().query<ReservationRow>(
+        `${RESERVATION_SELECT} WHERE reservations.external_event_id = $1 LIMIT 1`,
+        [externalEventId],
+      );
+      return result.rows[0] ? rowToReservation(result.rows[0]) : null;
+    }
+    const row = getDb()
+      .prepare(`${RESERVATION_SELECT} WHERE reservations.external_event_id = ? LIMIT 1`)
+      .get(externalEventId) as ReservationRow | undefined;
+    return row ? rowToReservation(row) : null;
+  }
+
   private assertReservationWindowAvailable(
     facilityId: number,
     startTime: string,
@@ -1104,6 +1118,38 @@ export class FacilitiesRepository {
       };
     }
     return this.createReservationGroup(data);
+  }
+
+  async insertSingleReservationAsync(data: {
+    facility_id: number;
+    title: string;
+    requester_name: string;
+    requester_user_id: number | null;
+    created_by_user_id: number | null;
+    start_time: string;
+    end_time: string;
+    notes?: string | null;
+    external_event_id: string;
+    external_source: string;
+    created_by_rhythm?: boolean;
+  }): Promise<Reservation> {
+    return this.insertReservationAsync({
+      facility_id: data.facility_id,
+      group_id: null,
+      series_id: null,
+      title: data.title,
+      requester_name: data.requester_name,
+      requester_user_id: data.requester_user_id,
+      created_by_user_id: data.created_by_user_id,
+      start_time: data.start_time,
+      end_time: data.end_time,
+      notes: data.notes ?? null,
+      external_event_id: data.external_event_id,
+      external_source: data.external_source,
+      created_by_rhythm: data.created_by_rhythm ?? true,
+      is_conflicted: false,
+      conflict_reason: null,
+    });
   }
 
   createReservationSeries(data: CreateReservationSeriesDto): ReservationSeries {

--- a/apps/api_server/src/repositories/facilities_repository.ts
+++ b/apps/api_server/src/repositories/facilities_repository.ts
@@ -1975,4 +1975,131 @@ export class FacilitiesRepository {
     }
     this.deleteReservationGroupsBySeriesId(seriesId);
   }
+
+  async previewAutomationReservationsAsync(filters: {
+    facilityId?: number;
+    startAfter?: string;
+    endBefore?: string;
+  }): Promise<{
+    total: number;
+    byFacility: Array<{ facilityId: number; facilityName: string; count: number }>;
+  }> {
+    const conditions: string[] = [`reservations.external_source = 'automation_rule'`];
+    if (env.dbClient === 'postgres') {
+      const params: Array<string | number> = [];
+      if (filters.facilityId != null) {
+        params.push(filters.facilityId);
+        conditions.push(`reservations.facility_id = $${params.length}`);
+      }
+      if (filters.startAfter != null) {
+        params.push(filters.startAfter);
+        conditions.push(`reservations.start_time >= $${params.length}`);
+      }
+      if (filters.endBefore != null) {
+        params.push(filters.endBefore);
+        conditions.push(`reservations.end_time <= $${params.length}`);
+      }
+      const where = conditions.join(' AND ');
+      const result = await getPostgresPool().query<{
+        facility_id: number;
+        facility_name: string;
+        count: string;
+      }>(
+        `SELECT reservations.facility_id, facilities.name AS facility_name, COUNT(*)::text AS count
+         FROM reservations
+         JOIN facilities ON facilities.id = reservations.facility_id
+         WHERE ${where}
+         GROUP BY reservations.facility_id, facilities.name
+         ORDER BY facilities.name ASC`,
+        params,
+      );
+      const byFacility = result.rows.map((row) => ({
+        facilityId: row.facility_id,
+        facilityName: row.facility_name,
+        count: Number(row.count),
+      }));
+      const total = byFacility.reduce((sum, f) => sum + f.count, 0);
+      return { total, byFacility };
+    }
+
+    const sqliteParams: Array<string | number> = [];
+    if (filters.facilityId != null) {
+      sqliteParams.push(filters.facilityId);
+      conditions.push(`reservations.facility_id = ?`);
+    }
+    if (filters.startAfter != null) {
+      sqliteParams.push(filters.startAfter);
+      conditions.push(`reservations.start_time >= ?`);
+    }
+    if (filters.endBefore != null) {
+      sqliteParams.push(filters.endBefore);
+      conditions.push(`reservations.end_time <= ?`);
+    }
+    const where = conditions.join(' AND ');
+    const rows = getDb()
+      .prepare(
+        `SELECT reservations.facility_id AS facility_id,
+                facilities.name AS facility_name,
+                COUNT(*) AS count
+         FROM reservations
+         JOIN facilities ON facilities.id = reservations.facility_id
+         WHERE ${where}
+         GROUP BY reservations.facility_id, facilities.name
+         ORDER BY facilities.name ASC`,
+      )
+      .all(...sqliteParams) as Array<{ facility_id: number; facility_name: string; count: number }>;
+    const byFacility = rows.map((row) => ({
+      facilityId: row.facility_id,
+      facilityName: row.facility_name,
+      count: row.count,
+    }));
+    const total = byFacility.reduce((sum, f) => sum + f.count, 0);
+    return { total, byFacility };
+  }
+
+  async deleteAutomationReservationsAsync(filters: {
+    facilityId?: number;
+    startAfter?: string;
+    endBefore?: string;
+  }): Promise<{ deleted: number }> {
+    const conditions: string[] = [`external_source = 'automation_rule'`];
+    if (env.dbClient === 'postgres') {
+      const params: Array<string | number> = [];
+      if (filters.facilityId != null) {
+        params.push(filters.facilityId);
+        conditions.push(`facility_id = $${params.length}`);
+      }
+      if (filters.startAfter != null) {
+        params.push(filters.startAfter);
+        conditions.push(`start_time >= $${params.length}`);
+      }
+      if (filters.endBefore != null) {
+        params.push(filters.endBefore);
+        conditions.push(`end_time <= $${params.length}`);
+      }
+      const result = await getPostgresPool().query(
+        `DELETE FROM reservations WHERE ${conditions.join(' AND ')}`,
+        params,
+      );
+      return { deleted: result.rowCount ?? 0 };
+    }
+
+    const sqliteParams: Array<string | number> = [];
+    if (filters.facilityId != null) {
+      sqliteParams.push(filters.facilityId);
+      conditions.push(`facility_id = ?`);
+    }
+    if (filters.startAfter != null) {
+      sqliteParams.push(filters.startAfter);
+      conditions.push(`start_time >= ?`);
+    }
+    if (filters.endBefore != null) {
+      sqliteParams.push(filters.endBefore);
+      conditions.push(`end_time <= ?`);
+    }
+    const result = getDb()
+      .prepare(`DELETE FROM reservations WHERE ${conditions.join(' AND ')}`)
+      .run(...sqliteParams);
+    return { deleted: Number(result.changes) };
+  }
 }

--- a/apps/api_server/src/repositories/facilities_repository.ts
+++ b/apps/api_server/src/repositories/facilities_repository.ts
@@ -341,7 +341,7 @@ export class FacilitiesRepository {
     return row ?? null;
   }
 
-  private async findReservationWindowConflictAsync(
+  async findReservationWindowConflictAsync(
     facilityId: number,
     startTime: string,
     endTime: string,

--- a/apps/api_server/src/routes/facilities_routes.ts
+++ b/apps/api_server/src/routes/facilities_routes.ts
@@ -12,6 +12,16 @@ facilitiesRouter.get(
   controller.getAllReservations.bind(controller),
 );
 facilitiesRouter.post('/', controller.create.bind(controller));
+// IMPORTANT: register these BEFORE the /:id-prefixed routes so Express
+// doesn't capture "automation-reservations" as a facility id.
+facilitiesRouter.get(
+  '/automation-reservations/preview',
+  controller.previewAutomationReservations.bind(controller),
+);
+facilitiesRouter.delete(
+  '/automation-reservations',
+  controller.deleteAutomationReservations.bind(controller),
+);
 facilitiesRouter.patch('/:id', controller.update.bind(controller));
 facilitiesRouter.delete('/:id', controller.remove.bind(controller));
 facilitiesRouter.get('/:id/reservations', controller.getReservations.bind(controller));

--- a/apps/api_server/src/routes/notifications_agent_routes.ts
+++ b/apps/api_server/src/routes/notifications_agent_routes.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { requireAuth } from '../middleware/auth_middleware';
+import { NotificationsAgentController } from '../controllers/notifications_agent_controller';
+import { env } from '../config/env';
+
+export const notificationsAgentRouter = Router();
+const controller = new NotificationsAgentController();
+
+if (!env.agentLocal) notificationsAgentRouter.use(requireAuth);
+
+notificationsAgentRouter.post('/', controller.post.bind(controller));

--- a/apps/api_server/src/services/automation_catalog_service.ts
+++ b/apps/api_server/src/services/automation_catalog_service.ts
@@ -154,6 +154,12 @@ const ACTIONS: AutomationActionCatalogItem[] = [
     description: 'Create or update a task with a scheduled weekday.',
     configSchema: { fields: ['titleTemplate', 'targetDay', 'dueDaysOffset'] },
   },
+  {
+    key: 'create_reservation',
+    label: 'Create reservation',
+    description: 'Book a Facilities room when a calendar event trigger matches.',
+    configSchema: { fields: ['facilityId', 'titleTemplate', 'notesTemplate'] },
+  },
 ];
 
 const PROVIDERS: AutomationProviderCatalogItem[] = [

--- a/apps/api_server/src/services/automation_engine_service.test.ts
+++ b/apps/api_server/src/services/automation_engine_service.test.ts
@@ -7,7 +7,9 @@ import { runMigrations } from "../database/migrations";
 import type { AutomationSignal } from "../models/automation_signal";
 import { AutomationRulesRepository } from "../repositories/automation_rules_repository";
 import { AutomationSignalsRepository } from "../repositories/automation_signals_repository";
+import { FacilitiesRepository } from "../repositories/facilities_repository";
 import { IntegrationAccountsRepository } from "../repositories/integration_accounts_repository";
+import { MessagesRepository } from "../repositories/messages_repository";
 import { ProjectInstancesRepository } from "../repositories/project_instances_repository";
 import { ProjectTemplatesRepository } from "../repositories/project_templates_repository";
 import { TasksRepository } from "../repositories/tasks_repository";
@@ -574,6 +576,275 @@ describe("Automation overhaul backend", () => {
         expect.objectContaining({ source: "gmail" }),
       ]),
     );
+  });
+});
+
+describe("create_reservation action", () => {
+  beforeEach(() => {
+    const db = new Database(":memory:");
+    runMigrations(db);
+    setDb(db);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function setupRule(opts: {
+    ownerId: number;
+    facilityId: number;
+    sourceAccountId: string;
+    actionConfig?: Record<string, unknown>;
+  }) {
+    const rulesRepo = new AutomationRulesRepository();
+    return rulesRepo.create({
+      name: "Calendar to Reservation",
+      source: "google_calendar",
+      triggerKey: "google_calendar.event_matching_filter",
+      triggerConfig: { textQuery: "Worship" },
+      actionType: "create_reservation",
+      actionConfig: { facilityId: opts.facilityId, ...opts.actionConfig },
+      ownerId: opts.ownerId,
+      sourceAccountId: opts.sourceAccountId,
+    });
+  }
+
+  function makeCalendarSignal(
+    overrides: Partial<AutomationSignal> = {},
+  ): AutomationSignal {
+    const occurredAt = "2026-05-15T14:00:00.000Z";
+    return {
+      id: "sig-cal-1",
+      provider: "google_calendar",
+      signalType: "calendar_event_seen",
+      externalId: "cal-1:event-1",
+      dedupeKey: "google_calendar:seen:cal-1:event-1",
+      occurredAt,
+      syncedAt: "2026-05-15T13:30:00.000Z",
+      sourceAccountId: "acct-1",
+      sourceLabel: "alice@example.com",
+      payload: {
+        title: "Worship Committee",
+        description: null,
+        location: null,
+        startDate: "2026-05-15",
+        startAt: "2026-05-15T14:00:00.000Z",
+        endAt: "2026-05-15T15:00:00.000Z",
+        isAllDay: false,
+        eventType: "default",
+        sourceName: "Primary",
+        daysUntilStart: 14,
+      },
+      createdAt: occurredAt,
+      updatedAt: occurredAt,
+      ...overrides,
+    };
+  }
+
+  test("creates a reservation for a timed calendar event", async () => {
+    const usersRepo = new UsersRepository();
+    const accountsRepo = new IntegrationAccountsRepository();
+    const facilitiesRepo = new FacilitiesRepository();
+    const owner = usersRepo.create({ name: "Alice", email: "a@example.com" });
+    const [account] = accountsRepo.upsertGoogleAccount({
+      ownerId: owner.id,
+      externalAccountId: "g-1",
+      email: "a@example.com",
+      displayName: "Alice",
+      accessToken: "t",
+      refreshToken: null,
+      scope: "cal",
+      tokenType: "Bearer",
+      expiresAt: null,
+    });
+    const facility = await facilitiesRepo.createAsync({ name: "Workroom" });
+    const rule = await setupRule({
+      ownerId: owner.id,
+      facilityId: facility.id,
+      sourceAccountId: account.id,
+    });
+
+    const engine = new AutomationEngineService();
+    const result = await engine.evaluateSignals("google_calendar", [
+      makeCalendarSignal(),
+    ]);
+
+    expect(result.matchedRules).toBe(1);
+    const reservations =
+      await facilitiesRepo.findReservationsByFacilityAsync(facility.id);
+    expect(reservations).toHaveLength(1);
+    expect(reservations[0].title).toBe("Worship Committee");
+    expect(reservations[0].externalSource).toBe("automation_rule");
+    expect(reservations[0].externalEventId).toBe(`${rule.id}:cal-1:event-1`);
+    expect(reservations[0].requesterName).toBe("Alice");
+    expect(reservations[0].createdByRhythm).toBe(true);
+  });
+
+  test("skips all-day events (no reservation created)", async () => {
+    const usersRepo = new UsersRepository();
+    const accountsRepo = new IntegrationAccountsRepository();
+    const facilitiesRepo = new FacilitiesRepository();
+    const owner = usersRepo.create({ name: "Alice", email: "a@example.com" });
+    const [account] = accountsRepo.upsertGoogleAccount({
+      ownerId: owner.id,
+      externalAccountId: "g-1",
+      email: "a@example.com",
+      displayName: "Alice",
+      accessToken: "t",
+      refreshToken: null,
+      scope: "cal",
+      tokenType: "Bearer",
+      expiresAt: null,
+    });
+    const facility = await facilitiesRepo.createAsync({ name: "Workroom" });
+    await setupRule({
+      ownerId: owner.id,
+      facilityId: facility.id,
+      sourceAccountId: account.id,
+    });
+
+    const engine = new AutomationEngineService();
+    await engine.evaluateSignals("google_calendar", [
+      makeCalendarSignal({
+        payload: { ...makeCalendarSignal().payload, isAllDay: true },
+      }),
+    ]);
+
+    const reservations =
+      await facilitiesRepo.findReservationsByFacilityAsync(facility.id);
+    expect(reservations).toHaveLength(0);
+  });
+
+  test("skips duplicates by external_event_id", async () => {
+    const usersRepo = new UsersRepository();
+    const accountsRepo = new IntegrationAccountsRepository();
+    const facilitiesRepo = new FacilitiesRepository();
+    const owner = usersRepo.create({ name: "Alice", email: "a@example.com" });
+    const [account] = accountsRepo.upsertGoogleAccount({
+      ownerId: owner.id,
+      externalAccountId: "g-1",
+      email: "a@example.com",
+      displayName: "Alice",
+      accessToken: "t",
+      refreshToken: null,
+      scope: "cal",
+      tokenType: "Bearer",
+      expiresAt: null,
+    });
+    const facility = await facilitiesRepo.createAsync({ name: "Workroom" });
+    await setupRule({
+      ownerId: owner.id,
+      facilityId: facility.id,
+      sourceAccountId: account.id,
+    });
+
+    const engine = new AutomationEngineService();
+    await engine.evaluateSignals("google_calendar", [makeCalendarSignal()]);
+    await engine.evaluateSignals("google_calendar", [makeCalendarSignal()]);
+
+    const reservations =
+      await facilitiesRepo.findReservationsByFacilityAsync(facility.id);
+    expect(reservations).toHaveLength(1);
+  });
+
+  test("sends DM on conflict and creates no new reservation", async () => {
+    const usersRepo = new UsersRepository();
+    const accountsRepo = new IntegrationAccountsRepository();
+    const facilitiesRepo = new FacilitiesRepository();
+    const messagesRepo = new MessagesRepository();
+    const owner = usersRepo.create({ name: "Alice", email: "a@example.com" });
+    const [account] = accountsRepo.upsertGoogleAccount({
+      ownerId: owner.id,
+      externalAccountId: "g-1",
+      email: "a@example.com",
+      displayName: "Alice",
+      accessToken: "t",
+      refreshToken: null,
+      scope: "cal",
+      tokenType: "Bearer",
+      expiresAt: null,
+    });
+    const facility = await facilitiesRepo.createAsync({ name: "Workroom" });
+
+    // Pre-book the room to create a conflict
+    await facilitiesRepo.insertSingleReservationAsync({
+      facility_id: facility.id,
+      title: "Existing meeting",
+      requester_name: "Bob",
+      requester_user_id: owner.id,
+      created_by_user_id: owner.id,
+      start_time: "2026-05-15T14:30:00.000Z",
+      end_time: "2026-05-15T15:30:00.000Z",
+      external_event_id: "manual-1",
+      external_source: "manual",
+    });
+
+    await setupRule({
+      ownerId: owner.id,
+      facilityId: facility.id,
+      sourceAccountId: account.id,
+    });
+
+    const engine = new AutomationEngineService();
+    await engine.evaluateSignals("google_calendar", [makeCalendarSignal()]);
+
+    const reservations =
+      await facilitiesRepo.findReservationsByFacilityAsync(facility.id);
+    expect(reservations).toHaveLength(1); // only the pre-existing one
+
+    // Check that owner received a DM about the conflict
+    const threads = await messagesRepo.findAllThreadsForUserAsync(owner.id);
+    let foundConflictDm = false;
+    for (const thread of threads) {
+      const messages = await messagesRepo.findMessagesByThreadAsync(
+        thread.id,
+        owner.id,
+      );
+      if (messages.some((m) => m.body.includes("Existing meeting"))) {
+        foundConflictDm = true;
+        break;
+      }
+    }
+    expect(foundConflictDm).toBe(true);
+  });
+
+  test("skips when actionConfig is missing facilityId", async () => {
+    const usersRepo = new UsersRepository();
+    const accountsRepo = new IntegrationAccountsRepository();
+    const facilitiesRepo = new FacilitiesRepository();
+    const owner = usersRepo.create({ name: "Alice", email: "a@example.com" });
+    const [account] = accountsRepo.upsertGoogleAccount({
+      ownerId: owner.id,
+      externalAccountId: "g-1",
+      email: "a@example.com",
+      displayName: "Alice",
+      accessToken: "t",
+      refreshToken: null,
+      scope: "cal",
+      tokenType: "Bearer",
+      expiresAt: null,
+    });
+    const facility = await facilitiesRepo.createAsync({ name: "Workroom" });
+    const rulesRepo = new AutomationRulesRepository();
+    await rulesRepo.create({
+      name: "No facility configured",
+      source: "google_calendar",
+      triggerKey: "google_calendar.event_matching_filter",
+      triggerConfig: {},
+      actionType: "create_reservation",
+      actionConfig: {}, // no facilityId
+      ownerId: owner.id,
+      sourceAccountId: account.id,
+    });
+
+    const engine = new AutomationEngineService();
+    await engine.evaluateSignals("google_calendar", [makeCalendarSignal()]);
+
+    const reservations =
+      await facilitiesRepo.findReservationsByFacilityAsync(facility.id);
+    expect(reservations).toHaveLength(0);
   });
 });
 

--- a/apps/api_server/src/services/automation_engine_service.ts
+++ b/apps/api_server/src/services/automation_engine_service.ts
@@ -6,6 +6,7 @@ import { UsersRepository } from '../repositories/users_repository';
 import type { AutomationSignal } from '../models/automation_signal';
 import type { AutomationRule, Condition } from '../models/automation_rule';
 import { ProjectGenerationService } from './project_generation_service';
+import { FacilitiesBookingService } from './facilities_booking_service';
 
 interface EvaluationResult {
   matchedRules: number;
@@ -101,6 +102,7 @@ export class AutomationEngineService {
   private readonly usersRepo = new UsersRepository();
   private readonly templatesRepo = new ProjectTemplatesRepository();
   private readonly projectGeneration = new ProjectGenerationService();
+  private readonly bookingService = new FacilitiesBookingService();
 
   async evaluateSignals(
     source: AutomationRule['source'],
@@ -363,6 +365,8 @@ export class AutomationEngineService {
         return this.sendNotification(rule, signal);
       case 'create_project_from_template':
         return this.createProject(rule, signal);
+      case 'create_reservation':
+        return this.createReservationFromSignal(rule, signal);
       default:
         return false;
     }
@@ -427,6 +431,54 @@ export class AutomationEngineService {
       `${rule.name} matched ${asString(signal.payload.title) ?? asString(signal.payload.subject) ?? signal.signalType}.`;
     await this.messagesRepo.sendDirectMessageAsync(bot.id, rule.ownerId, message);
     return true;
+  }
+
+  private async createReservationFromSignal(
+    rule: AutomationRule,
+    signal: AutomationSignal,
+  ): Promise<boolean> {
+    // Skip all-day events — product decision per issue #149.
+    if (signal.payload.isAllDay === true) return false;
+
+    if (rule.ownerId == null) return false;
+
+    const config = rule.actionConfig ?? {};
+    const facilityId = asNumber(config.facilityId);
+    if (facilityId == null) return false;
+
+    const startAt = asString(signal.payload.startAt);
+    const endAt = asString(signal.payload.endAt);
+    if (startAt == null || endAt == null) return false;
+
+    const title =
+      interpolate(asString(config.titleTemplate) ?? '{{title}}', signal) ||
+      asString(signal.payload.title) ||
+      rule.name;
+    const notes = interpolate(asString(config.notesTemplate) ?? '', signal) || null;
+    const externalEventId = `${rule.id}:${signal.externalId}`;
+
+    const result = await this.bookingService.createSingleAutomationReservationAsync({
+      facilityId,
+      title,
+      notes,
+      startTime: startAt,
+      endTime: endAt,
+      ownerId: rule.ownerId,
+      externalEventId,
+    });
+
+    if (result.skippedReason === 'conflict' && result.conflict) {
+      const bot = await this.usersRepo.findOrCreateSystemBotAsync();
+      const message =
+        `Automation rule "${rule.name}" couldn't book "${title}" in ${result.conflict.facilityName}: ` +
+        `conflicts with "${result.conflict.conflictingTitle}" ` +
+        `(${result.conflict.startTime}–${result.conflict.endTime}).`;
+      await this.messagesRepo.sendDirectMessageAsync(bot.id, rule.ownerId, message);
+      return true;
+    }
+
+    // duplicate skip → silent. Action ran (returned true), even if it created nothing.
+    return result.skippedReason !== null || result.created != null;
   }
 
   private async createProject(

--- a/apps/api_server/src/services/facilities_booking_service.test.ts
+++ b/apps/api_server/src/services/facilities_booking_service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, test } from 'vitest';
 import Database from 'better-sqlite3';
 
 import { setDb } from '../database/db';
@@ -290,5 +290,92 @@ describe('FacilitiesBookingService', () => {
     expect(
       facilitiesRepo.findReservationsByFacility(facilityId).map((item) => item.title),
     ).toEqual(['Independent Event']);
+  });
+});
+
+describe('FacilitiesBookingService.createSingleAutomationReservationAsync', () => {
+  let service: FacilitiesBookingService;
+  let repo: FacilitiesRepository;
+  let usersRepo: UsersRepository;
+  let ownerId: number;
+  let facilityId: number;
+
+  beforeEach(async () => {
+    const db = new Database(':memory:');
+    runMigrations(db);
+    setDb(db);
+    service = new FacilitiesBookingService();
+    repo = new FacilitiesRepository();
+    usersRepo = new UsersRepository();
+    const owner = usersRepo.create({ name: 'Alice', email: 'a@example.com' });
+    ownerId = owner.id;
+    const facility = await repo.createAsync({ name: 'Conf Room' });
+    facilityId = facility.id;
+  });
+
+  test('creates a reservation on a clean window', async () => {
+    const result = await service.createSingleAutomationReservationAsync({
+      facilityId,
+      title: 'Worship Committee',
+      notes: null,
+      startTime: '2026-05-15T14:00:00.000Z',
+      endTime: '2026-05-15T15:00:00.000Z',
+      ownerId,
+      externalEventId: 'rule-1:event-a',
+    });
+
+    expect(result.skippedReason).toBeNull();
+    expect(result.created).not.toBeNull();
+    expect(result.created!.requesterName).toBe('Alice');
+    expect(result.created!.externalEventId).toBe('rule-1:event-a');
+    expect(result.created!.externalSource).toBe('automation_rule');
+  });
+
+  test('returns duplicate skip when external_event_id already exists', async () => {
+    const input = {
+      facilityId,
+      title: 'Test',
+      notes: null,
+      startTime: '2026-05-15T14:00:00.000Z',
+      endTime: '2026-05-15T15:00:00.000Z',
+      ownerId,
+      externalEventId: 'rule-1:event-dup',
+    };
+    await service.createSingleAutomationReservationAsync(input);
+    const second = await service.createSingleAutomationReservationAsync(input);
+
+    expect(second.skippedReason).toBe('duplicate');
+    expect(second.created).toBeNull();
+  });
+
+  test('returns conflict skip with conflict details when room is blocked', async () => {
+    // Pre-book an overlapping reservation manually
+    await repo.insertSingleReservationAsync({
+      facility_id: facilityId,
+      title: 'Existing booking',
+      requester_name: 'Bob',
+      requester_user_id: ownerId,
+      created_by_user_id: ownerId,
+      start_time: '2026-05-15T14:30:00.000Z',
+      end_time: '2026-05-15T15:30:00.000Z',
+      external_event_id: 'manual-1',
+      external_source: 'manual',
+    });
+
+    const result = await service.createSingleAutomationReservationAsync({
+      facilityId,
+      title: 'Worship',
+      notes: null,
+      startTime: '2026-05-15T14:00:00.000Z',
+      endTime: '2026-05-15T15:00:00.000Z',
+      ownerId,
+      externalEventId: 'rule-1:event-c',
+    });
+
+    expect(result.skippedReason).toBe('conflict');
+    expect(result.created).toBeNull();
+    expect(result.conflict).toBeDefined();
+    expect(result.conflict!.conflictingTitle).toBe('Existing booking');
+    expect(result.conflict!.facilityName).toBe('Conf Room');
   });
 });

--- a/apps/api_server/src/services/facilities_booking_service.ts
+++ b/apps/api_server/src/services/facilities_booking_service.ts
@@ -10,6 +10,32 @@ import type {
   UpdateReservationSeriesDto,
 } from '../models/facility';
 import { FacilitiesRepository } from '../repositories/facilities_repository';
+import { UsersRepository } from '../repositories/users_repository';
+
+export interface AutomationReservationInput {
+  facilityId: number;
+  title: string;
+  notes: string | null;
+  startTime: string;
+  endTime: string;
+  ownerId: number;
+  externalEventId: string;
+}
+
+export type AutomationReservationSkipReason = 'duplicate' | 'conflict';
+
+export interface AutomationReservationConflict {
+  facilityName: string;
+  conflictingTitle: string;
+  startTime: string;
+  endTime: string;
+}
+
+export interface AutomationReservationResult {
+  created: Reservation | null;
+  skippedReason: AutomationReservationSkipReason | null;
+  conflict?: AutomationReservationConflict;
+}
 
 type ResolvedSeriesInput = {
   title: string;
@@ -32,6 +58,59 @@ type ResolvedSeriesFacilities = {
 
 export class FacilitiesBookingService {
   private readonly repo = new FacilitiesRepository();
+  private readonly usersRepo = new UsersRepository();
+
+  async createSingleAutomationReservationAsync(
+    input: AutomationReservationInput,
+  ): Promise<AutomationReservationResult> {
+    // 1. Dedup
+    const existing = await this.repo.findByExternalEventIdAsync(
+      input.externalEventId,
+    );
+    if (existing != null) {
+      return { created: null, skippedReason: 'duplicate' };
+    }
+
+    // 2. Conflict check
+    const facility = await this.repo.findByIdAsync(input.facilityId);
+    const conflict = await this.repo.findReservationWindowConflictAsync(
+      input.facilityId,
+      input.startTime,
+      input.endTime,
+    );
+    if (conflict != null) {
+      return {
+        created: null,
+        skippedReason: 'conflict',
+        conflict: {
+          facilityName: facility.name,
+          conflictingTitle: conflict.title,
+          startTime: conflict.start_time,
+          endTime: conflict.end_time,
+        },
+      };
+    }
+
+    // 3. Owner lookup
+    const owner = await this.usersRepo.findByIdAsync(input.ownerId);
+
+    // 4. Insert
+    const created = await this.repo.insertSingleReservationAsync({
+      facility_id: input.facilityId,
+      title: input.title,
+      requester_name: owner.name,
+      requester_user_id: input.ownerId,
+      created_by_user_id: input.ownerId,
+      start_time: input.startTime,
+      end_time: input.endTime,
+      notes: input.notes,
+      external_event_id: input.externalEventId,
+      external_source: 'automation_rule',
+      created_by_rhythm: true,
+    });
+
+    return { created, skippedReason: null };
+  }
 
   async createRecurringSeries(
     data: CreateReservationSeriesDto,

--- a/apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart
+++ b/apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 
 import '../../../app/core/agents/agent_server_controller.dart';
+import '../../../app/core/notifications/local_notification_service.dart';
+import '../../notifications/controllers/notifications_controller.dart';
 import '../models/agent_session.dart';
 import '../models/agent_session_message.dart';
 import '../models/agent_ws_message.dart';
@@ -22,11 +25,25 @@ class PendingTrigger {
   final DateTime arrivedAt;
 }
 
-class AgentsController extends ChangeNotifier {
-  AgentsController(this._repository, this._agentServerController);
+class AgentsController extends ChangeNotifier with WidgetsBindingObserver {
+  AgentsController(
+    this._repository,
+    this._agentServerController,
+    this._notificationService,
+    this._notificationsController,
+  );
 
   final AgentsRepository _repository;
   final AgentServerController _agentServerController;
+  final LocalNotificationService _notificationService;
+  final NotificationsController _notificationsController;
+
+  AppLifecycleState _lifecycleState = AppLifecycleState.resumed;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    _lifecycleState = state;
+  }
 
   AgentsLoadStatus _status = AgentsLoadStatus.idle;
   String? _error;
@@ -75,6 +92,7 @@ class AgentsController extends ChangeNotifier {
   // --------------------------------------------------------------------------
 
   Future<void> initialize() async {
+    WidgetsBinding.instance.addObserver(this);
     if (!_agentServerController.isReady ||
         !_agentServerController.hasAnyAgent) {
       // Agent server not ready or no CLI installed → skip WebSocket connect;
@@ -300,6 +318,19 @@ class AgentsController extends ChangeNotifier {
         taskTitle: msg.taskTitle,
         arrivedAt: DateTime.now(),
       ));
+    } else if (msg is NotificationPushMessage) {
+      _notificationsController.pushAgentNotification(
+        id: msg.id,
+        title: msg.title,
+        body: msg.body,
+      );
+      if (_lifecycleState != AppLifecycleState.resumed) {
+        _notificationService.showMessageNotification(
+          id: msg.id,
+          title: msg.title,
+          body: msg.body,
+        );
+      }
     }
     notifyListeners();
   }
@@ -310,6 +341,7 @@ class AgentsController extends ChangeNotifier {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _wsSub?.cancel();
     _repository.dispose();
     super.dispose();

--- a/apps/desktop_flutter/lib/features/agents/models/agent_ws_message.dart
+++ b/apps/desktop_flutter/lib/features/agents/models/agent_ws_message.dart
@@ -23,6 +23,8 @@ abstract class AgentWsMessage {
         return TranscriptAppendMessage.fromJson(json);
       case 'trigger.fired':
         return TriggerFiredMessage.fromJson(json);
+      case 'notification.push':
+        return NotificationPushMessage.fromJson(json);
       case 'error':
         return WsErrorMessage.fromJson(json);
       default:
@@ -164,6 +166,26 @@ class TriggerFiredMessage extends AgentWsMessage {
       taskId: asString(json['taskId']) ?? '',
       taskTitle: asString(json['taskTitle']) ?? '',
       triggeredByUserId: asInt(json['triggeredByUserId']),
+    );
+  }
+}
+
+class NotificationPushMessage extends AgentWsMessage {
+  const NotificationPushMessage({
+    required this.id,
+    required this.title,
+    required this.body,
+  });
+
+  final int id;
+  final String title;
+  final String body;
+
+  factory NotificationPushMessage.fromJson(Map<String, dynamic> json) {
+    return NotificationPushMessage(
+      id: asInt(json['id']) ?? 0,
+      title: asString(json['title']) ?? '',
+      body: asString(json['body']) ?? '',
     );
   }
 }

--- a/apps/desktop_flutter/lib/features/facilities/data/facilities_data_source.dart
+++ b/apps/desktop_flutter/lib/features/facilities/data/facilities_data_source.dart
@@ -204,4 +204,99 @@ class FacilitiesDataSource {
     );
     assertOk(response);
   }
+
+  Future<AutomationReservationPreview> previewAutomationReservations({
+    int? facilityId,
+    String? startAfter,
+    String? endBefore,
+  }) async {
+    final query = <String, String>{};
+    if (facilityId != null) query['facilityId'] = '$facilityId';
+    if (startAfter != null && startAfter.isNotEmpty) {
+      query['startAfter'] = startAfter;
+    }
+    if (endBefore != null && endBefore.isNotEmpty) {
+      query['endBefore'] = endBefore;
+    }
+    final uri =
+        Uri.parse('$_baseUrl/facilities/automation-reservations/preview')
+            .replace(queryParameters: query.isEmpty ? null : query);
+    final response = await http.get(uri, headers: AuthSessionStore.headers());
+    assertOk(response);
+    return AutomationReservationPreview.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+  }
+
+  Future<int> deleteAutomationReservations({
+    int? facilityId,
+    String? startAfter,
+    String? endBefore,
+  }) async {
+    final query = <String, String>{};
+    if (facilityId != null) query['facilityId'] = '$facilityId';
+    if (startAfter != null && startAfter.isNotEmpty) {
+      query['startAfter'] = startAfter;
+    }
+    if (endBefore != null && endBefore.isNotEmpty) {
+      query['endBefore'] = endBefore;
+    }
+    final uri = Uri.parse('$_baseUrl/facilities/automation-reservations')
+        .replace(queryParameters: query.isEmpty ? null : query);
+    final response =
+        await http.delete(uri, headers: AuthSessionStore.headers());
+    assertOk(response);
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    return (body['deleted'] as num?)?.toInt() ?? 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Automation-reservation preview models
+// ---------------------------------------------------------------------------
+
+class AutomationReservationPreview {
+  const AutomationReservationPreview({
+    required this.total,
+    required this.byFacility,
+  });
+
+  final int total;
+  final List<AutomationReservationFacilityCount> byFacility;
+
+  factory AutomationReservationPreview.fromJson(Map<String, dynamic> json) {
+    final list = (json['byFacility'] as List<dynamic>? ?? const []);
+    return AutomationReservationPreview(
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      byFacility: list
+          .map(
+            (item) => AutomationReservationFacilityCount.fromJson(
+              item as Map<String, dynamic>,
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class AutomationReservationFacilityCount {
+  const AutomationReservationFacilityCount({
+    required this.facilityId,
+    required this.facilityName,
+    required this.count,
+  });
+
+  final int facilityId;
+  final String facilityName;
+  final int count;
+
+  factory AutomationReservationFacilityCount.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return AutomationReservationFacilityCount(
+      facilityId: (json['facilityId'] as num?)?.toInt() ?? 0,
+      facilityName: (json['facilityName'] as String?) ?? '',
+      count: (json['count'] as num?)?.toInt() ?? 0,
+    );
+  }
 }

--- a/apps/desktop_flutter/lib/features/facilities/views/facilities_view.dart
+++ b/apps/desktop_flutter/lib/features/facilities/views/facilities_view.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../app/core/services/server_config_service.dart';
 import '../../../app/core/ui/tokens/rhythm_theme.dart';
 import '../../../app/core/widgets/error_banner.dart';
 import '../controllers/facilities_controller.dart';
+import '../data/facilities_data_source.dart';
 import '../models/facility.dart';
 import '../models/reservation.dart';
 import '../models/reservation_series.dart';
@@ -145,6 +147,21 @@ class _FacilitiesViewState extends State<FacilitiesView> {
       builder: (_) => _ReservationDialog(
         controller: controller,
         facilities: controller.facilities,
+      ),
+    );
+  }
+
+  Future<void> _showAutomationCleanupDialog(
+    BuildContext context,
+    FacilitiesController controller,
+  ) async {
+    final serverConfig = context.read<ServerConfigService>();
+    await showDialog<void>(
+      context: context,
+      builder: (_) => _AutomationCleanupDialog(
+        facilities: controller.facilities,
+        baseUrl: serverConfig.url,
+        onCleanedUp: controller.loadFacilities,
       ),
     );
   }
@@ -2894,6 +2911,14 @@ class _RoomsManagerBar extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 16),
+          TextButton.icon(
+            onPressed: () =>
+                (context.findAncestorStateOfType<_FacilitiesViewState>())
+                    ?._showAutomationCleanupDialog(context, controller),
+            icon: Icon(Icons.cleaning_services_outlined, size: 18),
+            label: Text('Manage automation reservations'),
+          ),
+          const SizedBox(width: 8),
           OutlinedButton.icon(
             onPressed: () =>
                 (context.findAncestorStateOfType<_FacilitiesViewState>())
@@ -5774,6 +5799,260 @@ class _AvailabilityReservationRow extends StatelessWidget {
               ),
             ),
         ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Automation-reservation cleanup dialog
+// ---------------------------------------------------------------------------
+
+class _AutomationCleanupDialog extends StatefulWidget {
+  const _AutomationCleanupDialog({
+    required this.facilities,
+    required this.baseUrl,
+    required this.onCleanedUp,
+  });
+
+  final List<Facility> facilities;
+  final String baseUrl;
+  final VoidCallback onCleanedUp;
+
+  @override
+  State<_AutomationCleanupDialog> createState() =>
+      _AutomationCleanupDialogState();
+}
+
+class _AutomationCleanupDialogState extends State<_AutomationCleanupDialog> {
+  late final FacilitiesDataSource _dataSource;
+  AutomationReservationPreview? _preview;
+  bool _loading = true;
+  bool _deleting = false;
+  String? _error;
+  int? _facilityFilter;
+  DateTime? _startAfter;
+  DateTime? _endBefore;
+
+  @override
+  void initState() {
+    super.initState();
+    _dataSource = FacilitiesDataSource(baseUrl: widget.baseUrl);
+    _refreshPreview();
+  }
+
+  Future<void> _refreshPreview() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final preview = await _dataSource.previewAutomationReservations(
+        facilityId: _facilityFilter,
+        startAfter: _startAfter?.toUtc().toIso8601String(),
+        endBefore: _endBefore?.toUtc().toIso8601String(),
+      );
+      if (!mounted) return;
+      setState(() {
+        _preview = preview;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _doDelete() async {
+    setState(() => _deleting = true);
+    try {
+      final deleted = await _dataSource.deleteAutomationReservations(
+        facilityId: _facilityFilter,
+        startAfter: _startAfter?.toUtc().toIso8601String(),
+        endBefore: _endBefore?.toUtc().toIso8601String(),
+      );
+      if (!mounted) return;
+      Navigator.of(context).pop();
+      widget.onCleanedUp();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Deleted $deleted automation reservations.')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _deleting = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Manage automation reservations'),
+      content: SizedBox(
+        width: 480,
+        child: _buildBody(context),
+      ),
+      actions: _buildActions(context),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    if (_loading) {
+      return const SizedBox(
+        height: 80,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (_error != null) {
+      return Text('Failed to load preview: $_error');
+    }
+    final preview = _preview!;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          preview.total == 0
+              ? 'No automation-created reservations to clean up.'
+              : 'This will permanently delete ${preview.total} '
+                  'reservation${preview.total == 1 ? '' : 's'} created by automation rules.',
+          style: const TextStyle(fontWeight: FontWeight.w600),
+        ),
+        if (preview.total > 0) ...[
+          const SizedBox(height: 12),
+          for (final entry in preview.byFacility)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2),
+              child: Text('• ${entry.facilityName}: ${entry.count}'),
+            ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField<int?>(
+            value: _facilityFilter,
+            isExpanded: true,
+            decoration: const InputDecoration(
+              labelText: 'Filter by facility (optional)',
+              border: OutlineInputBorder(),
+            ),
+            items: [
+              const DropdownMenuItem<int?>(
+                value: null,
+                child: Text('All facilities'),
+              ),
+              ...widget.facilities.map(
+                (f) => DropdownMenuItem<int?>(
+                  value: f.id,
+                  child: Text(f.name),
+                ),
+              ),
+            ],
+            onChanged: (value) {
+              setState(() => _facilityFilter = value);
+              _refreshPreview();
+            },
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: _DatePickerField(
+                  label: 'Start after',
+                  value: _startAfter,
+                  onChanged: (date) {
+                    setState(() => _startAfter = date);
+                    _refreshPreview();
+                  },
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _DatePickerField(
+                  label: 'End before',
+                  value: _endBefore,
+                  onChanged: (date) {
+                    setState(() => _endBefore = date);
+                    _refreshPreview();
+                  },
+                ),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+
+  List<Widget> _buildActions(BuildContext context) {
+    if (_loading) return [];
+    if (_preview == null || _preview!.total == 0) {
+      return [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ];
+    }
+    return [
+      TextButton(
+        onPressed: _deleting ? null : () => Navigator.of(context).pop(),
+        child: const Text('Cancel'),
+      ),
+      FilledButton(
+        style: FilledButton.styleFrom(backgroundColor: const Color(0xFFB42318)),
+        onPressed: _deleting ? null : _doDelete,
+        child: Text(
+          _deleting
+              ? 'Deleting…'
+              : 'Delete ${_preview!.total} reservation${_preview!.total == 1 ? '' : 's'}',
+        ),
+      ),
+    ];
+  }
+}
+
+class _DatePickerField extends StatelessWidget {
+  const _DatePickerField({
+    required this.label,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final String label;
+  final DateTime? value;
+  final ValueChanged<DateTime?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () async {
+        final picked = await showDatePicker(
+          context: context,
+          initialDate: value ?? DateTime.now(),
+          firstDate: DateTime(2020),
+          lastDate: DateTime(2035),
+        );
+        if (picked != null || value != null) onChanged(picked);
+      },
+      child: InputDecorator(
+        decoration: InputDecoration(
+          labelText: label,
+          border: const OutlineInputBorder(),
+          suffixIcon: value != null
+              ? IconButton(
+                  icon: const Icon(Icons.clear, size: 16),
+                  onPressed: () => onChanged(null),
+                )
+              : null,
+        ),
+        child: Text(
+          value == null
+              ? 'Any'
+              : '${value!.year}-${value!.month.toString().padLeft(2, '0')}-${value!.day.toString().padLeft(2, '0')}',
+        ),
       ),
     );
   }

--- a/apps/desktop_flutter/lib/features/notifications/controllers/notifications_controller.dart
+++ b/apps/desktop_flutter/lib/features/notifications/controllers/notifications_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
+import '../models/agent_notification.dart';
 import '../models/app_notification.dart';
 import '../repositories/notifications_repository.dart';
 
@@ -19,11 +20,18 @@ class NotificationsController extends ChangeNotifier {
 
   List<AppNotification> _notifications = [];
   Timer? _pollingTimer;
+  final List<AgentNotification> _agentNotifications = [];
   PendingNavigation? _pendingNavigation;
 
   List<AppNotification> get notifications => _notifications;
-  int get unreadCount => _notifications.length;
+  int get unreadCount => _notifications.length + unreadAgentCount;
   PendingNavigation? get pendingNavigation => _pendingNavigation;
+
+  List<AgentNotification> get agentNotifications =>
+      List.unmodifiable(_agentNotifications.reversed.toList());
+
+  int get unreadAgentCount =>
+      _agentNotifications.where((n) => !n.isRead).length;
 
   /// Start polling every 60 seconds. Call once when the app is ready.
   void startPolling() {
@@ -35,6 +43,20 @@ class NotificationsController extends ChangeNotifier {
   void stopPolling() {
     _pollingTimer?.cancel();
     _pollingTimer = null;
+  }
+
+  void pushAgentNotification({
+    required int id,
+    required String title,
+    required String body,
+  }) {
+    _agentNotifications.add(AgentNotification(
+      id: id,
+      title: title,
+      body: body,
+      receivedAt: DateTime.now(),
+    ));
+    notifyListeners();
   }
 
   Future<void> _poll() async {
@@ -58,6 +80,9 @@ class NotificationsController extends ChangeNotifier {
     try {
       await _repository.markAllRead();
       _notifications = [];
+      for (final n in _agentNotifications) {
+        n.isRead = true;
+      }
       notifyListeners();
     } catch (_) {}
   }

--- a/apps/desktop_flutter/lib/features/notifications/models/agent_notification.dart
+++ b/apps/desktop_flutter/lib/features/notifications/models/agent_notification.dart
@@ -1,0 +1,15 @@
+class AgentNotification {
+  AgentNotification({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.receivedAt,
+    this.isRead = false,
+  });
+
+  final int id;
+  final String title;
+  final String body;
+  final DateTime receivedAt;
+  bool isRead;
+}

--- a/apps/desktop_flutter/lib/features/notifications/views/notification_panel.dart
+++ b/apps/desktop_flutter/lib/features/notifications/views/notification_panel.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../../../app/core/ui/tokens/rhythm_theme.dart';
 import '../controllers/notifications_controller.dart';
 import '../models/app_notification.dart';
+import '../models/agent_notification.dart';
 
 class NotificationPanel extends StatelessWidget {
   const NotificationPanel({super.key});
@@ -11,6 +12,8 @@ class NotificationPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     final controller = context.watch<NotificationsController>();
     final notifications = controller.notifications;
+    final agentItems = controller.agentNotifications;
+    final hasAny = notifications.isNotEmpty || agentItems.isNotEmpty;
 
     return Material(
       elevation: 8,
@@ -28,24 +31,25 @@ class NotificationPanel extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            _PanelHeader(hasNotifications: notifications.isNotEmpty),
-            if (notifications.isEmpty)
+            _PanelHeader(hasNotifications: hasAny),
+            if (!hasAny)
               const _EmptyState()
             else
               Flexible(
-                child: ListView.separated(
+                child: ListView(
                   padding: EdgeInsets.zero,
                   shrinkWrap: true,
-                  itemCount: notifications.length,
-                  separatorBuilder: (context, __) => Divider(
-                    height: 1,
-                    color: context.rhythm.borderSubtle,
-                  ),
-                  itemBuilder: (context, index) {
-                    return _NotificationTile(
-                      notification: notifications[index],
-                    );
-                  },
+                  children: [
+                    for (final n in agentItems)
+                      _AgentNotificationTile(notification: n),
+                    if (agentItems.isNotEmpty && notifications.isNotEmpty)
+                      Divider(height: 1, color: context.rhythm.borderSubtle),
+                    for (int i = 0; i < notifications.length; i++) ...[
+                      _NotificationTile(notification: notifications[i]),
+                      if (i < notifications.length - 1)
+                        Divider(height: 1, color: context.rhythm.borderSubtle),
+                    ],
+                  ],
                 ),
               ),
           ],
@@ -218,5 +222,71 @@ class _NotificationTile extends StatelessWidget {
     } catch (_) {
       return '';
     }
+  }
+}
+
+class _AgentNotificationTile extends StatelessWidget {
+  const _AgentNotificationTile({required this.notification});
+
+  final AgentNotification notification;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Icon(
+              Icons.smart_toy_outlined,
+              size: 16,
+              color: context.rhythm.accent,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  notification.title,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: context.rhythm.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  notification.body,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: context.rhythm.textSecondary,
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  _relativeTime(notification.receivedAt),
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: context.rhythm.textMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _relativeTime(DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inMinutes < 1) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
   }
 }

--- a/apps/desktop_flutter/lib/features/tasks/models/automation_rule.dart
+++ b/apps/desktop_flutter/lib/features/tasks/models/automation_rule.dart
@@ -152,6 +152,7 @@ class AutomationRule {
         'auto_schedule' => 'Auto-schedule to day',
         'send_notification' => 'Send notification',
         'tag_task' => 'Tag task',
+        'create_reservation' => 'Create reservation',
         _ => type,
       };
 }

--- a/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart
@@ -3,8 +3,11 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../app/core/services/server_config_service.dart';
 import '../../../app/core/ui/tokens/rhythm_theme.dart';
 import '../../../app/core/widgets/error_banner.dart';
+import '../../facilities/data/facilities_data_source.dart';
+import '../../facilities/models/facility.dart';
 import '../../integrations/models/integration_account.dart';
 import '../../integrations/models/planning_center_task_options.dart';
 import '../controllers/automation_rules_controller.dart';
@@ -746,6 +749,9 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
   String? _selectedTemplateName;
   late final FocusNode _titleTemplateFocus;
   late final FocusNode _notesTemplateFocus;
+  List<Facility> _dialogFacilities = [];
+  int? _selectedFacilityId;
+  bool _facilitiesLoading = false;
 
   @override
   void initState() {
@@ -839,10 +845,18 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
           ),
         )
         .toList();
+    _selectedFacilityId = widget.existing?.actionConfig?['facilityId'] is int
+        ? widget.existing!.actionConfig!['facilityId'] as int
+        : (widget.existing?.actionConfig?['facilityId'] is num
+            ? (widget.existing!.actionConfig!['facilityId'] as num).toInt()
+            : null);
     _syncAccountSelectionWithSource();
     if (existing == null && _nameController.text.trim().isEmpty) {
       _nameController.text = _suggestedName();
     }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadFacilitiesIfNeeded();
+    });
   }
 
   @override
@@ -874,15 +888,18 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
     final trigger =
         triggers.where((item) => item.key == _selectedTriggerKey).firstOrNull;
     final isPco = _selectedSource == 'planning_center';
+    final isGoogleCalendar = _selectedSource == 'google_calendar';
     final availableActions = isPco
         ? widget.controller.actions
-            .where(
-              (item) =>
-                  item.key == 'create_task' ||
-                  item.key == 'create_project_from_template',
-            )
+            .where((item) =>
+                item.key == 'create_task' ||
+                item.key == 'create_project_from_template')
             .toList()
-        : widget.controller.actions;
+        : isGoogleCalendar
+            ? widget.controller.actions.toList()
+            : widget.controller.actions
+                .where((item) => item.key != 'create_reservation')
+                .toList();
     if (availableActions.isNotEmpty &&
         !availableActions.any((item) => item.key == _selectedActionType)) {
       _selectedActionType = availableActions.first.key;
@@ -1841,6 +1858,64 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
             template: _messageTemplateController.text,
           ),
         ];
+      case 'create_reservation':
+        return [
+          if (_facilitiesLoading)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 8),
+              child: LinearProgressIndicator(),
+            )
+          else if (_dialogFacilities.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                'No facilities available. Add a facility in the Facilities view first.',
+                style: TextStyle(color: context.rhythm.textSecondary),
+              ),
+            )
+          else
+            DropdownButtonFormField<int>(
+              value: _dialogFacilities.any((f) => f.id == _selectedFacilityId)
+                  ? _selectedFacilityId
+                  : null,
+              isExpanded: true,
+              decoration: const InputDecoration(
+                labelText: 'Room / facility',
+                border: OutlineInputBorder(),
+              ),
+              items: _dialogFacilities
+                  .map((f) => DropdownMenuItem<int>(
+                        value: f.id,
+                        child: Text(
+                          f.building == null
+                              ? f.name
+                              : '${f.building} — ${f.name}',
+                        ),
+                      ))
+                  .toList(),
+              onChanged: (value) => setState(() => _selectedFacilityId = value),
+            ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _titleTemplateController,
+            decoration: const InputDecoration(
+              labelText: 'Reservation title template',
+              border: OutlineInputBorder(),
+              helperText:
+                  'Defaults to the calendar event title. Use {{title}}, {{date}}.',
+            ),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            controller: _notesTemplateController,
+            minLines: 2,
+            maxLines: 4,
+            decoration: const InputDecoration(
+              labelText: 'Reservation notes (optional)',
+              border: OutlineInputBorder(),
+            ),
+          ),
+        ];
       default:
         return [
           TextField(
@@ -2009,6 +2084,10 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
     }
     if (_targetDay != null) config['targetDay'] = _targetDay;
     if (_targetDayOfWeek != null) config['targetDayOfWeek'] = _targetDayOfWeek;
+    if (_selectedActionType == 'create_reservation' &&
+        _selectedFacilityId != null) {
+      config['facilityId'] = _selectedFacilityId;
+    }
     return config.isEmpty ? null : config;
   }
 
@@ -2073,6 +2152,25 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
     _selectedAccountId = accounts.firstOrNull?.id;
   }
 
+  Future<void> _loadFacilitiesIfNeeded() async {
+    if (_dialogFacilities.isNotEmpty || _facilitiesLoading) return;
+    if (!mounted) return;
+    setState(() => _facilitiesLoading = true);
+    try {
+      final serverConfig = context.read<ServerConfigService>();
+      final dataSource = FacilitiesDataSource(baseUrl: serverConfig.url);
+      final facilities = await dataSource.getFacilities();
+      if (!mounted) return;
+      setState(() {
+        _dialogFacilities = facilities;
+        _facilitiesLoading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _facilitiesLoading = false);
+    }
+  }
+
   String? _validateDraft() {
     if (_selectedSource != null && _selectedSource != 'rhythm') {
       final hasConnectedAccount = widget.controller.accounts.any(
@@ -2092,6 +2190,10 @@ class _AutomationBuilderDialogState extends State<_AutomationBuilderDialog> {
     if (_selectedActionType == 'send_notification' &&
         _messageTemplateController.text.trim().isEmpty) {
       return 'Notification automations need a message template.';
+    }
+    if (_selectedActionType == 'create_reservation' &&
+        _selectedFacilityId == null) {
+      return 'Pick a room for the reservation.';
     }
     return null;
   }

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -212,11 +212,15 @@ class RhythmApp extends StatelessWidget {
           ),
         ),
         ChangeNotifierProvider(
-          create: (_) {
+          create: (ctx) {
             final ds = AgentsDataSource();
             final repo = AgentsRepository(ds);
-            final controller = AgentsController(repo, agentServerController)
-              ..initialize();
+            final controller = AgentsController(
+              repo,
+              agentServerController,
+              localNotificationService,
+              ctx.read<NotificationsController>(),
+            )..initialize();
             _maybeSeedDebugTrigger(controller);
             return controller;
           },

--- a/apps/desktop_flutter/test/features/agents/agent_trigger_watcher_test.dart
+++ b/apps/desktop_flutter/test/features/agents/agent_trigger_watcher_test.dart
@@ -10,11 +10,15 @@ import 'package:rhythm_desktop/app/core/auth/auth_data_source.dart';
 import 'package:rhythm_desktop/app/core/auth/auth_session_service.dart';
 import 'package:rhythm_desktop/app/core/server/api_server_service.dart';
 import 'package:rhythm_desktop/app/core/services/server_config_service.dart';
+import 'package:rhythm_desktop/app/core/notifications/local_notification_service.dart';
 import 'package:rhythm_desktop/features/agents/controllers/agents_controller.dart';
 import 'package:rhythm_desktop/features/agents/models/agent_session.dart';
 import 'package:rhythm_desktop/features/agents/models/agent_session_message.dart';
 import 'package:rhythm_desktop/features/agents/models/agent_ws_message.dart';
 import 'package:rhythm_desktop/features/agents/repositories/agents_repository.dart';
+import 'package:rhythm_desktop/features/notifications/controllers/notifications_controller.dart';
+import 'package:rhythm_desktop/features/notifications/data/notifications_data_source.dart';
+import 'package:rhythm_desktop/features/notifications/repositories/notifications_repository.dart';
 
 // ---------------------------------------------------------------------------
 // Fakes / stubs
@@ -131,6 +135,27 @@ class _FakeAgentsRepository implements AgentsRepository {
   }
 }
 
+class _FakeLocalNotificationService extends LocalNotificationService {
+  @override
+  Future<void> showMessageNotification({
+    required int id,
+    required String title,
+    required String body,
+  }) async {}
+}
+
+class _FakeNotificationsController extends NotificationsController {
+  _FakeNotificationsController()
+      : super(NotificationsRepository(NotificationsDataSource()));
+
+  @override
+  void pushAgentNotification({
+    required int id,
+    required String title,
+    required String body,
+  }) {}
+}
+
 /// A stub [AuthDataSource] that does nothing (prevents real network calls).
 class _FakeAuthDataSource extends AuthDataSource {
   _FakeAuthDataSource() : super(baseUrl: 'http://localhost:4000');
@@ -166,6 +191,8 @@ void main() {
     agentsController = AgentsController(
       _FakeAgentsRepository(),
       agentServerController,
+      _FakeLocalNotificationService(),
+      _FakeNotificationsController(),
     );
     serverConfigService = ServerConfigService();
   });

--- a/apps/desktop_flutter/test/features/agents/agent_trigger_watcher_test.dart
+++ b/apps/desktop_flutter/test/features/agents/agent_trigger_watcher_test.dart
@@ -182,6 +182,8 @@ class _StubAuthSessionService extends AuthSessionService {
 // ---------------------------------------------------------------------------
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late AgentsController agentsController;
   late _FakeAgentServerController agentServerController;
   late ServerConfigService serverConfigService;

--- a/apps/desktop_flutter/test/features/agents/agents_controller_test.dart
+++ b/apps/desktop_flutter/test/features/agents/agents_controller_test.dart
@@ -171,6 +171,8 @@ AgentSession _makeSession(String id, AgentSessionStatus status) {
 // ---------------------------------------------------------------------------
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   late _FakeAgentsRepository fakeRepo;
   late AgentsController controller;
 

--- a/apps/desktop_flutter/test/features/agents/agents_controller_test.dart
+++ b/apps/desktop_flutter/test/features/agents/agents_controller_test.dart
@@ -2,12 +2,16 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:rhythm_desktop/app/core/agents/agent_server_controller.dart';
+import 'package:rhythm_desktop/app/core/notifications/local_notification_service.dart';
 import 'package:rhythm_desktop/app/core/server/api_server_service.dart';
 import 'package:rhythm_desktop/features/agents/controllers/agents_controller.dart';
 import 'package:rhythm_desktop/features/agents/models/agent_session.dart';
 import 'package:rhythm_desktop/features/agents/models/agent_session_message.dart';
 import 'package:rhythm_desktop/features/agents/models/agent_ws_message.dart';
 import 'package:rhythm_desktop/features/agents/repositories/agents_repository.dart';
+import 'package:rhythm_desktop/features/notifications/controllers/notifications_controller.dart';
+import 'package:rhythm_desktop/features/notifications/data/notifications_data_source.dart';
+import 'package:rhythm_desktop/features/notifications/repositories/notifications_repository.dart';
 
 // ---------------------------------------------------------------------------
 // Fake AgentServerController
@@ -121,6 +125,31 @@ class _FakeAgentsRepository implements AgentsRepository {
 }
 
 // ---------------------------------------------------------------------------
+// Fake notification dependencies
+// ---------------------------------------------------------------------------
+
+class _FakeLocalNotificationService extends LocalNotificationService {
+  @override
+  Future<void> showMessageNotification({
+    required int id,
+    required String title,
+    required String body,
+  }) async {}
+}
+
+class _FakeNotificationsController extends NotificationsController {
+  _FakeNotificationsController()
+      : super(NotificationsRepository(NotificationsDataSource()));
+
+  @override
+  void pushAgentNotification({
+    required int id,
+    required String title,
+    required String body,
+  }) {}
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -150,6 +179,8 @@ void main() {
     controller = AgentsController(
       fakeRepo,
       _FakeAgentServerController(ready: true, anyAgent: true),
+      _FakeLocalNotificationService(),
+      _FakeNotificationsController(),
     );
   });
 
@@ -198,6 +229,8 @@ void main() {
       final notReadyController = AgentsController(
         fakeRepo,
         _FakeAgentServerController(ready: false, anyAgent: false),
+        _FakeLocalNotificationService(),
+        _FakeNotificationsController(),
       );
       addTearDown(notReadyController.dispose);
 

--- a/apps/mcp_server/src/index.ts
+++ b/apps/mcp_server/src/index.ts
@@ -11,9 +11,11 @@ import { registerFacilityTools } from './tools/facilities.js';
 import { registerDashboardTools } from './tools/dashboard.js';
 import { registerClaudeTriggerTools } from './tools/claude_triggers.js';
 import { registerAutomationTools } from './tools/automations.js';
+import { registerNotificationTools } from './tools/notifications.js';
 
 const RHYTHM_API_URL = process.env.RHYTHM_API_URL ?? 'https://api.vcrcapps.com';
 const RHYTHM_API_TOKEN = process.env.RHYTHM_API_TOKEN ?? '';
+const RHYTHM_AGENT_URL = process.env.RHYTHM_AGENT_URL ?? 'http://localhost:4001';
 
 if (!RHYTHM_API_TOKEN) {
   process.stderr.write(
@@ -38,6 +40,7 @@ registerFacilityTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerDashboardTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerClaudeTriggerTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerAutomationTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
+registerNotificationTools(server, RHYTHM_AGENT_URL);
 
 // Connect over stdio (Claude Desktop / Claude Code MCP transport)
 const transport = new StdioServerTransport();

--- a/apps/mcp_server/src/tools/notifications.ts
+++ b/apps/mcp_server/src/tools/notifications.ts
@@ -1,0 +1,33 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { toolResult, toolError } from '../api_client.js';
+import { registerTool } from './_tool.js';
+
+export function registerNotificationTools(server: McpServer, agentUrl: string) {
+  registerTool(
+    server,
+    'rhythm_notify',
+    'Send a notification to the Rhythm app user. Use this when you have finished a task or have something important to report. The notification appears as a macOS system alert when Rhythm is in the background, and as an in-app badge when it is foregrounded.',
+    {
+      title: z.string().max(200).describe('Short headline, e.g. "Refactor complete".'),
+      body: z.string().max(200).describe('One or two sentences of detail about what you did or found.'),
+    },
+    async ({ title, body }: { title: string; body: string }) => {
+      try {
+        const res = await fetch(`${agentUrl}/notifications/agent`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title, body }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({})) as Record<string, unknown>;
+          throw new Error(`Rhythm agent server returned ${res.status}: ${String(err.error ?? res.statusText)}`);
+        }
+        const data = await res.json() as { id: number };
+        return toolResult(`Notification sent (id=${data.id}). The user has been alerted in Rhythm.`);
+      } catch (err) {
+        return toolError(err);
+      }
+    },
+  );
+}

--- a/docs/superpowers/specs/2026-05-08-agent-notifications-design.md
+++ b/docs/superpowers/specs/2026-05-08-agent-notifications-design.md
@@ -1,0 +1,193 @@
+# Agent Notification Design
+
+**Date:** 2026-05-08  
+**Status:** Approved
+
+## Goal
+
+Allow Claude and Codex agent skills to send a notification to the Rhythm user when they finish a task. The notification must:
+
+- Appear as a **macOS system notification** when Rhythm is backgrounded (persists until dismissed).
+- Appear as an **in-app bell badge** when Rhythm is foregrounded (accumulates; cleared by opening the notification panel).
+- Carry a **custom title and body** set by the calling agent.
+
+---
+
+## Architecture
+
+### Delivery path
+
+```
+MCP tool (rhythm_notify)
+  → POST http://localhost:4001/notifications/agent   (no auth; AGENT_LOCAL=true bypass)
+      → ws_gateway.broadcast({ type: 'notification.push', title, body })
+          → Flutter AgentsController._onWsMessage
+              → if backgrounded: LocalNotificationService.showMessageNotification()
+              → always: increment bell badge in NavigationSidebar
+```
+
+No new server. Port 4001 is the existing `api_server` process spawned by Flutter on launch.
+
+---
+
+## Components
+
+### 1. api_server — new route
+
+**File:** `src/routes/notifications_agent_routes.ts` (new)  
+**File:** `src/controllers/notifications_agent_controller.ts` (new)
+
+`POST /notifications/agent`
+
+- Auth: **bypassed** (same `AGENT_LOCAL=true` pattern as agent session endpoints).
+- Body: `{ title: string; body: string }` — both required, max 200 chars each.
+- Behaviour:
+  1. Insert a row into a new local-only `agent_notifications` table (`id`, `title`, `body`, `read_at`, `created_at`).
+  2. Call `broadcast({ v: 1, type: 'notification.push', title, body, id })`.
+  3. Return `201 { id }`.
+- Validation errors return `400`.
+
+**Migration:** add `agent_notifications` table in `database/migrations.ts`.  
+This table lives in local SQLite only — it is never referenced by the production Postgres path.
+
+**Route registration:** added to `app.ts` under the agent-local guard (same block as agent session routes).
+
+### 2. api_server — WebSocket broadcast
+
+No changes to `ws_gateway.ts` itself — `broadcast()` already exists and accepts any object. The controller calls it directly after the DB insert.
+
+### 3. MCP server — new tool
+
+**File:** `apps/mcp_server/src/tools/notifications.ts` (new)
+
+Tool name: `rhythm_notify`  
+Description: "Send a notification to the Rhythm app user. Use this when you have finished a task or have something important to report."
+
+Args:
+- `title` — string, required. Short headline (e.g. "Refactor complete").
+- `body` — string, required. One or two sentences of detail.
+
+Implementation: `apiPost` to `${RHYTHM_AGENT_URL}/notifications/agent` with `{ title, body }`.  
+Returns a success string on 201, or propagates the error.
+
+**Env var:** `RHYTHM_AGENT_URL` — defaults to `http://localhost:4001`. Added to `index.ts` alongside `RHYTHM_API_URL`. No token needed (auth bypassed on that route).
+
+**Registration:** `registerNotificationTools(server, RHYTHM_AGENT_URL)` called in `index.ts`.
+
+### 4. Flutter — new WS message type
+
+**File:** `lib/features/agents/models/agent_ws_message.dart`
+
+Add `NotificationPushMessage`:
+
+```dart
+class NotificationPushMessage extends AgentWsMessage {
+  const NotificationPushMessage({
+    required this.id,
+    required this.title,
+    required this.body,
+  });
+  final int id;
+  final String title;
+  final String body;
+  // fromJson factory
+}
+```
+
+Add `case 'notification.push':` to `AgentWsMessage.parse()`.
+
+### 5. Flutter — AgentsController
+
+**File:** `lib/features/agents/controllers/agents_controller.dart`
+
+- Inject `LocalNotificationService` into `AgentsController`.
+- In `_onWsMessage`, handle `NotificationPushMessage`:
+  - Always: append to `_agentNotifications` list (new field) and call `notifyListeners()`.
+  - If app is not in the foreground (`WidgetsBinding.instance.lifecycleState != AppLifecycleState.resumed`): call `LocalNotificationService.showMessageNotification(id, title, body)`.
+
+New fields:
+
+```dart
+final List<AgentNotification> _agentNotifications = [];
+int get unreadNotificationCount => _agentNotifications.where((n) => !n.isRead).length;
+```
+
+`AgentNotification` is a plain Dart class: `{ int id, String title, String body, bool isRead }`.
+
+Expose:
+- `List<AgentNotification> get agentNotifications` — unmodifiable list, newest-first.
+- `markAllNotificationsRead()` — sets all `isRead = true`, calls `notifyListeners()`.
+
+`AgentsController` must mix in `WidgetsBindingObserver` and register itself in `initialize()` so it can check `WidgetsBinding.instance.lifecycleState` when a push message arrives.
+
+### 6. Flutter — NavigationSidebar bell
+
+**File:** `lib/app/core/layout/navigation_sidebar.dart`
+
+- Add a bell icon button above (or below) the gear icon in the sidebar.
+- Show a red count badge when `agentsController.unreadNotificationCount > 0`.
+- Tapping the bell opens a `NotificationPanel` overlay (see below).
+- Badge and panel are driven by `context.watch<AgentsController>()`.
+
+### 7. Flutter — NotificationPanel
+
+**File:** `lib/app/core/agents/notification_panel.dart` (new)
+
+A `Positioned` overlay (similar to the agent bubble overlay pattern already in the codebase):
+
+- Lists `agentsController.agentNotifications` newest-first.
+- Each row: bold title, body text, relative timestamp.
+- "Mark all read" button at top — calls `agentsController.markAllNotificationsRead()` and closes panel.
+- Clicking outside dismisses (does not mark read — only the button does).
+- Notifications persist in memory for the session; they are not re-fetched from the server on next launch (agent_notifications table is a delivery store, not a history store).
+
+---
+
+## Data model
+
+### `agent_notifications` (local SQLite only)
+
+| column | type | notes |
+|---|---|---|
+| id | INTEGER PK AUTOINCREMENT | |
+| title | TEXT NOT NULL | |
+| body | TEXT NOT NULL | |
+| read_at | TEXT | ISO datetime or NULL |
+| created_at | TEXT | default datetime('now') |
+
+Row is inserted on `POST /notifications/agent`. Flutter reads `id` from the WS event — it does not need to query this table. The table is retained for potential future history endpoint.
+
+---
+
+## Error handling
+
+- MCP tool: if `localhost:4001` is unreachable, surface the error text to the agent so it can report to the user via its normal output.
+- Flutter: if the WS message arrives but `LocalNotificationService` throws (e.g. notification permission denied), log to stderr and still update the badge.
+- api_server: validation (missing/empty title or body) returns 400 with `{ error: "..." }`.
+
+---
+
+## What is NOT in scope
+
+- Notification persistence across Rhythm restarts (in-memory only this session).
+- Per-notification dismiss (only "mark all read").
+- Notifications from sources other than the MCP tool (e.g. production webhook).
+- Mobile / web surfaces.
+
+---
+
+## Files changed summary
+
+| File | Change |
+|---|---|
+| `apps/api_server/src/database/migrations.ts` | Add `agent_notifications` table |
+| `apps/api_server/src/controllers/notifications_agent_controller.ts` | New |
+| `apps/api_server/src/routes/notifications_agent_routes.ts` | New |
+| `apps/api_server/src/app.ts` | Register new route |
+| `apps/mcp_server/src/tools/notifications.ts` | New |
+| `apps/mcp_server/src/index.ts` | Register tool; add `RHYTHM_AGENT_URL` |
+| `apps/desktop_flutter/lib/features/agents/models/agent_ws_message.dart` | Add `NotificationPushMessage` |
+| `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart` | Handle push message; expose badge count |
+| `apps/desktop_flutter/lib/app/core/layout/navigation_sidebar.dart` | Bell icon + badge |
+| `apps/desktop_flutter/lib/app/core/agents/notification_panel.dart` | New overlay |
+| `apps/desktop_flutter/lib/main.dart` | Pass `LocalNotificationService` to `AgentsController` |


### PR DESCRIPTION
## Summary

This branch bundles two related-but-independent feature streams:

1. **Calendar → Reservation Automation** (issues #412–#417) — a new `create_reservation` automation action that books a Facilities room when a Google Calendar event trigger fires, with dedup, conflict detection, and a manager bulk-cleanup tool.
2. **Agent notifications** — push-notification infrastructure so agents (Claude/Codex) can post notifications into Rhythm via a new `rhythm_notify` MCP tool, with a WS push to the Flutter NotificationPanel.

## Calendar → Reservation (#412–#417)

- [#412](https://github.com/ajhochy/Rhythm/issues/412) — Backend foundation: `create_reservation` type, catalog entry, FacilitiesRepository methods (`438f369`)
- [#413](https://github.com/ajhochy/Rhythm/issues/413) — Booking service: `createSingleAutomationReservationAsync` with dedup + conflict detection (`37499fe`)
- [#414](https://github.com/ajhochy/Rhythm/issues/414) — Engine integration: `create_reservation` handler + Flutter `actionLabel` (`29c8d36`)
- [#415](https://github.com/ajhochy/Rhythm/issues/415) — Flutter automation editor: room picker + Google Calendar gating (`a2679c1`)
- [#416](https://github.com/ajhochy/Rhythm/issues/416) — Bulk-delete backend: preview + delete endpoints for automation reservations (`08de0c4`)
- [#417](https://github.com/ajhochy/Rhythm/issues/417) — Flutter Facilities cleanup dialog (`baf3a4c`)

## Agent notifications

- Design spec (`712f28c`)
- Schema: `agent_notifications` migration (`4d41979`)
- Backend API: `POST /notifications/agent` endpoint (`94b36a2`), endpoint tests (`6ff0607`), `NotificationsController` agent support (`50c5fd0`)
- WS contract: `NotificationPushMessage` type (`bce9da7`), `AgentsController` push handling (`3e3792c`)
- Flutter model: `AgentNotification` (`090e22a`), NotificationPanel rendering (`5bb3640`)
- MCP tool: `rhythm_notify` (`075b0cc`)

## Verification

- `npm run build` (api_server) — exit 0
- `npm test` (api_server) — 192/192 passing
- `flutter analyze --no-fatal-infos` — exit 0 on every file touched by this PR

## Test plan

### Calendar → Reservation
- [ ] Create an automation rule with Google Calendar trigger + `create_reservation` action; confirm room picker appears and is required
- [ ] Trigger a calendar event; verify a reservation is created with correct `external_event_id`
- [ ] Trigger the same event again; verify no duplicate reservation
- [ ] Trigger an event that conflicts with an existing booking; verify owner DM is sent
- [ ] Open Facilities → "Manage automation reservations"; preview filters work; delete removes only `automation_rule`-sourced rows
- [ ] Confirm non-managers cannot access the bulk delete

### Agent notifications
- [ ] From an agent session, call `rhythm_notify` MCP tool with a sample title/body
- [ ] Verify `POST /notifications/agent` records the row and pushes a `NotificationPushMessage` over WS
- [ ] Verify the notification renders in the Flutter NotificationPanel and is dismissable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
