### PR TITLE
Agent Id Required Bug

### DIFF
--- a/apps/desktop_flutter/lib/features/agents/data/agents_data_source.dart
+++ b/apps/desktop_flutter/lib/features/agents/data/agents_data_source.dart
@@ -150,7 +150,7 @@ class AgentsDataSource {
       Uri.parse('$_baseUrl/agent-sessions'),
       headers: AuthSessionStore.headers(json: true),
       body: jsonEncode({
-        'agent_id': agentId,
+        'agentId': agentId,
         'cwd': cwd,
         'name': name,
         if (taskId != null) 'taskId': taskId,


### PR DESCRIPTION
# Agent Id Required Bug

## What you asked for
Bug in CLI integration in rhythm. Whenever an agent is launched, it shows 'agentId is required' for all agent types.

## What was built
- Fix agent_id payload key in Flutter createSession

## Manual setup needed
_None._

## What we verified
All smoketest items passed.
