### PR TITLE
ci: fix desktop release smoke test capability keys

### DIFF
--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -181,9 +181,12 @@ jobs:
                 console.error("Response is not a JSON object");
                 process.exit(1);
               }
-              if (typeof parsed.claude !== "boolean" || typeof parsed.codex !== "boolean") {
-                console.error("Response missing boolean claude/codex keys:", JSON.stringify(parsed));
-                process.exit(1);
+              const requiredKeys = ["claude-code", "codex", "gemini-cli", "opencode"];
+              for (const key of requiredKeys) {
+                if (typeof parsed[key] !== "boolean") {
+                  console.error("Response missing boolean key " + key + ":", JSON.stringify(parsed));
+                  process.exit(1);
+                }
               }
               console.log("capabilities OK:", JSON.stringify(parsed));
             });


### PR DESCRIPTION
## Summary
- Desktop Release workflow run [25701141246](https://github.com/ajhochy/Rhythm/actions/runs/25701141246) failed on the `Smoke-test bundled CLI server` step.
- `/agents/capabilities` now returns `claude-code`, `codex`, `gemini-cli`, `opencode` boolean keys, but the smoke test was still asserting the old `claude`/`codex` shape.
- Updated the validator to check all four current keys.

## Test plan
- [ ] Re-run Desktop Release workflow and confirm the smoke-test step passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)