### PR TITLE
Introduce scheduledDate semantics + past-deadline visual state

### DIFF
--- a/apps/api_server/src/__tests__/backfill_scheduled_date.test.ts
+++ b/apps/api_server/src/__tests__/backfill_scheduled_date.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import Database from 'better-sqlite3';
+import { runMigrations } from '../database/migrations';
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+  return db;
+}
+
+describe('backfill_scheduled_date_v1 migration (issue #520)', () => {
+  it('fresh DB: migration runs on empty tables, marker row inserted, log emitted (no rows match)', () => {
+    const db = makeDb();
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      runMigrations(db);
+    } finally {
+      console.log = origLog;
+    }
+
+    // Marker must be present.
+    const marker = db.prepare(`SELECT value FROM schema_meta WHERE key = 'backfill_scheduled_date_v1'`).get() as { value: string } | undefined;
+    expect(marker).toBeDefined();
+    expect(new Date(marker!.value).toString()).not.toBe('Invalid Date');
+
+    // Log must have been emitted with zero counts.
+    const backfillLog = logs.find((l) => l.includes('backfill_scheduled_date_v1'));
+    expect(backfillLog).toBeDefined();
+    expect(backfillLog).toMatch(/tasks updated=0/);
+    expect(backfillLog).toMatch(/project_steps updated=0/);
+  });
+
+  it('pre-existing DB with legacy rows: correct rows backfilled, marker inserted, correct counts logged', () => {
+    const db = makeDb();
+
+    // Run migrations once to set up all tables (but no legacy data yet).
+    runMigrations(db);
+
+    // Remove the marker so we can test as if this were a pre-existing DB.
+    db.exec(`DELETE FROM schema_meta WHERE key = 'backfill_scheduled_date_v1'`);
+
+    // Seed tasks:
+    //   t1: due_date set, scheduled_date NULL → should be backfilled
+    //   t2: both set → scheduled_date must NOT change
+    //   t3: due_date NULL, scheduled_date NULL → not touched
+    //   t4: due_date set, scheduled_date NULL → should be backfilled
+    db.exec(`
+      INSERT INTO tasks (id, title, due_date, scheduled_date, status)
+      VALUES
+        ('t1', 'Task 1', '2026-01-01', NULL,         'open'),
+        ('t2', 'Task 2', '2026-01-02', '2026-01-10', 'open'),
+        ('t3', 'Task 3', NULL,         NULL,          'open'),
+        ('t4', 'Task 4', '2026-01-05', NULL,          'open')
+    `);
+
+    // Seed project_instance_steps:
+    //   ps1: due_date set, scheduled_date NULL → backfilled
+    //   ps2: scheduled_date already set → not changed (due_date is required NOT NULL)
+    // Note: project_instance_steps.due_date is NOT NULL so the NULL-due_date scenario
+    // is enforced at the schema level; that constraint coverage is tested separately.
+    // Disable FK enforcement so we can insert without real instance/step rows.
+    db.pragma('foreign_keys = OFF');
+    db.exec(`
+      INSERT INTO project_instance_steps (id, instance_id, step_id, title, due_date, scheduled_date, status)
+      VALUES
+        ('ps1', 'dummy-inst', 'dummy-step', 'Step 1', '2026-02-01', NULL,         'open'),
+        ('ps2', 'dummy-inst', 'dummy-step', 'Step 2', '2026-02-05', '2026-02-20', 'open')
+    `);
+    db.pragma('foreign_keys = ON');
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      runMigrations(db);
+    } finally {
+      console.log = origLog;
+    }
+
+    // --- task assertions ---
+    const tasks = db.prepare(`SELECT id, scheduled_date FROM tasks ORDER BY id`).all() as { id: string; scheduled_date: string | null }[];
+    const t1 = tasks.find((t) => t.id === 't1')!;
+    const t2 = tasks.find((t) => t.id === 't2')!;
+    const t3 = tasks.find((t) => t.id === 't3')!;
+    const t4 = tasks.find((t) => t.id === 't4')!;
+
+    expect(t1.scheduled_date).toBe('2026-01-01'); // backfilled from due_date
+    expect(t2.scheduled_date).toBe('2026-01-10'); // unchanged
+    expect(t3.scheduled_date).toBeNull();          // untouched (no due_date)
+    expect(t4.scheduled_date).toBe('2026-01-05'); // backfilled from due_date
+
+    // --- project_instance_steps assertions ---
+    const steps = db.prepare(`SELECT id, scheduled_date FROM project_instance_steps ORDER BY id`).all() as { id: string; scheduled_date: string | null }[];
+    const ps1 = steps.find((s) => s.id === 'ps1')!;
+    const ps2 = steps.find((s) => s.id === 'ps2')!;
+
+    expect(ps1.scheduled_date).toBe('2026-02-01'); // backfilled
+    expect(ps2.scheduled_date).toBe('2026-02-20'); // unchanged
+
+    // --- marker ---
+    const marker = db.prepare(`SELECT value FROM schema_meta WHERE key = 'backfill_scheduled_date_v1'`).get() as { value: string } | undefined;
+    expect(marker).toBeDefined();
+
+    // --- log: tasks=2, steps=1 ---
+    const backfillLog = logs.find((l) => l.includes('backfill_scheduled_date_v1'));
+    expect(backfillLog).toBeDefined();
+    expect(backfillLog).toMatch(/tasks updated=2/);
+    expect(backfillLog).toMatch(/project_steps updated=1/);
+  });
+
+  it('running migrations a second time is a no-op: no rows re-updated, no log emitted', () => {
+    const db = makeDb();
+
+    // First run: sets up tables and marker.
+    runMigrations(db);
+
+    // Capture any logs from a second run.
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+    try {
+      runMigrations(db);
+    } finally {
+      console.log = origLog;
+    }
+
+    // No backfill log should be emitted on a second run.
+    const backfillLog = logs.find((l) => l.includes('backfill_scheduled_date_v1'));
+    expect(backfillLog).toBeUndefined();
+
+    // Marker still present (not removed).
+    const marker = db.prepare(`SELECT key FROM schema_meta WHERE key = 'backfill_scheduled_date_v1'`).get();
+    expect(marker).toBeDefined();
+  });
+
+  it('rows where scheduled_date was already set are untouched even when due_date differs', () => {
+    const db = makeDb();
+    runMigrations(db);
+
+    // Remove marker to re-test as a legacy DB.
+    db.exec(`DELETE FROM schema_meta WHERE key = 'backfill_scheduled_date_v1'`);
+
+    // Task with both dates already populated.
+    db.exec(`
+      INSERT INTO tasks (id, title, due_date, scheduled_date, status)
+      VALUES ('tx', 'Already Scheduled', '2026-06-01', '2026-05-15', 'open')
+    `);
+
+    runMigrations(db);
+
+    const row = db.prepare(`SELECT scheduled_date FROM tasks WHERE id = 'tx'`).get() as { scheduled_date: string };
+    expect(row.scheduled_date).toBe('2026-05-15'); // unchanged
+  });
+});

--- a/apps/api_server/src/__tests__/dashboard_summary.test.ts
+++ b/apps/api_server/src/__tests__/dashboard_summary.test.ts
@@ -183,4 +183,101 @@ describe('GET /dashboard/summary', () => {
     expect(summary.tasks.todayRemainingCount).toBe(1);
     expect(summary.tasks.pastDueCount).toBe(0);
   });
+
+  it('pastDeadlineCount is present in response and defaults to 0 when no tasks are past deadline', async () => {
+    const owner = usersRepo.create({ name: 'Bob', email: 'bob@example.com' });
+    const headers = await authHeaderFor(owner.id);
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+
+    tasksRepo.create({ title: 'Future task', dueDate: tomorrow, ownerId: owner.id });
+
+    const res = await fetch(`${baseUrl}/dashboard/summary`, { headers });
+    expect(res.status).toBe(200);
+
+    const summary = await readJson(res) as { tasks: { pastDeadlineCount: number } };
+    expect(summary.tasks.pastDeadlineCount).toBe(0);
+  });
+
+  it('pastDeadlineCount counts task with dueDate in past but scheduledDate in future (past-deadline-only)', async () => {
+    // A task where dueDate has passed but scheduledDate is future:
+    //   isOverdue = false (priorityDate = scheduledDate which is future)
+    //   isPastDeadline = true (dueDate < today)
+    // → counted in pastDeadlineCount only, NOT in pastDueCount.
+    const owner = usersRepo.create({ name: 'Carol', email: 'carol@example.com' });
+    const headers = await authHeaderFor(owner.id);
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+
+    // scheduledDate in future (not overdue), dueDate yesterday (past deadline)
+    tasksRepo.create({
+      title: 'Past deadline only',
+      dueDate: yesterday,
+      scheduledDate: tomorrow,
+      ownerId: owner.id,
+    });
+
+    const res = await fetch(`${baseUrl}/dashboard/summary`, { headers });
+    expect(res.status).toBe(200);
+
+    const summary = await readJson(res) as {
+      tasks: { pastDueCount: number; pastDeadlineCount: number };
+    };
+
+    // Must be mutually exclusive: past-deadline-only task goes to pastDeadlineCount
+    expect(summary.tasks.pastDueCount).toBe(0);
+    expect(summary.tasks.pastDeadlineCount).toBe(1);
+  });
+
+  it('pastDeadlineCount excludes tasks that are overdue (mutual exclusivity)', async () => {
+    // A task where both scheduledDate and dueDate are in the past:
+    //   isOverdue = true  → counted in pastDueCount
+    //   isPastDeadline = true, but overdue wins → NOT in pastDeadlineCount
+    const owner = usersRepo.create({ name: 'Dave', email: 'dave@example.com' });
+    const headers = await authHeaderFor(owner.id);
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+
+    // Both dates in the past → overdue AND past-deadline, but must count in pastDueCount only
+    tasksRepo.create({
+      title: 'Both overdue and past deadline',
+      scheduledDate: twoDaysAgo,
+      dueDate: yesterday,
+      ownerId: owner.id,
+    });
+
+    const res = await fetch(`${baseUrl}/dashboard/summary`, { headers });
+    expect(res.status).toBe(200);
+
+    const summary = await readJson(res) as {
+      tasks: { pastDueCount: number; pastDeadlineCount: number };
+    };
+
+    // pastDueCount gets it; pastDeadlineCount must NOT double-count it
+    expect(summary.tasks.pastDueCount).toBe(1);
+    expect(summary.tasks.pastDeadlineCount).toBe(0);
+  });
+
+  it('done tasks are excluded from pastDeadlineCount', async () => {
+    const owner = usersRepo.create({ name: 'Eve', email: 'eve@example.com' });
+    const headers = await authHeaderFor(owner.id);
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+
+    // Past-deadline-only task that's done → must not appear in pastDeadlineCount
+    const doneTask = tasksRepo.create({
+      title: 'Done past deadline task',
+      dueDate: yesterday,
+      scheduledDate: tomorrow,
+      ownerId: owner.id,
+    });
+    tasksRepo.update(doneTask.id, { status: 'done' }, owner.id);
+
+    const res = await fetch(`${baseUrl}/dashboard/summary`, { headers });
+    expect(res.status).toBe(200);
+
+    const summary = await readJson(res) as {
+      tasks: { pastDeadlineCount: number };
+    };
+    expect(summary.tasks.pastDeadlineCount).toBe(0);
+  });
 });

--- a/apps/api_server/src/__tests__/dashboard_summary.test.ts
+++ b/apps/api_server/src/__tests__/dashboard_summary.test.ts
@@ -194,8 +194,9 @@ describe('GET /dashboard/summary', () => {
     const res = await fetch(`${baseUrl}/dashboard/summary`, { headers });
     expect(res.status).toBe(200);
 
-    const summary = await readJson(res) as { tasks: { pastDeadlineCount: number } };
+    const summary = await readJson(res) as { tasks: { pastDeadlineCount: number; pastDeadlineTasks: unknown[] } };
     expect(summary.tasks.pastDeadlineCount).toBe(0);
+    expect(summary.tasks.pastDeadlineTasks).toHaveLength(0);
   });
 
   it('pastDeadlineCount counts task with dueDate in past but scheduledDate in future (past-deadline-only)', async () => {
@@ -220,12 +221,64 @@ describe('GET /dashboard/summary', () => {
     expect(res.status).toBe(200);
 
     const summary = await readJson(res) as {
-      tasks: { pastDueCount: number; pastDeadlineCount: number };
+      tasks: {
+        pastDueCount: number;
+        pastDeadlineCount: number;
+        pastDeadlineTasks: Array<{ id: string; title: string; dueDate: string | null; scheduledDate: string | null; sourceType: string | null }>;
+      };
     };
 
     // Must be mutually exclusive: past-deadline-only task goes to pastDeadlineCount
     expect(summary.tasks.pastDueCount).toBe(0);
     expect(summary.tasks.pastDeadlineCount).toBe(1);
+
+    // pastDeadlineTasks should contain the task with correct fields
+    expect(summary.tasks.pastDeadlineTasks).toHaveLength(1);
+    expect(summary.tasks.pastDeadlineTasks[0].title).toBe('Past deadline only');
+    expect(summary.tasks.pastDeadlineTasks[0].dueDate).toBe(yesterday);
+    expect(summary.tasks.pastDeadlineTasks[0].scheduledDate).toBe(tomorrow);
+    expect(summary.tasks.pastDeadlineTasks[0].sourceType).toBeNull();
+  });
+
+  it('pastDeadlineTasks is sorted by dueDate ascending (most-overdue deadline first)', async () => {
+    const owner = usersRepo.create({ name: 'Frank', email: 'frank@example.com' });
+    const headers = await authHeaderFor(owner.id);
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
+    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+    const dayAfterTomorrow = new Date(Date.now() + 2 * 86_400_000).toISOString().slice(0, 10);
+
+    // Two past-deadline-only tasks (dueDate past, scheduledDate future → not overdue)
+    tasksRepo.create({
+      title: 'Older deadline',
+      dueDate: twoDaysAgo,
+      scheduledDate: tomorrow,
+      ownerId: owner.id,
+    });
+    tasksRepo.create({
+      title: 'Newer deadline',
+      dueDate: yesterday,
+      scheduledDate: dayAfterTomorrow,
+      ownerId: owner.id,
+    });
+
+    const res = await fetch(`${baseUrl}/dashboard/summary`, { headers });
+    expect(res.status).toBe(200);
+
+    const summary = await readJson(res) as {
+      tasks: {
+        pastDeadlineCount: number;
+        pastDeadlineTasks: Array<{ title: string; dueDate: string | null }>;
+      };
+    };
+
+    expect(summary.tasks.pastDeadlineCount).toBe(2);
+    expect(summary.tasks.pastDeadlineTasks).toHaveLength(2);
+    // Most-overdue deadline (oldest dueDate) first
+    expect(summary.tasks.pastDeadlineTasks[0].title).toBe('Older deadline');
+    expect(summary.tasks.pastDeadlineTasks[0].dueDate).toBe(twoDaysAgo);
+    expect(summary.tasks.pastDeadlineTasks[1].title).toBe('Newer deadline');
+    expect(summary.tasks.pastDeadlineTasks[1].dueDate).toBe(yesterday);
   });
 
   it('pastDeadlineCount excludes tasks that are overdue (mutual exclusivity)', async () => {
@@ -249,12 +302,14 @@ describe('GET /dashboard/summary', () => {
     expect(res.status).toBe(200);
 
     const summary = await readJson(res) as {
-      tasks: { pastDueCount: number; pastDeadlineCount: number };
+      tasks: { pastDueCount: number; pastDeadlineCount: number; pastDeadlineTasks: unknown[] };
     };
 
     // pastDueCount gets it; pastDeadlineCount must NOT double-count it
     expect(summary.tasks.pastDueCount).toBe(1);
     expect(summary.tasks.pastDeadlineCount).toBe(0);
+    // pastDeadlineTasks must also be empty (task is in pastDue, not here)
+    expect(summary.tasks.pastDeadlineTasks).toHaveLength(0);
   });
 
   it('done tasks are excluded from pastDeadlineCount', async () => {
@@ -276,8 +331,9 @@ describe('GET /dashboard/summary', () => {
     expect(res.status).toBe(200);
 
     const summary = await readJson(res) as {
-      tasks: { pastDeadlineCount: number };
+      tasks: { pastDeadlineCount: number; pastDeadlineTasks: unknown[] };
     };
     expect(summary.tasks.pastDeadlineCount).toBe(0);
+    expect(summary.tasks.pastDeadlineTasks).toHaveLength(0);
   });
 });

--- a/apps/api_server/src/__tests__/dashboard_summary.test.ts
+++ b/apps/api_server/src/__tests__/dashboard_summary.test.ts
@@ -148,4 +148,39 @@ describe('GET /dashboard/summary', () => {
     const res = await fetch(`${baseUrl}/dashboard/summary`);
     expect(res.status).toBe(401);
   });
+
+  it("respects the user's timezone when classifying tasks as past-due vs today", async () => {
+    // This test pins dates relative to "today" using the server's clock (same as
+    // the test runner).  The key assertion is that the dashboard uses the user's
+    // timezone (America/Los_Angeles by default) rather than UTC, so a task
+    // scheduled for today should show up in todayRemainingCount rather than
+    // pastDueCount regardless of which UTC offset the test runner runs on.
+    const owner = usersRepo.create({
+      name: 'TZ user',
+      email: 'tz@example.com',
+      timezone: 'America/Los_Angeles',
+    });
+    const headers = await authHeaderFor(owner.id);
+
+    // Derive "today" in America/Los_Angeles (same logic as the service under test).
+    const laTodayStr = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'America/Los_Angeles',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(new Date());
+
+    tasksRepo.create({ title: 'LA today task', dueDate: laTodayStr, ownerId: owner.id });
+
+    const res = await fetch(`${baseUrl}/dashboard/summary`, { headers });
+    expect(res.status).toBe(200);
+
+    const summary = await readJson(res) as {
+      tasks: { pastDueCount: number; todayRemainingCount: number };
+    };
+
+    // The task is due today in LA → should appear in today, not past due.
+    expect(summary.tasks.todayRemainingCount).toBe(1);
+    expect(summary.tasks.pastDueCount).toBe(0);
+  });
 });

--- a/apps/api_server/src/__tests__/dashboard_summary.test.ts
+++ b/apps/api_server/src/__tests__/dashboard_summary.test.ts
@@ -19,6 +19,25 @@ function makeDb() {
   return db;
 }
 
+/**
+ * Returns a YYYY-MM-DD date string for the given timezone, offset by `offsetDays`
+ * from today (negative = past, positive = future).  All dashboard test fixtures
+ * should use this helper so that "yesterday" in the test matches "yesterday" as
+ * seen by the service, which classifies tasks using the user's timezone.
+ */
+function dateInTimezone(timezone: string, offsetDays: number): string {
+  const todayStr = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
+  // Parse as local midnight so we can add/subtract days safely.
+  const d = new Date(todayStr + 'T00:00:00');
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
 async function readJson(response: Response) {
   const text = await response.text();
   return text ? JSON.parse(text) : null;
@@ -61,9 +80,12 @@ describe('GET /dashboard/summary', () => {
   it('returns a well-shaped summary with correct counts for a realistic scenario', async () => {
     const owner = usersRepo.create({ name: 'Alice', email: 'alice@example.com' });
     const headers = await authHeaderFor(owner.id);
-    const today = new Date().toISOString().slice(0, 10);
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+    // Use the user's default timezone (America/Los_Angeles) so that "yesterday",
+    // "today", and "tomorrow" align with the service's classification logic.
+    const tz = 'America/Los_Angeles';
+    const today = dateInTimezone(tz, 0);
+    const yesterday = dateInTimezone(tz, -1);
+    const tomorrow = dateInTimezone(tz, 1);
 
     // Create tasks: 1 past due, 1 today, 1 tomorrow, 1 done today, 1 unscheduled
     tasksRepo.create({ title: 'Past due task', dueDate: yesterday, ownerId: owner.id });
@@ -206,8 +228,10 @@ describe('GET /dashboard/summary', () => {
     // → counted in pastDeadlineCount only, NOT in pastDueCount.
     const owner = usersRepo.create({ name: 'Carol', email: 'carol@example.com' });
     const headers = await authHeaderFor(owner.id);
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+    // Use the user's default timezone so dates match the service's classification.
+    const tz = 'America/Los_Angeles';
+    const yesterday = dateInTimezone(tz, -1);
+    const tomorrow = dateInTimezone(tz, 1);
 
     // scheduledDate in future (not overdue), dueDate yesterday (past deadline)
     tasksRepo.create({
@@ -243,10 +267,12 @@ describe('GET /dashboard/summary', () => {
   it('pastDeadlineTasks is sorted by dueDate ascending (most-overdue deadline first)', async () => {
     const owner = usersRepo.create({ name: 'Frank', email: 'frank@example.com' });
     const headers = await authHeaderFor(owner.id);
-    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
-    const dayAfterTomorrow = new Date(Date.now() + 2 * 86_400_000).toISOString().slice(0, 10);
+    // Use the user's default timezone so dates match the service's classification.
+    const tz = 'America/Los_Angeles';
+    const twoDaysAgo = dateInTimezone(tz, -2);
+    const yesterday = dateInTimezone(tz, -1);
+    const tomorrow = dateInTimezone(tz, 1);
+    const dayAfterTomorrow = dateInTimezone(tz, 2);
 
     // Two past-deadline-only tasks (dueDate past, scheduledDate future → not overdue)
     tasksRepo.create({
@@ -287,8 +313,9 @@ describe('GET /dashboard/summary', () => {
     //   isPastDeadline = true, but overdue wins → NOT in pastDeadlineCount
     const owner = usersRepo.create({ name: 'Dave', email: 'dave@example.com' });
     const headers = await authHeaderFor(owner.id);
-    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+    const tz = 'America/Los_Angeles';
+    const twoDaysAgo = dateInTimezone(tz, -2);
+    const yesterday = dateInTimezone(tz, -1);
 
     // Both dates in the past → overdue AND past-deadline, but must count in pastDueCount only
     tasksRepo.create({
@@ -315,8 +342,9 @@ describe('GET /dashboard/summary', () => {
   it('done tasks are excluded from pastDeadlineCount', async () => {
     const owner = usersRepo.create({ name: 'Eve', email: 'eve@example.com' });
     const headers = await authHeaderFor(owner.id);
-    const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
-    const tomorrow = new Date(Date.now() + 86_400_000).toISOString().slice(0, 10);
+    const tz = 'America/Los_Angeles';
+    const yesterday = dateInTimezone(tz, -1);
+    const tomorrow = dateInTimezone(tz, 1);
 
     // Past-deadline-only task that's done → must not appear in pastDeadlineCount
     const doneTask = tasksRepo.create({

--- a/apps/api_server/src/__tests__/phase8_collaboration.test.ts
+++ b/apps/api_server/src/__tests__/phase8_collaboration.test.ts
@@ -186,10 +186,11 @@ describe('Phase 8 collaboration APIs', () => {
     });
     expect(generateResponse.status).toBe(201);
     const instance = await readJson(generateResponse) as {
-      steps: Array<{ id: string; assigneeId: number | null; assigneeName: string | null }>;
+      steps: Array<{ id: string; assigneeId: number | null; assigneeName: string | null; scheduledDate: string | null }>;
     };
     expect(instance.steps[0].assigneeId).toBe(firstAssignee.id);
     expect(instance.steps[0].assigneeName).toBe('Bob Assignee');
+    expect(instance.steps[0].scheduledDate).toBeNull();
 
     const updateInstanceStepResponse = await fetch(
       `${baseUrl}/project-instances/steps/${instance.steps[0].id}`,
@@ -206,9 +207,11 @@ describe('Phase 8 collaboration APIs', () => {
     const updatedStep = await readJson(updateInstanceStepResponse) as {
       assigneeId: number | null;
       assigneeName: string | null;
+      scheduledDate: string | null;
     };
     expect(updatedStep.assigneeId).toBe(secondAssignee.id);
     expect(updatedStep.assigneeName).toBe('Carol Reassigned');
+    expect(updatedStep.scheduledDate).toBeNull();
   });
 
   it('lets workspace admins directly add existing users as members', async () => {

--- a/apps/api_server/src/__tests__/task_date_status.test.ts
+++ b/apps/api_server/src/__tests__/task_date_status.test.ts
@@ -4,6 +4,8 @@ import {
   isPastDeadline,
   priorityDate,
   taskDateStatus,
+  todayInTimezone,
+  todayDateInTimezone,
 } from '../services/task_date_status';
 
 // Pin a fixed reference date for all tests: 2026-05-15
@@ -177,5 +179,55 @@ describe('taskDateStatus', () => {
     expect(result.overdue).toBe(false);
     expect(result.pastDeadline).toBe(false);
     expect(result.priorityDate).toBeNull();
+  });
+});
+
+// ── todayInTimezone / todayDateInTimezone ──────────────────────────────────────
+//
+// These tests verify TZ-boundary behaviour by constructing a pinned Date that
+// falls in "UTC tomorrow" but is still "today" in America/Los_Angeles.
+//
+// 2026-05-15 at 23:00 UTC = 2026-05-15 at 16:00 PDT (UTC-7 in summer).
+// So when "now" is 2026-05-15T23:00:00Z:
+//   • todayInTimezone('America/Los_Angeles') → '2026-05-15'
+//   • todayInTimezone('UTC') → '2026-05-15'
+//
+// 2026-05-16 at 01:00 UTC = 2026-05-15 at 18:00 PDT.
+// So when "now" is 2026-05-16T01:00:00Z:
+//   • todayInTimezone('UTC') → '2026-05-16'
+//   • todayInTimezone('America/Los_Angeles') → '2026-05-15'   ← the key TZ-boundary case
+
+describe('todayInTimezone', () => {
+  it('returns a string in YYYY-MM-DD format', () => {
+    const result = todayInTimezone('America/Los_Angeles');
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('returns a string in YYYY-MM-DD format for UTC', () => {
+    const result = todayInTimezone('UTC');
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe('todayDateInTimezone', () => {
+  it('returns a Date whose YYYY-MM-DD matches todayInTimezone for the same TZ', () => {
+    const tz = 'America/Los_Angeles';
+    const dateStr = todayInTimezone(tz);
+    const d = todayDateInTimezone(tz);
+    const expected = new Date(dateStr + 'T00:00:00');
+    expect(d.getTime()).toBe(expected.getTime());
+  });
+
+  it('task overdue check uses LA date — task for "today in LA" is NOT overdue even when UTC says tomorrow', () => {
+    // Simulate: user is in LA. Their local date is 2026-05-15.
+    // The server clock (UTC) shows 2026-05-16T01:00:00Z (1 AM UTC next day).
+    // A task scheduled for 2026-05-15 should NOT be overdue from the LA perspective.
+    const laTodayDate = new Date('2026-05-15T00:00:00'); // midnight, local representation
+    const task = { status: 'open' as const, scheduledDate: '2026-05-15' };
+    // From LA's "today" (2026-05-15), this task is due today — not overdue.
+    expect(isOverdue(task, laTodayDate)).toBe(false);
+    // From UTC's "today" (2026-05-16), the same task would appear overdue.
+    const utcTodayDate = new Date('2026-05-16T00:00:00');
+    expect(isOverdue(task, utcTodayDate)).toBe(true);
   });
 });

--- a/apps/api_server/src/__tests__/task_date_status.test.ts
+++ b/apps/api_server/src/__tests__/task_date_status.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isOverdue,
+  isPastDeadline,
+  priorityDate,
+  taskDateStatus,
+} from '../services/task_date_status';
+
+// Pin a fixed reference date for all tests: 2026-05-15
+const TODAY = new Date('2026-05-15T00:00:00');
+
+// ── priorityDate ─────────────────────────────────────────────────────────────
+
+describe('priorityDate', () => {
+  it('returns scheduledDate when both are set', () => {
+    const result = priorityDate({ scheduledDate: '2026-05-10', dueDate: '2026-05-12' });
+    expect(result).toEqual(new Date('2026-05-10T00:00:00'));
+  });
+
+  it('returns dueDate when only dueDate is set', () => {
+    const result = priorityDate({ dueDate: '2026-05-12' });
+    expect(result).toEqual(new Date('2026-05-12T00:00:00'));
+  });
+
+  it('returns scheduledDate when only scheduledDate is set', () => {
+    const result = priorityDate({ scheduledDate: '2026-05-10' });
+    expect(result).toEqual(new Date('2026-05-10T00:00:00'));
+  });
+
+  it('returns null when both dates are null', () => {
+    expect(priorityDate({ scheduledDate: null, dueDate: null })).toBeNull();
+  });
+
+  it('returns null when both dates are undefined', () => {
+    expect(priorityDate({})).toBeNull();
+  });
+});
+
+// ── isOverdue ─────────────────────────────────────────────────────────────────
+
+describe('isOverdue', () => {
+  it('returns true when scheduledDate is in the past (scheduled-only task)', () => {
+    expect(isOverdue({ status: 'open', scheduledDate: '2026-05-14' }, TODAY)).toBe(true);
+  });
+
+  it('returns true when dueDate is in the past (due-only task)', () => {
+    expect(isOverdue({ status: 'open', dueDate: '2026-05-14' }, TODAY)).toBe(true);
+  });
+
+  it('returns true when both dates are in the past', () => {
+    expect(
+      isOverdue({ status: 'open', scheduledDate: '2026-05-10', dueDate: '2026-05-12' }, TODAY),
+    ).toBe(true);
+  });
+
+  it('returns false when both dates are null', () => {
+    expect(isOverdue({ status: 'open', scheduledDate: null, dueDate: null }, TODAY)).toBe(false);
+  });
+
+  it('returns false when status is done (hard short-circuit)', () => {
+    expect(isOverdue({ status: 'done', scheduledDate: '2026-05-10' }, TODAY)).toBe(false);
+    expect(isOverdue({ status: 'done', dueDate: '2026-05-10' }, TODAY)).toBe(false);
+    expect(isOverdue({ status: 'done', scheduledDate: null, dueDate: null }, TODAY)).toBe(false);
+  });
+
+  it('returns false for status=done even when both dates are deeply in the past', () => {
+    expect(
+      isOverdue({ status: 'done', scheduledDate: '2020-01-01', dueDate: '2019-01-01' }, TODAY),
+    ).toBe(false);
+  });
+
+  it('returns false when scheduledDate is today (not strictly before)', () => {
+    expect(isOverdue({ status: 'open', scheduledDate: '2026-05-15' }, TODAY)).toBe(false);
+  });
+
+  it('returns false when dueDate is today (not strictly before)', () => {
+    expect(isOverdue({ status: 'open', dueDate: '2026-05-15' }, TODAY)).toBe(false);
+  });
+
+  it('returns false when scheduledDate is in the future', () => {
+    expect(isOverdue({ status: 'open', scheduledDate: '2026-05-20' }, TODAY)).toBe(false);
+  });
+
+  // Reported bug case: scheduledDate is in future but dueDate is in past
+  // isOverdue uses scheduledDate ?? dueDate, so scheduledDate wins → NOT overdue
+  it('returns false when scheduledDate is in the future even if dueDate is in the past (bug case)', () => {
+    expect(
+      isOverdue({ status: 'open', scheduledDate: '2026-05-20', dueDate: '2026-05-10' }, TODAY),
+    ).toBe(false);
+  });
+
+  it('returns true for in_progress status when scheduledDate is past', () => {
+    expect(isOverdue({ status: 'in_progress', scheduledDate: '2026-05-14' }, TODAY)).toBe(true);
+  });
+
+  it('returns true for waiting_for_reply status when dueDate is past', () => {
+    expect(
+      isOverdue({ status: 'waiting_for_reply', dueDate: '2026-05-14' }, TODAY),
+    ).toBe(true);
+  });
+});
+
+// ── isPastDeadline ────────────────────────────────────────────────────────────
+
+describe('isPastDeadline', () => {
+  it('returns true when dueDate is in the past', () => {
+    expect(isPastDeadline({ status: 'open', dueDate: '2026-05-14' }, TODAY)).toBe(true);
+  });
+
+  it('returns false when dueDate is today (not strictly before)', () => {
+    expect(isPastDeadline({ status: 'open', dueDate: '2026-05-15' }, TODAY)).toBe(false);
+  });
+
+  it('returns false when dueDate is in the future', () => {
+    expect(isPastDeadline({ status: 'open', dueDate: '2026-05-20' }, TODAY)).toBe(false);
+  });
+
+  it('returns false when dueDate is null', () => {
+    expect(isPastDeadline({ status: 'open', dueDate: null }, TODAY)).toBe(false);
+  });
+
+  it('returns false when dueDate is undefined', () => {
+    expect(isPastDeadline({ status: 'open' }, TODAY)).toBe(false);
+  });
+
+  it('returns false when status is done (hard short-circuit)', () => {
+    expect(isPastDeadline({ status: 'done', dueDate: '2026-05-10' }, TODAY)).toBe(false);
+  });
+
+  // Reported bug case: scheduledDate is in future but dueDate is in past
+  // isPastDeadline only looks at dueDate → IS past deadline
+  it('returns true when dueDate is past even if scheduledDate is in the future (bug case)', () => {
+    expect(
+      isPastDeadline({ status: 'open', scheduledDate: '2026-05-20', dueDate: '2026-05-10' }, TODAY),
+    ).toBe(true);
+  });
+
+  it('ignores scheduledDate entirely when dueDate is not set', () => {
+    expect(
+      isPastDeadline({ status: 'open', scheduledDate: '2026-05-10', dueDate: null }, TODAY),
+    ).toBe(false);
+  });
+});
+
+// ── taskDateStatus ────────────────────────────────────────────────────────────
+
+describe('taskDateStatus', () => {
+  it('returns combined result for a straightforwardly overdue task', () => {
+    const result = taskDateStatus({ status: 'open', scheduledDate: '2026-05-14' }, TODAY);
+    expect(result.overdue).toBe(true);
+    expect(result.pastDeadline).toBe(false); // no dueDate
+    expect(result.priorityDate).toEqual(new Date('2026-05-14T00:00:00'));
+  });
+
+  it('returns false for both flags when status is done', () => {
+    const result = taskDateStatus(
+      { status: 'done', scheduledDate: '2026-05-10', dueDate: '2026-05-10' },
+      TODAY,
+    );
+    expect(result.overdue).toBe(false);
+    expect(result.pastDeadline).toBe(false);
+  });
+
+  it('handles the reported bug case correctly', () => {
+    // scheduledDate in future, dueDate in past
+    const result = taskDateStatus(
+      { status: 'open', scheduledDate: '2026-05-20', dueDate: '2026-05-10' },
+      TODAY,
+    );
+    expect(result.overdue).toBe(false);       // scheduled for the future
+    expect(result.pastDeadline).toBe(true);   // deadline already passed
+    expect(result.priorityDate).toEqual(new Date('2026-05-20T00:00:00'));
+  });
+
+  it('returns null priorityDate and both false when no dates set', () => {
+    const result = taskDateStatus({ status: 'open' }, TODAY);
+    expect(result.overdue).toBe(false);
+    expect(result.pastDeadline).toBe(false);
+    expect(result.priorityDate).toBeNull();
+  });
+});

--- a/apps/api_server/src/__tests__/task_date_status.test.ts
+++ b/apps/api_server/src/__tests__/task_date_status.test.ts
@@ -182,6 +182,69 @@ describe('taskDateStatus', () => {
   });
 });
 
+// ── Canonical cross-stack date-status predicate matrix ───────────────────────
+//
+// Anchor date: 2026-05-11 (today).
+// Each row asserts isOverdue and isPastDeadline for the documented combination
+// of status, scheduledDate, and dueDate. The Dart test file in
+// apps/desktop_flutter/test/date_formatters_test.dart mirrors every row.
+
+describe('cross-stack matrix (anchor: 2026-05-11)', () => {
+  const MATRIX_TODAY = new Date('2026-05-11T00:00:00');
+
+  it('case 1: done task, both dates in past → neither flag set', () => {
+    expect(isOverdue({ status: 'done', scheduledDate: '2026-04-01', dueDate: '2026-04-01' }, MATRIX_TODAY)).toBe(false);
+    expect(isPastDeadline({ status: 'done', scheduledDate: '2026-04-01', dueDate: '2026-04-01' }, MATRIX_TODAY)).toBe(false);
+  });
+
+  it('case 2: open, no dates → neither flag set', () => {
+    expect(isOverdue({ status: 'open', scheduledDate: null, dueDate: null }, MATRIX_TODAY)).toBe(false);
+    expect(isPastDeadline({ status: 'open', scheduledDate: null, dueDate: null }, MATRIX_TODAY)).toBe(false);
+  });
+
+  it('case 3: open, future scheduled, no due → neither flag set', () => {
+    expect(isOverdue({ status: 'open', scheduledDate: '2026-05-15' }, MATRIX_TODAY)).toBe(false);
+    expect(isPastDeadline({ status: 'open', scheduledDate: '2026-05-15' }, MATRIX_TODAY)).toBe(false);
+  });
+
+  it('case 4: open, past scheduled, no due → overdue only', () => {
+    expect(isOverdue({ status: 'open', scheduledDate: '2026-05-05' }, MATRIX_TODAY)).toBe(true);
+    expect(isPastDeadline({ status: 'open', scheduledDate: '2026-05-05' }, MATRIX_TODAY)).toBe(false);
+  });
+
+  it('case 5: open, no scheduled, future due → neither flag set', () => {
+    expect(isOverdue({ status: 'open', dueDate: '2026-05-15' }, MATRIX_TODAY)).toBe(false);
+    expect(isPastDeadline({ status: 'open', dueDate: '2026-05-15' }, MATRIX_TODAY)).toBe(false);
+  });
+
+  it('case 6: open, no scheduled, past due → both flags set', () => {
+    expect(isOverdue({ status: 'open', dueDate: '2026-05-05' }, MATRIX_TODAY)).toBe(true);
+    expect(isPastDeadline({ status: 'open', dueDate: '2026-05-05' }, MATRIX_TODAY)).toBe(true);
+  });
+
+  it('case 7: scheduled future, deadline past → past-deadline only — the original reported bug', () => {
+    // scheduledDate wins for isOverdue (future → not overdue)
+    // isPastDeadline only checks dueDate (past → true)
+    expect(isOverdue({ status: 'open', scheduledDate: '2026-05-15', dueDate: '2026-05-05' }, MATRIX_TODAY)).toBe(false);
+    expect(isPastDeadline({ status: 'open', scheduledDate: '2026-05-15', dueDate: '2026-05-05' }, MATRIX_TODAY)).toBe(true);
+  });
+
+  it('case 8: open, past scheduled, future due → overdue only', () => {
+    expect(isOverdue({ status: 'open', scheduledDate: '2026-05-05', dueDate: '2026-05-15' }, MATRIX_TODAY)).toBe(true);
+    expect(isPastDeadline({ status: 'open', scheduledDate: '2026-05-05', dueDate: '2026-05-15' }, MATRIX_TODAY)).toBe(false);
+  });
+
+  it('case 9: open, both dates == today → neither flag set (today is not past)', () => {
+    expect(isOverdue({ status: 'open', scheduledDate: '2026-05-11', dueDate: '2026-05-11' }, MATRIX_TODAY)).toBe(false);
+    expect(isPastDeadline({ status: 'open', scheduledDate: '2026-05-11', dueDate: '2026-05-11' }, MATRIX_TODAY)).toBe(false);
+  });
+
+  it('case 10: open, both dates == yesterday → both flags set', () => {
+    expect(isOverdue({ status: 'open', scheduledDate: '2026-05-10', dueDate: '2026-05-10' }, MATRIX_TODAY)).toBe(true);
+    expect(isPastDeadline({ status: 'open', scheduledDate: '2026-05-10', dueDate: '2026-05-10' }, MATRIX_TODAY)).toBe(true);
+  });
+});
+
 // ── todayInTimezone / todayDateInTimezone ──────────────────────────────────────
 //
 // These tests verify TZ-boundary behaviour by constructing a pinned Date that

--- a/apps/api_server/src/__tests__/tasks_controller.test.ts
+++ b/apps/api_server/src/__tests__/tasks_controller.test.ts
@@ -1,0 +1,483 @@
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { createApp } from '../app';
+import { runMigrations } from '../database/migrations';
+import { setDb } from '../database/db';
+import { SessionsRepository } from '../repositories/sessions_repository';
+import { TasksRepository } from '../repositories/tasks_repository';
+import { UsersRepository } from '../repositories/users_repository';
+import { parseTaskFilters } from '../controllers/tasks_controller';
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+  runMigrations(db);
+  return db;
+}
+
+async function readJson(response: Response) {
+  const text = await response.text();
+  return text ? JSON.parse(text) : null;
+}
+
+// ─── Unit tests for parseTaskFilters ────────────────────────────────────────
+
+describe('parseTaskFilters', () => {
+  const userId = 1;
+
+  it('returns default filter when no query params are provided', () => {
+    const result = parseTaskFilters({}, userId);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.filter.status).toBe('open');
+    expect(result.filter.scheduledBefore).toBeUndefined();
+    expect(result.filter.dueBefore).toBeUndefined();
+    expect(result.filter.overdue).toBeUndefined();
+    expect(result.filter.search).toBeUndefined();
+  });
+
+  it('accepts a valid status value', () => {
+    const result = parseTaskFilters({ status: 'done' }, userId);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.filter.status).toBe('done');
+  });
+
+  it('accepts status=all', () => {
+    const result = parseTaskFilters({ status: 'all' }, userId);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.filter.status).toBe('all');
+  });
+
+  it('rejects an unknown status value', () => {
+    const result = parseTaskFilters({ status: 'pending' }, userId);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.field).toBe('status');
+  });
+
+  it('accepts a valid scheduled_before date', () => {
+    const result = parseTaskFilters({ scheduled_before: '2025-06-01' }, userId);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.filter.scheduledBefore).toBe('2025-06-01');
+  });
+
+  it('rejects a malformed scheduled_before date (wrong format)', () => {
+    const result = parseTaskFilters({ scheduled_before: '06/01/2025' }, userId);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.field).toBe('scheduled_before');
+  });
+
+  it('rejects an invalid scheduled_before date (invalid calendar date)', () => {
+    const result = parseTaskFilters({ scheduled_before: '2025-13-01' }, userId);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.field).toBe('scheduled_before');
+  });
+
+  it('accepts a valid due_before date', () => {
+    const result = parseTaskFilters({ due_before: '2025-12-31' }, userId);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.filter.dueBefore).toBe('2025-12-31');
+  });
+
+  it('rejects a malformed due_before date', () => {
+    const result = parseTaskFilters({ due_before: 'not-a-date' }, userId);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.field).toBe('due_before');
+  });
+
+  it("accepts overdue='true'", () => {
+    const result = parseTaskFilters({ overdue: 'true' }, userId);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.filter.overdue).toBe(true);
+  });
+
+  it("accepts overdue='false'", () => {
+    const result = parseTaskFilters({ overdue: 'false' }, userId);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.filter.overdue).toBe(false);
+  });
+
+  it('rejects an invalid overdue value', () => {
+    const result = parseTaskFilters({ overdue: 'yes' }, userId);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.field).toBe('overdue');
+  });
+
+  it('accepts a search string', () => {
+    const result = parseTaskFilters({ search: 'meeting' }, userId);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.filter.search).toBe('meeting');
+  });
+
+  it('returns a combined filter with multiple valid params', () => {
+    const result = parseTaskFilters(
+      { status: 'open', due_before: '2025-12-31', search: 'report' },
+      userId,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.filter.status).toBe('open');
+    expect(result.filter.dueBefore).toBe('2025-12-31');
+    expect(result.filter.search).toBe('report');
+  });
+});
+
+// ─── Integration tests for GET /tasks query filters ─────────────────────────
+
+describe('GET /tasks query param filters', () => {
+  let usersRepo: UsersRepository;
+  let sessionsRepo: SessionsRepository;
+  let tasksRepo: TasksRepository;
+  let baseUrl: string;
+  let closeServer: () => Promise<void>;
+
+  beforeEach(async () => {
+    setDb(makeDb());
+    usersRepo = new UsersRepository();
+    sessionsRepo = new SessionsRepository();
+    tasksRepo = new TasksRepository();
+
+    const server = createApp().listen(0);
+    await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+    closeServer = () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+  });
+
+  afterEach(async () => {
+    await closeServer();
+  });
+
+  async function authHeaderFor(userId: number) {
+    const session = await sessionsRepo.createAsync(userId);
+    return { Authorization: `Bearer ${session.token}` };
+  }
+
+  async function createTask(
+    userId: number,
+    opts: { title: string; status?: string; dueDate?: string; scheduledDate?: string },
+  ) {
+    const headers = await authHeaderFor(userId);
+    const resp = await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: opts.title,
+        status: opts.status,
+        dueDate: opts.dueDate ?? null,
+        scheduledDate: opts.scheduledDate ?? null,
+      }),
+    });
+    expect(resp.status).toBe(201);
+    const task = await readJson(resp) as { id: string; title: string };
+    // If the task needs a scheduledDate set (POST may not handle it), patch it
+    if (opts.scheduledDate) {
+      const ph = await authHeaderFor(userId);
+      await fetch(`${baseUrl}/tasks/${task.id}`, {
+        method: 'PATCH',
+        headers: { ...ph, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scheduledDate: opts.scheduledDate }),
+      });
+    }
+    return task;
+  }
+
+  it('GET /tasks with no params returns only open tasks (default)', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u1@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    // Create one open and one done task via the API
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Open task' }),
+    });
+
+    const doneResp = await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Done task', status: 'done' }),
+    });
+    const doneTask = await readJson(doneResp) as { id: string };
+
+    // Also set an open task to done via PATCH
+    const resp = await fetch(`${baseUrl}/tasks/${doneTask.id}`, {
+      method: 'PATCH',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'done' }),
+    });
+    expect(resp.status).toBe(200);
+
+    const listResp = await fetch(`${baseUrl}/tasks`, { headers });
+    expect(listResp.status).toBe(200);
+    const tasks = await readJson(listResp) as Array<{ title: string; status: string }>;
+    // Default should only return open tasks
+    expect(tasks.every((t) => t.status !== 'done')).toBe(true);
+    expect(tasks.some((t) => t.title === 'Open task')).toBe(true);
+  });
+
+  it('GET /tasks?status=done returns only done tasks', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u2@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    // Create one open task
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Open task' }),
+    });
+
+    // Create one done task directly
+    const doneResp = await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Done task' }),
+    });
+    const doneTask = await readJson(doneResp) as { id: string };
+    await fetch(`${baseUrl}/tasks/${doneTask.id}`, {
+      method: 'PATCH',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'done' }),
+    });
+
+    const listResp = await fetch(`${baseUrl}/tasks?status=done`, { headers });
+    expect(listResp.status).toBe(200);
+    const tasks = await readJson(listResp) as Array<{ title: string; status: string }>;
+    expect(tasks.every((t) => t.status === 'done')).toBe(true);
+    expect(tasks.some((t) => t.title === 'Done task')).toBe(true);
+  });
+
+  it('GET /tasks?status=all returns both open and done tasks', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u3@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Open task' }),
+    });
+
+    const doneResp = await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Done task' }),
+    });
+    const doneTask = await readJson(doneResp) as { id: string };
+    await fetch(`${baseUrl}/tasks/${doneTask.id}`, {
+      method: 'PATCH',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'done' }),
+    });
+
+    const listResp = await fetch(`${baseUrl}/tasks?status=all`, { headers });
+    expect(listResp.status).toBe(200);
+    const tasks = await readJson(listResp) as Array<{ title: string }>;
+    expect(tasks.length).toBeGreaterThanOrEqual(2);
+    expect(tasks.some((t) => t.title === 'Open task')).toBe(true);
+    expect(tasks.some((t) => t.title === 'Done task')).toBe(true);
+  });
+
+  it('GET /tasks?status=invalid returns 400 with validation error shape', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u4@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    const resp = await fetch(`${baseUrl}/tasks?status=pending`, { headers });
+    expect(resp.status).toBe(400);
+    const body = await readJson(resp) as { error: string; field: string; message: string };
+    expect(body.error).toBe('validation');
+    expect(body.field).toBe('status');
+    expect(typeof body.message).toBe('string');
+  });
+
+  it('GET /tasks?due_before=bad-date returns 400 with validation error shape', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u5@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    const resp = await fetch(`${baseUrl}/tasks?due_before=not-a-date`, { headers });
+    expect(resp.status).toBe(400);
+    const body = await readJson(resp) as { error: string; field: string; message: string };
+    expect(body.error).toBe('validation');
+    expect(body.field).toBe('due_before');
+  });
+
+  it('GET /tasks?scheduled_before=bad-date returns 400', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u6@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    const resp = await fetch(`${baseUrl}/tasks?scheduled_before=2025/06/01`, { headers });
+    expect(resp.status).toBe(400);
+    const body = await readJson(resp) as { error: string; field: string };
+    expect(body.error).toBe('validation');
+    expect(body.field).toBe('scheduled_before');
+  });
+
+  it('GET /tasks?overdue=yes returns 400', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u7@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    const resp = await fetch(`${baseUrl}/tasks?overdue=yes`, { headers });
+    expect(resp.status).toBe(400);
+    const body = await readJson(resp) as { error: string; field: string };
+    expect(body.error).toBe('validation');
+    expect(body.field).toBe('overdue');
+  });
+
+  it('GET /tasks?due_before filters by due date', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u8@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    // Task with past due date
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Past task', dueDate: '2020-01-01' }),
+    });
+
+    // Task with future due date
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Future task', dueDate: '2099-12-31' }),
+    });
+
+    // Task with no due date
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'No date task' }),
+    });
+
+    const listResp = await fetch(`${baseUrl}/tasks?due_before=2025-01-01&status=all`, { headers });
+    expect(listResp.status).toBe(200);
+    const tasks = await readJson(listResp) as Array<{ title: string }>;
+    expect(tasks.some((t) => t.title === 'Past task')).toBe(true);
+    expect(tasks.every((t) => t.title !== 'Future task')).toBe(true);
+    expect(tasks.every((t) => t.title !== 'No date task')).toBe(true);
+  });
+
+  it('GET /tasks?search= filters by title substring (case-insensitive)', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u9@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Weekly Meeting' }),
+    });
+
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Send Report' }),
+    });
+
+    const listResp = await fetch(`${baseUrl}/tasks?search=meeting`, { headers });
+    expect(listResp.status).toBe(200);
+    const tasks = await readJson(listResp) as Array<{ title: string }>;
+    expect(tasks.some((t) => t.title === 'Weekly Meeting')).toBe(true);
+    expect(tasks.every((t) => t.title !== 'Send Report')).toBe(true);
+  });
+
+  it('GET /tasks?overdue=true returns only overdue open tasks', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u10@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    // Overdue open task (past due date)
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Overdue task', dueDate: '2020-01-01' }),
+    });
+
+    // Not overdue open task (future due date)
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Future task', dueDate: '2099-12-31' }),
+    });
+
+    const listResp = await fetch(`${baseUrl}/tasks?overdue=true&status=all`, { headers });
+    expect(listResp.status).toBe(200);
+    const tasks = await readJson(listResp) as Array<{ title: string; status: string }>;
+    expect(tasks.some((t) => t.title === 'Overdue task')).toBe(true);
+    expect(tasks.every((t) => t.title !== 'Future task')).toBe(true);
+    // All returned tasks must not be done
+    expect(tasks.every((t) => t.status !== 'done')).toBe(true);
+  });
+
+  it('GET /tasks?overdue=false excludes overdue tasks', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u11@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Overdue task', dueDate: '2020-01-01' }),
+    });
+
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Future task', dueDate: '2099-12-31' }),
+    });
+
+    const listResp = await fetch(`${baseUrl}/tasks?overdue=false&status=all`, { headers });
+    expect(listResp.status).toBe(200);
+    const tasks = await readJson(listResp) as Array<{ title: string }>;
+    expect(tasks.every((t) => t.title !== 'Overdue task')).toBe(true);
+  });
+
+  it('GET /tasks handles combined filters: search + due_before', async () => {
+    const user = usersRepo.create({ name: 'User', email: 'u12@example.com' });
+    const headers = await authHeaderFor(user.id);
+
+    // Matches both search and due_before
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Report 2020', dueDate: '2020-03-01' }),
+    });
+
+    // Matches search but not due_before (future date)
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Report 2099', dueDate: '2099-01-01' }),
+    });
+
+    // Matches due_before but not search
+    await fetch(`${baseUrl}/tasks`, {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Other old task', dueDate: '2020-01-01' }),
+    });
+
+    const listResp = await fetch(
+      `${baseUrl}/tasks?search=report&due_before=2025-01-01&status=all`,
+      { headers },
+    );
+    expect(listResp.status).toBe(200);
+    const tasks = await readJson(listResp) as Array<{ title: string }>;
+    expect(tasks.some((t) => t.title === 'Report 2020')).toBe(true);
+    expect(tasks.every((t) => t.title !== 'Report 2099')).toBe(true);
+    expect(tasks.every((t) => t.title !== 'Other old task')).toBe(true);
+  });
+});

--- a/apps/api_server/src/__tests__/tasks_repository.test.ts
+++ b/apps/api_server/src/__tests__/tasks_repository.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Unit / integration tests for TasksRepository.findByFilter (SQLite).
+ *
+ * Each test uses an in-memory SQLite database so tests are fully isolated and
+ * do not touch the filesystem.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+
+import { runMigrations } from '../database/migrations';
+import { setDb } from '../database/db';
+import { TasksRepository } from '../repositories/tasks_repository';
+import { UsersRepository } from '../repositories/users_repository';
+import type { TaskFilter } from '../models/task_filter';
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+  runMigrations(db);
+  return db;
+}
+
+// A fixed "today" used across tests so results are deterministic.
+const TODAY = '2026-05-11';
+const PAST = '2020-01-01';
+const FUTURE = '2099-12-31';
+
+describe('TasksRepository.findByFilter', () => {
+  let repo: TasksRepository;
+  let userId: number;
+
+  beforeEach(() => {
+    setDb(makeDb());
+    repo = new TasksRepository();
+    const usersRepo = new UsersRepository();
+    const user = usersRepo.create({ name: 'Alice', email: 'alice@example.com' });
+    userId = user.id;
+  });
+
+  function baseFilter(overrides: Partial<TaskFilter> = {}): TaskFilter {
+    return { userId, status: 'all', today: TODAY, ...overrides };
+  }
+
+  async function seed(opts: {
+    title: string;
+    status?: string;
+    dueDate?: string;
+    scheduledDate?: string;
+  }) {
+    return repo.createAsync({
+      title: opts.title,
+      status: (opts.status ?? 'open') as 'open' | 'done',
+      dueDate: opts.dueDate ?? null,
+      scheduledDate: opts.scheduledDate ?? null,
+      ownerId: userId,
+    });
+  }
+
+  // ── status filter ──────────────────────────────────────────────────────────
+
+  it('status=open excludes done tasks', async () => {
+    await seed({ title: 'Open task' });
+    await seed({ title: 'Done task', status: 'done' });
+
+    const tasks = repo.findByFilter(baseFilter({ status: 'open' }));
+    expect(tasks.map((t) => t.title)).toContain('Open task');
+    expect(tasks.map((t) => t.title)).not.toContain('Done task');
+  });
+
+  it('status=done returns only done tasks', async () => {
+    await seed({ title: 'Open task' });
+    await seed({ title: 'Done task', status: 'done' });
+
+    const tasks = repo.findByFilter(baseFilter({ status: 'done' }));
+    expect(tasks.map((t) => t.title)).not.toContain('Open task');
+    expect(tasks.map((t) => t.title)).toContain('Done task');
+  });
+
+  it('status=all returns both open and done tasks', async () => {
+    await seed({ title: 'Open task' });
+    await seed({ title: 'Done task', status: 'done' });
+
+    const tasks = repo.findByFilter(baseFilter({ status: 'all' }));
+    const titles = tasks.map((t) => t.title);
+    expect(titles).toContain('Open task');
+    expect(titles).toContain('Done task');
+  });
+
+  // ── scheduledBefore filter ─────────────────────────────────────────────────
+
+  it('scheduledBefore filters by COALESCE(scheduled_date, due_date)', async () => {
+    // scheduled_date wins when present
+    await seed({ title: 'Past scheduled', scheduledDate: PAST });
+    // falls back to due_date when scheduled_date is null
+    await seed({ title: 'Past due', dueDate: PAST });
+    await seed({ title: 'Future scheduled', scheduledDate: FUTURE });
+    await seed({ title: 'Future due', dueDate: FUTURE });
+    // no date at all → excluded
+    await seed({ title: 'No date' });
+
+    const tasks = repo.findByFilter(baseFilter({ scheduledBefore: '2025-01-01' }));
+    const titles = tasks.map((t) => t.title);
+    expect(titles).toContain('Past scheduled');
+    expect(titles).toContain('Past due');
+    expect(titles).not.toContain('Future scheduled');
+    expect(titles).not.toContain('Future due');
+    expect(titles).not.toContain('No date');
+  });
+
+  it('scheduledBefore is inclusive (date == boundary is included)', async () => {
+    await seed({ title: 'Boundary', dueDate: '2025-01-01' });
+    const tasks = repo.findByFilter(baseFilter({ scheduledBefore: '2025-01-01' }));
+    expect(tasks.map((t) => t.title)).toContain('Boundary');
+  });
+
+  // ── dueBefore filter ───────────────────────────────────────────────────────
+
+  it('dueBefore requires due_date (tasks with only scheduled_date excluded)', async () => {
+    await seed({ title: 'Past due', dueDate: PAST });
+    await seed({ title: 'Past scheduled only', scheduledDate: PAST });
+    await seed({ title: 'Future due', dueDate: FUTURE });
+    await seed({ title: 'No date' });
+
+    const tasks = repo.findByFilter(baseFilter({ dueBefore: '2025-01-01' }));
+    const titles = tasks.map((t) => t.title);
+    expect(titles).toContain('Past due');
+    expect(titles).not.toContain('Past scheduled only');
+    expect(titles).not.toContain('Future due');
+    expect(titles).not.toContain('No date');
+  });
+
+  // ── overdue filter ─────────────────────────────────────────────────────────
+
+  it('overdue=true returns open tasks with priority date < today', async () => {
+    await seed({ title: 'Overdue open', dueDate: PAST });
+    await seed({ title: 'Future open', dueDate: FUTURE });
+    await seed({ title: 'Overdue done', dueDate: PAST, status: 'done' });
+    await seed({ title: 'No date open' });
+
+    const tasks = repo.findByFilter(baseFilter({ overdue: true, status: 'all' }));
+    const titles = tasks.map((t) => t.title);
+    expect(titles).toContain('Overdue open');
+    expect(titles).not.toContain('Future open');
+    expect(titles).not.toContain('Overdue done');
+    expect(titles).not.toContain('No date open');
+  });
+
+  it('overdue=true uses scheduled_date when present over due_date', async () => {
+    // scheduled_date is in the past → overdue even though due_date is in the future
+    await seed({ title: 'Overdue by scheduled', scheduledDate: PAST, dueDate: FUTURE });
+    const tasks = repo.findByFilter(baseFilter({ overdue: true, status: 'all' }));
+    expect(tasks.map((t) => t.title)).toContain('Overdue by scheduled');
+  });
+
+  it('overdue=false excludes overdue tasks', async () => {
+    await seed({ title: 'Overdue open', dueDate: PAST });
+    await seed({ title: 'Future open', dueDate: FUTURE });
+    await seed({ title: 'No date open' });
+
+    const tasks = repo.findByFilter(baseFilter({ overdue: false, status: 'all' }));
+    const titles = tasks.map((t) => t.title);
+    expect(titles).not.toContain('Overdue open');
+    // Non-overdue tasks are included
+    expect(titles).toContain('Future open');
+    expect(titles).toContain('No date open');
+  });
+
+  // ── search filter ──────────────────────────────────────────────────────────
+
+  it('search matches case-insensitively on title substring', async () => {
+    await seed({ title: 'Weekly Meeting' });
+    await seed({ title: 'Send Report' });
+    await seed({ title: 'MEETING notes' });
+
+    const tasks = repo.findByFilter(baseFilter({ search: 'meeting' }));
+    const titles = tasks.map((t) => t.title);
+    expect(titles).toContain('Weekly Meeting');
+    expect(titles).toContain('MEETING notes');
+    expect(titles).not.toContain('Send Report');
+  });
+
+  it('empty search string returns all tasks for user', async () => {
+    await seed({ title: 'Task A' });
+    await seed({ title: 'Task B' });
+
+    const tasks = repo.findByFilter(baseFilter({ search: '' }));
+    expect(tasks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ── combined filters ───────────────────────────────────────────────────────
+
+  it('status=open + scheduledBefore ANDs the clauses', async () => {
+    await seed({ title: 'Open past', dueDate: PAST });
+    await seed({ title: 'Done past', dueDate: PAST, status: 'done' });
+    await seed({ title: 'Open future', dueDate: FUTURE });
+
+    const tasks = repo.findByFilter(
+      baseFilter({ status: 'open', scheduledBefore: '2025-01-01' }),
+    );
+    const titles = tasks.map((t) => t.title);
+    expect(titles).toContain('Open past');
+    expect(titles).not.toContain('Done past');
+    expect(titles).not.toContain('Open future');
+  });
+
+  it('search + due_before ANDs the clauses', async () => {
+    // Matches both
+    await seed({ title: 'Report 2020', dueDate: '2020-03-01' });
+    // Matches search but not due_before
+    await seed({ title: 'Report 2099', dueDate: FUTURE });
+    // Matches due_before but not search
+    await seed({ title: 'Other old task', dueDate: '2020-01-01' });
+
+    const tasks = repo.findByFilter(
+      baseFilter({ search: 'report', dueBefore: '2025-01-01', status: 'all' }),
+    );
+    const titles = tasks.map((t) => t.title);
+    expect(titles).toContain('Report 2020');
+    expect(titles).not.toContain('Report 2099');
+    expect(titles).not.toContain('Other old task');
+  });
+
+  // ── isolation ─────────────────────────────────────────────────────────────
+
+  it('does not return tasks owned by another user', async () => {
+    const usersRepo = new UsersRepository();
+    const other = usersRepo.create({ name: 'Bob', email: 'bob@example.com' });
+
+    await repo.createAsync({ title: 'My task', ownerId: userId });
+    await repo.createAsync({ title: 'Their task', ownerId: other.id });
+
+    const tasks = repo.findByFilter(baseFilter());
+    const titles = tasks.map((t) => t.title);
+    expect(titles).toContain('My task');
+    expect(titles).not.toContain('Their task');
+  });
+
+  // ── ordering ──────────────────────────────────────────────────────────────
+
+  it('returns tasks ordered by COALESCE(scheduled_date, due_date) ASC NULLS LAST', async () => {
+    await seed({ title: 'No date' });
+    await seed({ title: 'Far future', dueDate: FUTURE });
+    await seed({ title: 'Near past', dueDate: PAST });
+
+    const tasks = repo.findByFilter(baseFilter());
+    const titles = tasks.map((t) => t.title);
+    const nearIdx = titles.indexOf('Near past');
+    const farIdx = titles.indexOf('Far future');
+    const noneIdx = titles.indexOf('No date');
+
+    expect(nearIdx).toBeLessThan(farIdx);
+    // NULLS LAST: 'No date' should come after both dated tasks
+    expect(noneIdx).toBeGreaterThan(farIdx);
+  });
+
+  // ── empty results ─────────────────────────────────────────────────────────
+
+  it('returns [] when no tasks match, never throws', () => {
+    const tasks = repo.findByFilter(baseFilter({ search: 'nonexistent-xyz-987' }));
+    expect(tasks).toEqual([]);
+  });
+});

--- a/apps/api_server/src/__tests__/tasks_repository.test.ts
+++ b/apps/api_server/src/__tests__/tasks_repository.test.ts
@@ -255,6 +255,47 @@ describe('TasksRepository.findByFilter', () => {
     expect(noneIdx).toBeGreaterThan(farIdx);
   });
 
+  it('overdue-first: open overdue tasks sort before non-overdue, then by priority date, then nulls last', async () => {
+    // Overdue open tasks (priority date < TODAY and status != done)
+    await seed({ title: 'Overdue A', dueDate: '2020-01-01' });
+    await seed({ title: 'Overdue B', scheduledDate: '2021-06-15' });
+    // Non-overdue open tasks
+    await seed({ title: 'Today task', dueDate: TODAY });
+    await seed({ title: 'Future task', dueDate: FUTURE });
+    // Overdue but DONE → not overdue per the CASE; should fall in non-overdue tier
+    await seed({ title: 'Overdue done', dueDate: PAST, status: 'done' });
+    // No date at all → NULLS LAST within non-overdue tier
+    await seed({ title: 'No date open' });
+
+    const tasks = repo.findByFilter(baseFilter({ status: 'all', today: TODAY }));
+    const titles = tasks.map((t) => t.title);
+
+    const idxOverdueA = titles.indexOf('Overdue A');
+    const idxOverdueB = titles.indexOf('Overdue B');
+    const idxToday = titles.indexOf('Today task');
+    const idxFuture = titles.indexOf('Future task');
+    const idxOverdueDone = titles.indexOf('Overdue done');
+    const idxNoDate = titles.indexOf('No date open');
+
+    // Both overdue open tasks must come before any non-overdue tasks
+    expect(idxOverdueA).toBeLessThan(idxToday);
+    expect(idxOverdueA).toBeLessThan(idxFuture);
+    expect(idxOverdueB).toBeLessThan(idxToday);
+    expect(idxOverdueB).toBeLessThan(idxFuture);
+
+    // Within the overdue tier, sorted by priority date ASC (2020 before 2021)
+    expect(idxOverdueA).toBeLessThan(idxOverdueB);
+
+    // Within the non-overdue tier: today < future < no-date (NULLS LAST)
+    expect(idxToday).toBeLessThan(idxFuture);
+    expect(idxFuture).toBeLessThan(idxNoDate);
+
+    // Overdue done falls into the non-overdue tier (CASE excludes it)
+    // so it must come after both overdue-open tasks
+    expect(idxOverdueA).toBeLessThan(idxOverdueDone);
+    expect(idxOverdueB).toBeLessThan(idxOverdueDone);
+  });
+
   // ── empty results ─────────────────────────────────────────────────────────
 
   it('returns [] when no tasks match, never throws', () => {

--- a/apps/api_server/src/__tests__/users_permissions.test.ts
+++ b/apps/api_server/src/__tests__/users_permissions.test.ts
@@ -167,6 +167,69 @@ describe('UsersController permissions', () => {
     expect(usersRepo.findById(other.id).emailNotificationsEnabled).toBe(true);
   });
 
+  it('allows any authenticated user to update their own timezone', async () => {
+    const member = usersRepo.create({
+      name: 'TZ Member',
+      email: 'tz-member@example.com',
+    });
+    let payload: unknown;
+    let forwardedError: unknown;
+
+    await controller.updateMyPreferences(
+      {
+        auth: { user: member },
+        body: { timezone: 'America/New_York' },
+      } as never,
+      {
+        json(value: unknown) {
+          payload = value;
+          return this;
+        },
+      } as never,
+      (error?: unknown) => {
+        forwardedError = error;
+      },
+    );
+
+    expect(forwardedError).toBeUndefined();
+    expect(payload).toMatchObject({
+      id: member.id,
+      timezone: 'America/New_York',
+    });
+  });
+
+  it('rejects invalid IANA timezone strings with 400', async () => {
+    const member = usersRepo.create({
+      name: 'Bad TZ Member',
+      email: 'bad-tz@example.com',
+    });
+    let forwardedError: unknown;
+
+    await controller.updateMyPreferences(
+      {
+        auth: { user: member },
+        body: { timezone: 'Not/A/Valid/Timezone' },
+      } as never,
+      {} as never,
+      (error?: unknown) => {
+        forwardedError = error;
+      },
+    );
+
+    expect(forwardedError).toMatchObject({
+      statusCode: 400,
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('user response includes timezone field', async () => {
+    const member = usersRepo.create({
+      name: 'TZ Check Member',
+      email: 'tz-check@example.com',
+    });
+    expect(member.timezone).toBe('America/Los_Angeles');
+  });
+
   it('allows admins to update user permissions', async () => {
     const admin = usersRepo.create({
       name: 'Admin',

--- a/apps/api_server/src/__tests__/weekly_planning_service.test.ts
+++ b/apps/api_server/src/__tests__/weekly_planning_service.test.ts
@@ -206,6 +206,52 @@ describe('WeeklyPlanningService.assemblePlan', () => {
     expect(tue.tasks[0].locked).toBe(true);
   });
 
+  it('synthesizes shadow events with scheduledDate set and dueDate null', async () => {
+    shadowRepo.replaceForOwner(ownerId, [
+      {
+        provider: 'google_calendar',
+        externalId: 'evt-002',
+        calendarId: 'primary',
+        sourceName: 'Work',
+        title: 'All-hands meeting',
+        description: null,
+        location: null,
+        startAt: '2026-03-25T09:00:00.000Z',
+        endAt: '2026-03-25T10:00:00.000Z',
+        isAllDay: false,
+      },
+      {
+        provider: 'google_calendar',
+        externalId: 'evt-003',
+        calendarId: 'primary',
+        sourceName: 'Work',
+        title: 'Holiday',
+        description: null,
+        location: null,
+        startAt: '2026-03-26T00:00:00.000Z',
+        endAt: '2026-03-26T23:59:59.000Z',
+        isAllDay: true,
+      },
+    ]);
+    const plan = await service.assemblePlan(WEEK, ownerId);
+    const wed = plan.days.find((d) => d.date === '2026-03-25')!;
+    const thu = plan.days.find((d) => d.date === '2026-03-26')!;
+
+    // Time-range event: scheduledDate = event day, dueDate = null
+    expect(wed.tasks).toHaveLength(1);
+    const timeEvent = wed.tasks[0];
+    expect(timeEvent.title).toBe('All-hands meeting');
+    expect(timeEvent.scheduledDate).toBe('2026-03-25');
+    expect(timeEvent.dueDate).toBeNull();
+
+    // All-day event: scheduledDate = event day, dueDate = null
+    expect(thu.tasks).toHaveLength(1);
+    const allDayEvent = thu.tasks[0];
+    expect(allDayEvent.title).toBe('Holiday');
+    expect(allDayEvent.scheduledDate).toBe('2026-03-26');
+    expect(allDayEvent.dueDate).toBeNull();
+  });
+
   it('handles multiple tasks across different days', async () => {
     tasksRepo.create({ title: 'Mon', dueDate: '2026-03-23', ownerId });
     tasksRepo.create({ title: 'Wed', dueDate: '2026-03-25', ownerId });

--- a/apps/api_server/src/controllers/dashboard_controller.ts
+++ b/apps/api_server/src/controllers/dashboard_controller.ts
@@ -6,7 +6,8 @@ const service = new DashboardSummaryService();
 export class DashboardController {
   async getSummary(req: Request, res: Response, next: NextFunction) {
     try {
-      const summary = await service.getSummaryAsync(req.auth!.user.id);
+      const user = req.auth!.user;
+      const summary = await service.getSummaryAsync(user.id, user.timezone);
       res.json(summary);
     } catch (err) {
       next(err);

--- a/apps/api_server/src/controllers/project_generation_controller.ts
+++ b/apps/api_server/src/controllers/project_generation_controller.ts
@@ -78,12 +78,18 @@ export class ProjectGenerationController {
     try {
       const actorId = req.auth!.user.id;
       const { stepId } = req.params;
-      const { title, dueDate, status, notes, assigneeId } = req.body as Record<string, unknown>;
+      const { title, dueDate, scheduledDate, status, notes, assigneeId } = req.body as Record<string, unknown>;
       const step = await instanceRepo.updateStepAsync(
         stepId,
         {
           title: typeof title === 'string' ? title : undefined,
           dueDate: typeof dueDate === 'string' ? dueDate : undefined,
+          scheduledDate:
+            scheduledDate === null
+              ? null
+              : typeof scheduledDate === 'string'
+                ? scheduledDate
+                : undefined,
           status: typeof status === 'string' ? status : undefined,
           notes:
             notes === null

--- a/apps/api_server/src/controllers/tasks_controller.ts
+++ b/apps/api_server/src/controllers/tasks_controller.ts
@@ -13,6 +13,110 @@ import { emitAppEvent } from '../utils/app_events';
 const VALID_STATUSES = ['open', 'in_progress', 'waiting_for_reply', 'done'] as const;
 type ValidStatus = (typeof VALID_STATUSES)[number];
 
+/** Status values accepted by the filter param (superset of task statuses; 'all' means no filter). */
+const VALID_FILTER_STATUSES = ['open', 'in_progress', 'waiting_for_reply', 'done', 'all'] as const;
+type FilterStatus = (typeof VALID_FILTER_STATUSES)[number];
+
+/** Typed filter object passed to findByFilterAsync. */
+export interface TaskFilter {
+  userId: number;
+  /** 'all' means no status filter. Defaults to 'open'. */
+  status: FilterStatus;
+  /** Return tasks where COALESCE(scheduled_date, due_date) <= scheduledBefore */
+  scheduledBefore?: string;
+  /** Return tasks where due_date <= dueBefore */
+  dueBefore?: string;
+  /** When true, return only tasks that are overdue (status != 'done' AND priority date < today). */
+  overdue?: boolean;
+  /** Case-insensitive substring match against title. */
+  search?: string;
+}
+
+/** Discriminated union returned by parseTaskFilters. */
+type ParseResult =
+  | { ok: true; filter: TaskFilter }
+  | { ok: false; field: string; message: string };
+
+/** Strict ISO date validation: must match YYYY-MM-DD and produce a valid Date. */
+function isValidIsoDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const d = new Date(value);
+  return !isNaN(d.getTime());
+}
+
+/**
+ * Parse and validate query parameters for GET /tasks.
+ * Returns a validated TaskFilter on success or a field-level error on failure.
+ */
+export function parseTaskFilters(query: Request['query'], userId: number): ParseResult {
+  // --- status ---
+  let status: FilterStatus = 'open'; // default preserves backward compatibility
+  if (query.status !== undefined) {
+    const raw = query.status as string;
+    if (!VALID_FILTER_STATUSES.includes(raw as FilterStatus)) {
+      return {
+        ok: false,
+        field: 'status',
+        message: `status must be one of: ${VALID_FILTER_STATUSES.join(', ')}`,
+      };
+    }
+    status = raw as FilterStatus;
+  }
+
+  // --- scheduled_before ---
+  let scheduledBefore: string | undefined;
+  if (query.scheduled_before !== undefined) {
+    const raw = query.scheduled_before as string;
+    if (!isValidIsoDate(raw)) {
+      return {
+        ok: false,
+        field: 'scheduled_before',
+        message: 'scheduled_before must be a valid date in YYYY-MM-DD format',
+      };
+    }
+    scheduledBefore = raw;
+  }
+
+  // --- due_before ---
+  let dueBefore: string | undefined;
+  if (query.due_before !== undefined) {
+    const raw = query.due_before as string;
+    if (!isValidIsoDate(raw)) {
+      return {
+        ok: false,
+        field: 'due_before',
+        message: 'due_before must be a valid date in YYYY-MM-DD format',
+      };
+    }
+    dueBefore = raw;
+  }
+
+  // --- overdue ---
+  let overdue: boolean | undefined;
+  if (query.overdue !== undefined) {
+    const raw = query.overdue as string;
+    if (raw !== 'true' && raw !== 'false') {
+      return {
+        ok: false,
+        field: 'overdue',
+        message: "overdue must be 'true' or 'false'",
+      };
+    }
+    overdue = raw === 'true';
+  }
+
+  // --- search ---
+  let search: string | undefined;
+  if (query.search !== undefined) {
+    search = query.search as string;
+  }
+
+  return {
+    ok: true,
+    filter: { userId, status, scheduledBefore, dueBefore, overdue, search },
+  };
+}
+
 const VALID_PREFERRED_AGENTS = ['claude-code', 'codex'] as const;
 type ValidPreferredAgent = (typeof VALID_PREFERRED_AGENTS)[number];
 
@@ -36,7 +140,17 @@ const emailService = new EmailService(usersRepo);
 export class TasksController {
   async getAll(req: Request, res: Response, next: NextFunction) {
     try {
-      res.json(await repo.findAllAsync(req.auth!.user.id));
+      const userId = req.auth!.user.id;
+      const result = parseTaskFilters(req.query, userId);
+      if (!result.ok) {
+        res.status(400).json({
+          error: 'validation',
+          field: result.field,
+          message: result.message,
+        });
+        return;
+      }
+      res.json(await repo.findByFilterAsync(result.filter));
     } catch (err) {
       next(err);
     }

--- a/apps/api_server/src/controllers/tasks_controller.ts
+++ b/apps/api_server/src/controllers/tasks_controller.ts
@@ -9,28 +9,16 @@ import { env } from '../config/env';
 import { EmailService } from '../services/email_service';
 import { UsersRepository } from '../repositories/users_repository';
 import { emitAppEvent } from '../utils/app_events';
+import type { FilterStatus, TaskFilter } from '../models/task_filter';
+
+// Re-export so callers that previously imported from this module still work.
+export type { TaskFilter };
 
 const VALID_STATUSES = ['open', 'in_progress', 'waiting_for_reply', 'done'] as const;
 type ValidStatus = (typeof VALID_STATUSES)[number];
 
 /** Status values accepted by the filter param (superset of task statuses; 'all' means no filter). */
 const VALID_FILTER_STATUSES = ['open', 'in_progress', 'waiting_for_reply', 'done', 'all'] as const;
-type FilterStatus = (typeof VALID_FILTER_STATUSES)[number];
-
-/** Typed filter object passed to findByFilterAsync. */
-export interface TaskFilter {
-  userId: number;
-  /** 'all' means no status filter. Defaults to 'open'. */
-  status: FilterStatus;
-  /** Return tasks where COALESCE(scheduled_date, due_date) <= scheduledBefore */
-  scheduledBefore?: string;
-  /** Return tasks where due_date <= dueBefore */
-  dueBefore?: string;
-  /** When true, return only tasks that are overdue (status != 'done' AND priority date < today). */
-  overdue?: boolean;
-  /** Case-insensitive substring match against title. */
-  search?: string;
-}
 
 /** Discriminated union returned by parseTaskFilters. */
 type ParseResult =
@@ -111,9 +99,12 @@ export function parseTaskFilters(query: Request['query'], userId: number): Parse
     search = query.search as string;
   }
 
+  // Inject today's date so the repository never calls new Date() itself.
+  const today = new Date().toISOString().slice(0, 10);
+
   return {
     ok: true,
-    filter: { userId, status, scheduledBefore, dueBefore, overdue, search },
+    filter: { userId, status, scheduledBefore, dueBefore, overdue, search, today },
   };
 }
 

--- a/apps/api_server/src/controllers/users_controller.ts
+++ b/apps/api_server/src/controllers/users_controller.ts
@@ -4,6 +4,20 @@ import { UsersRepository } from '../repositories/users_repository';
 
 const repo = new UsersRepository();
 
+/**
+ * Validate that the given string is a recognised IANA timezone name.
+ * Throws a 400 AppError if the timezone is not supported by Intl.DateTimeFormat.
+ */
+function validateTimezone(tz: string): void {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: tz });
+  } catch {
+    throw AppError.badRequest(
+      `Invalid timezone "${tz}". Must be a recognised IANA timezone name (e.g. "America/Los_Angeles").`,
+    );
+  }
+}
+
 export class UsersController {
   private requireAdmin(req: Request) {
     const actor = req.auth?.user;
@@ -60,11 +74,22 @@ export class UsersController {
   async updateMyPreferences(req: Request, res: Response, next: NextFunction) {
     try {
       const userId = req.auth!.user.id;
-      const { emailNotificationsEnabled } = req.body as Record<string, unknown>;
-      if (typeof emailNotificationsEnabled !== 'boolean') {
+      const { emailNotificationsEnabled, timezone } = req.body as Record<string, unknown>;
+      if (emailNotificationsEnabled !== undefined && typeof emailNotificationsEnabled !== 'boolean') {
         throw AppError.badRequest('emailNotificationsEnabled must be a boolean');
       }
-      const user = await repo.updateAsync(userId, { emailNotificationsEnabled });
+      const patch: Record<string, unknown> = {};
+      if (typeof emailNotificationsEnabled === 'boolean') {
+        patch.emailNotificationsEnabled = emailNotificationsEnabled;
+      }
+      if (typeof timezone === 'string') {
+        validateTimezone(timezone);
+        patch.timezone = timezone;
+      }
+      if (Object.keys(patch).length === 0) {
+        throw AppError.badRequest('No valid preference fields provided');
+      }
+      const user = await repo.updateAsync(userId, patch);
       res.json(user);
     } catch (err) {
       next(err);
@@ -74,8 +99,11 @@ export class UsersController {
   async update(req: Request, res: Response, next: NextFunction) {
     try {
       this.requireAdmin(req);
-      const { name, email, role, googleSub, photoUrl, isFacilitiesManager } =
+      const { name, email, role, googleSub, photoUrl, isFacilitiesManager, timezone } =
         req.body as Record<string, unknown>;
+      if (typeof timezone === 'string') {
+        validateTimezone(timezone);
+      }
       const user = await repo.updateAsync(Number(req.params.id), {
         ...(typeof name === 'string' ? { name } : {}),
         ...(typeof email === 'string' ? { email } : {}),
@@ -89,6 +117,7 @@ export class UsersController {
         ...(typeof isFacilitiesManager === 'boolean'
           ? { isFacilitiesManager }
           : {}),
+        ...(typeof timezone === 'string' ? { timezone } : {}),
       });
       res.json(user);
     } catch (err) {

--- a/apps/api_server/src/controllers/weekly_plan_controller.ts
+++ b/apps/api_server/src/controllers/weekly_plan_controller.ts
@@ -17,14 +17,15 @@ export class WeeklyPlanController {
 
   async getPlan(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
+      const user = req.auth!.user;
       const weekLabel =
-        (req.query.week as string | undefined) ?? currentWeekLabel();
+        (req.query.week as string | undefined) ?? currentWeekLabel(user.timezone);
       if (!/^\d{4}-W\d{1,2}$/.test(weekLabel)) {
         throw AppError.badRequest(
           "Invalid week format. Use YYYY-WNN (e.g. 2026-W13).",
         );
       }
-      const userId = req.auth!.user.id;
+      const userId = user.id;
       const plan = await this.service.assemblePlan(weekLabel, userId);
       const assemblySignal: AutomationSignal = {
         id: `rhythm:plan_assembly:${weekLabel}`,

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -976,4 +976,13 @@ export function runMigrations(db: Database.Database): void {
   if (!instanceStepColsScheduled.includes('scheduled_date')) {
     db.exec(`ALTER TABLE project_instance_steps ADD COLUMN scheduled_date TEXT`);
   }
+
+  // Issue #539 — users.timezone for per-user "today" computation.
+  // Default: America/Los_Angeles (AJ's TZ; keeps existing rows stable on upgrade).
+  const userColsP539 = (db.pragma('table_info(users)') as { name: string }[]).map((c) => c.name);
+  if (!userColsP539.includes('timezone')) {
+    db.exec(
+      `ALTER TABLE users ADD COLUMN timezone TEXT NOT NULL DEFAULT 'America/Los_Angeles'`,
+    );
+  }
 }

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -985,4 +985,51 @@ export function runMigrations(db: Database.Database): void {
       `ALTER TABLE users ADD COLUMN timezone TEXT NOT NULL DEFAULT 'America/Los_Angeles'`,
     );
   }
+
+  // Issue #520 — One-time backfill: copy due_date → scheduled_date for legacy rows.
+  //
+  // Many tasks and project_steps were created by the legacy quick-add UI which only
+  // wrote due_date. Under the new date-semantics model (scheduled_date primary, due_date
+  // fallback) those rows appear "unscheduled". This migration copies due_date into
+  // scheduled_date for every row where scheduled_date IS NULL AND due_date IS NOT NULL,
+  // covering both tables in a single transaction.
+  //
+  // A schema_meta marker row prevents re-execution on DBs that have already received
+  // this migration. Must run AFTER issue #519 (project_instance_steps.scheduled_date).
+
+  // 1. Ensure schema_meta table exists.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT
+    )
+  `);
+
+  // 2. Check for the idempotency marker.
+  const backfillMarker = (db.prepare(`SELECT key FROM schema_meta WHERE key = 'backfill_scheduled_date_v1'`).get()) as { key: string } | undefined;
+
+  if (!backfillMarker) {
+    // 3. Run both UPDATEs inside a single transaction.
+    const backfill = db.transaction(() => {
+      const tasksResult = db.prepare(
+        `UPDATE tasks SET scheduled_date = due_date WHERE scheduled_date IS NULL AND due_date IS NOT NULL`
+      ).run();
+
+      const stepsResult = db.prepare(
+        `UPDATE project_instance_steps SET scheduled_date = due_date WHERE scheduled_date IS NULL AND due_date IS NOT NULL`
+      ).run();
+
+      // 4. Insert marker row with ISO timestamp.
+      db.prepare(
+        `INSERT INTO schema_meta (key, value) VALUES ('backfill_scheduled_date_v1', ?)`
+      ).run(new Date().toISOString());
+
+      return { tasksUpdated: tasksResult.changes, stepsUpdated: stepsResult.changes };
+    });
+
+    const { tasksUpdated, stepsUpdated } = backfill();
+
+    // 5. Log affected row counts at INFO level for audit after deploy.
+    console.log(`backfill_scheduled_date_v1: tasks updated=${tasksUpdated}, project_steps updated=${stepsUpdated}`);
+  }
 }

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -969,4 +969,11 @@ export function runMigrations(db: Database.Database): void {
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     )
   `);
+
+  // Issue #519 — scheduled_date column for project_instance_steps.
+  // Additive, nullable, no default. Safe to run on existing DBs (idempotent via pragma check).
+  const instanceStepColsScheduled = (db.pragma('table_info(project_instance_steps)') as { name: string }[]).map((c) => c.name);
+  if (!instanceStepColsScheduled.includes('scheduled_date')) {
+    db.exec(`ALTER TABLE project_instance_steps ADD COLUMN scheduled_date TEXT`);
+  }
 }

--- a/apps/api_server/src/models/dashboard_summary.ts
+++ b/apps/api_server/src/models/dashboard_summary.ts
@@ -1,9 +1,20 @@
 import type { Task } from './task';
 
+/** Concise task summary included in pastDeadlineTasks — no large fields. */
+export interface PastDeadlineTaskSummary {
+  id: string;
+  title: string;
+  dueDate: string | null;
+  scheduledDate: string | null;
+  sourceType: string | null;
+}
+
 export interface DashboardTaskSummary {
   openCount: number;
   pastDueCount: number;
   pastDeadlineCount: number;
+  /** Tasks whose hard dueDate has passed but whose scheduledDate has not (mutually exclusive with pastDue). Sorted by dueDate ASC. */
+  pastDeadlineTasks: PastDeadlineTaskSummary[];
   todayRemainingCount: number;
   todayTotalCount: number;
   thisWeekRemainingCount: number;

--- a/apps/api_server/src/models/dashboard_summary.ts
+++ b/apps/api_server/src/models/dashboard_summary.ts
@@ -3,6 +3,7 @@ import type { Task } from './task';
 export interface DashboardTaskSummary {
   openCount: number;
   pastDueCount: number;
+  pastDeadlineCount: number;
   todayRemainingCount: number;
   todayTotalCount: number;
   thisWeekRemainingCount: number;

--- a/apps/api_server/src/models/project_instance.ts
+++ b/apps/api_server/src/models/project_instance.ts
@@ -4,6 +4,7 @@ export interface ProjectInstanceStep {
   stepId: string;
   title: string;
   dueDate: string;
+  scheduledDate: string | null;
   status: 'open' | 'done';
   notes: string | null;
   assigneeId: number | null;

--- a/apps/api_server/src/models/task_filter.ts
+++ b/apps/api_server/src/models/task_filter.ts
@@ -1,0 +1,30 @@
+/** Status values accepted by the filter param ('all' means no status filter). */
+export type FilterStatus = 'open' | 'in_progress' | 'waiting_for_reply' | 'done' | 'all';
+
+/**
+ * Typed filter object passed to TasksRepository.findByFilterAsync.
+ * All user-supplied string values are validated before reaching the repository;
+ * the repository binds them as SQL parameters — never interpolated into SQL.
+ */
+export interface TaskFilter {
+  userId: number;
+  /** 'all' means no status clause. Defaults to 'open'. */
+  status: FilterStatus;
+  /** Return tasks where COALESCE(scheduled_date, due_date) <= scheduledBefore */
+  scheduledBefore?: string;
+  /** Return tasks where due_date IS NOT NULL AND due_date <= dueBefore */
+  dueBefore?: string;
+  /**
+   * When true: status != 'done' AND COALESCE(scheduled_date, due_date) < today.
+   * When false: exclude those tasks.
+   * Caller must provide `today` (YYYY-MM-DD) for the comparison.
+   */
+  overdue?: boolean;
+  /** Case-insensitive substring match against title. */
+  search?: string;
+  /**
+   * Today's date in YYYY-MM-DD format, injected by the controller.
+   * Required when `overdue` is set; ignored otherwise.
+   */
+  today?: string;
+}

--- a/apps/api_server/src/models/user.ts
+++ b/apps/api_server/src/models/user.ts
@@ -7,6 +7,7 @@ export interface User {
   role: string;
   isFacilitiesManager: boolean;
   emailNotificationsEnabled: boolean;
+  timezone: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -19,6 +20,7 @@ export interface CreateUserDto {
   role?: string;
   isFacilitiesManager?: boolean;
   emailNotificationsEnabled?: boolean;
+  timezone?: string;
 }
 
 export interface UpdateUserDto {
@@ -29,4 +31,5 @@ export interface UpdateUserDto {
   role?: string;
   isFacilitiesManager?: boolean;
   emailNotificationsEnabled?: boolean;
+  timezone?: string;
 }

--- a/apps/api_server/src/repositories/project_instances_repository.ts
+++ b/apps/api_server/src/repositories/project_instances_repository.ts
@@ -21,6 +21,7 @@ interface InstanceStepRow {
   step_id: string;
   title: string;
   due_date: string;
+  scheduled_date: string | null;
   status: string;
   notes: string | null;
   assignee_id: number | null;
@@ -34,6 +35,7 @@ function rowToStep(row: InstanceStepRow): ProjectInstanceStep {
     stepId: row.step_id,
     title: row.title,
     dueDate: row.due_date,
+    scheduledDate: row.scheduled_date ?? null,
     status: row.status as ProjectInstanceStep['status'],
     notes: row.notes ?? null,
     assigneeId: row.assignee_id ?? null,
@@ -484,7 +486,7 @@ export class ProjectInstancesRepository {
       `INSERT INTO project_instances (id, template_id, name, anchor_date, status, owner_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
     );
     const insertStep = db.prepare(
-      `INSERT INTO project_instance_steps (id, instance_id, step_id, title, due_date, status, assignee_id) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO project_instance_steps (id, instance_id, step_id, title, due_date, scheduled_date, status, assignee_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     );
 
     db.transaction(() => {
@@ -504,6 +506,7 @@ export class ProjectInstancesRepository {
           step.stepId,
           step.title,
           step.dueDate,
+          null,
           'open',
           step.assigneeId !== undefined ? step.assigneeId : (templateAssignees.get(step.stepId) ?? null),
         );
@@ -531,14 +534,15 @@ export class ProjectInstancesRepository {
       );
       for (const step of steps) {
         await getPostgresPool().query(
-          `INSERT INTO project_instance_steps (id, instance_id, step_id, title, due_date, status, assignee_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+          `INSERT INTO project_instance_steps (id, instance_id, step_id, title, due_date, scheduled_date, status, assignee_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
           [
             uuidv4(),
             instanceId,
             step.stepId,
             step.title,
             step.dueDate,
+            null,
             'open',
             step.assigneeId !== undefined ? step.assigneeId : (templateAssignees.get(step.stepId) ?? null),
           ],
@@ -551,7 +555,7 @@ export class ProjectInstancesRepository {
 
   updateStep(
     stepId: string,
-    data: { title?: string; dueDate?: string; status?: string; notes?: string | null; assigneeId?: number | null },
+    data: { title?: string; dueDate?: string; scheduledDate?: string | null; status?: string; notes?: string | null; assigneeId?: number | null },
     userId?: number,
   ): ProjectInstanceStep {
     const row = (userId != null
@@ -576,11 +580,12 @@ export class ProjectInstancesRepository {
 
     getDb()
       .prepare(
-        `UPDATE project_instance_steps SET title = ?, due_date = ?, status = ?, notes = ?, assignee_id = ? WHERE id = ?`,
+        `UPDATE project_instance_steps SET title = ?, due_date = ?, scheduled_date = ?, status = ?, notes = ?, assignee_id = ? WHERE id = ?`,
       )
       .run(
         data.title ?? row.title,
         data.dueDate ?? row.due_date,
+        data.scheduledDate !== undefined ? data.scheduledDate : row.scheduled_date,
         data.status ?? row.status,
         data.notes !== undefined ? data.notes : row.notes,
         data.assigneeId !== undefined ? data.assigneeId : row.assignee_id,
@@ -602,7 +607,7 @@ export class ProjectInstancesRepository {
 
   async updateStepAsync(
     stepId: string,
-    data: { title?: string; dueDate?: string; status?: string; notes?: string | null; assigneeId?: number | null },
+    data: { title?: string; dueDate?: string; scheduledDate?: string | null; status?: string; notes?: string | null; assigneeId?: number | null },
     userId?: number,
   ): Promise<ProjectInstanceStep> {
     if (env.dbClient === 'postgres') {
@@ -628,11 +633,12 @@ export class ProjectInstancesRepository {
 
       await getPostgresPool().query(
         `UPDATE project_instance_steps
-         SET title = $1, due_date = $2, status = $3, notes = $4, assignee_id = $5
-         WHERE id = $6`,
+         SET title = $1, due_date = $2, scheduled_date = $3, status = $4, notes = $5, assignee_id = $6
+         WHERE id = $7`,
         [
           data.title ?? row.title,
           data.dueDate ?? row.due_date,
+          data.scheduledDate !== undefined ? data.scheduledDate : row.scheduled_date,
           data.status ?? row.status,
           data.notes !== undefined ? data.notes : row.notes,
           data.assigneeId !== undefined ? data.assigneeId : row.assignee_id,

--- a/apps/api_server/src/repositories/tasks_repository.ts
+++ b/apps/api_server/src/repositories/tasks_repository.ts
@@ -281,6 +281,7 @@ export class TasksRepository {
       params.push('%' + search.toLowerCase() + '%');
     }
 
+    const todayForSort = today ?? new Date().toISOString().slice(0, 10);
     const where = clauses.map((c, i) => (i === 0 ? `WHERE ${c}` : `AND ${c}`)).join('\n  ');
 
     const sql = `
@@ -301,15 +302,22 @@ export class TasksRepository {
        AND (tasks.source_id = rr.id OR tasks.source_id LIKE rr.id || ':%')
       ${where}
       ORDER BY
+        CASE
+          WHEN tasks.status != 'done'
+           AND COALESCE(tasks.scheduled_date, tasks.due_date) IS NOT NULL
+           AND COALESCE(tasks.scheduled_date, tasks.due_date) < ?
+          THEN 0 ELSE 1
+        END ASC,
         COALESCE(tasks.scheduled_date, tasks.due_date) ASC NULLS LAST,
-        tasks.scheduled_order ASC,
+        tasks.scheduled_order ASC NULLS LAST,
         tasks.created_at ASC
     `;
 
-    // userId for the is_shared CASE expression goes first, then the WHERE params.
+    // userId for the is_shared CASE expression goes first, then the WHERE params,
+    // then the today value for the overdue ORDER BY CASE expression.
     const rows = getDb()
       .prepare(sql)
-      .all(userId, ...params) as TaskRow[];
+      .all(userId, ...params, todayForSort) as TaskRow[];
 
     const tasks = rows.map(rowToTask);
 

--- a/apps/api_server/src/repositories/tasks_repository.ts
+++ b/apps/api_server/src/repositories/tasks_repository.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { getDb, getPostgresPool } from '../database/db';
 import { AppError } from '../errors/app_error';
 import type { CreateTaskDto, Task, TaskCollaborator, UpdateTaskDto } from '../models/task';
-import type { TaskFilter } from '../controllers/tasks_controller';
+import type { TaskFilter } from '../models/task_filter';
 
 interface TaskRow {
   id: string;
@@ -85,6 +85,47 @@ const TASK_SELECT = `
    AND (tasks.source_id = rr.id OR tasks.source_id LIKE rr.id || ':%')
 `;
 
+/**
+ * Apply TaskFilter predicates to an already-fetched list of Task objects.
+ * Used as the Postgres fallback until the Postgres query layer is updated.
+ * All date comparisons use plain string comparison (ISO dates sort lexicographically).
+ */
+function applyFilterInMemory(tasks: Task[], filter: TaskFilter): Task[] {
+  const { status, scheduledBefore, dueBefore, overdue, today, search } = filter;
+  const todayStr = today ?? new Date().toISOString().slice(0, 10);
+
+  return tasks.filter((t) => {
+    // status
+    if (status === 'open' && t.status === 'done') return false;
+    if (status !== 'all' && status !== 'open' && t.status !== status) return false;
+
+    // scheduled_before
+    if (scheduledBefore !== undefined) {
+      const priority = t.scheduledDate ?? t.dueDate;
+      if (!priority || priority > scheduledBefore) return false;
+    }
+
+    // due_before
+    if (dueBefore !== undefined) {
+      if (!t.dueDate || t.dueDate > dueBefore) return false;
+    }
+
+    // overdue
+    if (overdue !== undefined) {
+      const priority = t.scheduledDate ?? t.dueDate;
+      const isOverdue = t.status !== 'done' && !!priority && priority < todayStr;
+      if (overdue !== isOverdue) return false;
+    }
+
+    // search
+    if (search !== undefined && search !== '') {
+      if (!t.title.toLowerCase().includes(search.toLowerCase())) return false;
+    }
+
+    return true;
+  });
+}
+
 export class TasksRepository {
   async findAllAsync(userId: number): Promise<Task[]> {
     if (env.dbClient === 'postgres') {
@@ -165,52 +206,127 @@ export class TasksRepository {
   }
 
   /**
-   * Fetch tasks for a user with optional server-side filters.
-   * SQLite implementation only — Postgres path falls back to in-memory filtering
-   * until the Postgres query layer is updated in the follow-up issue.
+   * Fetch tasks for a user with optional server-side filters using parameterized SQL.
+   * All user-supplied values are bound as parameters — never interpolated into SQL.
+   *
+   * Postgres falls back to in-memory filtering via findAllAsync until the Postgres
+   * query layer is updated in a follow-up issue.
    */
   async findByFilterAsync(filter: TaskFilter): Promise<Task[]> {
-    const { userId, status, scheduledBefore, dueBefore, overdue, search } = filter;
+    if (env.dbClient === 'postgres') {
+      // Postgres fallback: fetch all, filter in JS (same logic as SQLite below but
+      // operating on already-mapped Task objects).
+      const all = await this.findAllAsync(filter.userId);
+      return applyFilterInMemory(all, filter);
+    }
 
-    // Fetch all tasks visible to the user, then filter in JS.
-    // The follow-up repository issue will push these predicates into SQL.
-    const all = await this.findAllAsync(userId);
+    return this.findByFilter(filter);
+  }
 
-    const today = new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00');
+  /**
+   * SQLite implementation of findByFilterAsync.
+   * Builds the WHERE clause dynamically from the filter, binding all values as
+   * parameters to prevent SQL injection.
+   */
+  findByFilter(filter: TaskFilter): Task[] {
+    const { userId, status, scheduledBefore, dueBefore, overdue, today, search } = filter;
 
-    return all.filter((t) => {
-      // status filter
-      if (status !== 'all' && t.status !== status) return false;
+    const clauses: string[] = [
+      // Visibility: own tasks OR tasks the user is a collaborator on.
+      '(tasks.owner_id = ? OR EXISTS (SELECT 1 FROM task_collaborators tc WHERE tc.task_id = tasks.id AND tc.user_id = ?))',
+    ];
+    const params: unknown[] = [userId, userId];
 
-      // scheduled_before: COALESCE(scheduled_date, due_date) <= scheduledBefore
-      if (scheduledBefore !== undefined) {
-        const priorityRaw = t.scheduledDate ?? t.dueDate;
-        if (!priorityRaw) return false;
-        if (priorityRaw > scheduledBefore) return false;
+    // --- status ---
+    if (status === 'open') {
+      clauses.push("tasks.status != 'done'");
+    } else if (status !== 'all') {
+      clauses.push('tasks.status = ?');
+      params.push(status);
+    }
+    // status === 'all' → no status clause
+
+    // --- scheduled_before: COALESCE(scheduled_date, due_date) <= ? ---
+    if (scheduledBefore !== undefined) {
+      clauses.push('COALESCE(tasks.scheduled_date, tasks.due_date) IS NOT NULL AND COALESCE(tasks.scheduled_date, tasks.due_date) <= ?');
+      params.push(scheduledBefore);
+    }
+
+    // --- due_before: due_date IS NOT NULL AND due_date <= ? ---
+    if (dueBefore !== undefined) {
+      clauses.push('tasks.due_date IS NOT NULL AND tasks.due_date <= ?');
+      params.push(dueBefore);
+    }
+
+    // --- overdue ---
+    if (overdue !== undefined) {
+      if (overdue) {
+        // Overdue: not done AND priority date < today
+        clauses.push(
+          "tasks.status != 'done' AND COALESCE(tasks.scheduled_date, tasks.due_date) IS NOT NULL AND COALESCE(tasks.scheduled_date, tasks.due_date) < ?",
+        );
+        params.push(today ?? new Date().toISOString().slice(0, 10));
+      } else {
+        // Not overdue: done OR priority date >= today OR no priority date
+        clauses.push(
+          "(tasks.status = 'done' OR COALESCE(tasks.scheduled_date, tasks.due_date) IS NULL OR COALESCE(tasks.scheduled_date, tasks.due_date) >= ?)",
+        );
+        params.push(today ?? new Date().toISOString().slice(0, 10));
       }
+    }
 
-      // due_before: due_date <= dueBefore
-      if (dueBefore !== undefined) {
-        if (!t.dueDate) return false;
-        if (t.dueDate > dueBefore) return false;
-      }
+    // --- search: case-insensitive substring match on title ---
+    if (search !== undefined && search !== '') {
+      clauses.push('LOWER(tasks.title) LIKE ?');
+      params.push('%' + search.toLowerCase() + '%');
+    }
 
-      // overdue: status != 'done' AND COALESCE(scheduled_date, due_date) < today
-      if (overdue !== undefined) {
-        const priorityRaw = t.scheduledDate ?? t.dueDate;
-        const isOverdue = t.status !== 'done' && priorityRaw !== null && priorityRaw !== undefined
-          ? new Date(priorityRaw + 'T00:00:00') < today
-          : false;
-        if (overdue !== isOverdue) return false;
-      }
+    const where = clauses.map((c, i) => (i === 0 ? `WHERE ${c}` : `AND ${c}`)).join('\n  ');
 
-      // search: case-insensitive substring match on title
-      if (search !== undefined && search !== '') {
-        if (!t.title.toLowerCase().includes(search.toLowerCase())) return false;
-      }
+    const sql = `
+      SELECT
+        tasks.*,
+        CASE
+          WHEN tasks.source_type = 'project_step' THEN COALESCE(pi.name, pt.name)
+          WHEN tasks.source_type = 'recurring_rule' THEN rr.title
+          ELSE NULL
+        END AS source_name,
+        CASE WHEN tasks.owner_id != ? THEN 1 ELSE 0 END AS is_shared
+      FROM tasks
+      LEFT JOIN project_instances pi
+        ON tasks.source_type = 'project_step' AND tasks.source_id = pi.id
+      LEFT JOIN project_templates pt ON pi.template_id = pt.id
+      LEFT JOIN recurring_task_rules rr
+        ON tasks.source_type = 'recurring_rule'
+       AND (tasks.source_id = rr.id OR tasks.source_id LIKE rr.id || ':%')
+      ${where}
+      ORDER BY
+        COALESCE(tasks.scheduled_date, tasks.due_date) ASC NULLS LAST,
+        tasks.scheduled_order ASC,
+        tasks.created_at ASC
+    `;
 
-      return true;
-    });
+    // userId for the is_shared CASE expression goes first, then the WHERE params.
+    const rows = getDb()
+      .prepare(sql)
+      .all(userId, ...params) as TaskRow[];
+
+    const tasks = rows.map(rowToTask);
+
+    if (tasks.length > 0) {
+      const placeholders = tasks.map(() => '?').join(',');
+      const collabRows = getDb()
+        .prepare(
+          `SELECT tc.task_id, u.id AS user_id, u.name, u.photo_url
+           FROM task_collaborators tc
+           JOIN users u ON u.id = tc.user_id
+           WHERE tc.task_id IN (${placeholders})`,
+        )
+        .all(...tasks.map((t) => t.id)) as Array<{ task_id: string; user_id: number; name: string; photo_url: string | null }>;
+      attachCollaboratorsToTasks(tasks, collabRows);
+    }
+
+    return tasks;
   }
 
   async findAllIncludingLegacyAsync(): Promise<Task[]> {

--- a/apps/api_server/src/repositories/tasks_repository.ts
+++ b/apps/api_server/src/repositories/tasks_repository.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { getDb, getPostgresPool } from '../database/db';
 import { AppError } from '../errors/app_error';
 import type { CreateTaskDto, Task, TaskCollaborator, UpdateTaskDto } from '../models/task';
+import type { TaskFilter } from '../controllers/tasks_controller';
 
 interface TaskRow {
   id: string;
@@ -161,6 +162,55 @@ export class TasksRepository {
       attachCollaboratorsToTasks(tasks, collabRows);
     }
     return tasks;
+  }
+
+  /**
+   * Fetch tasks for a user with optional server-side filters.
+   * SQLite implementation only — Postgres path falls back to in-memory filtering
+   * until the Postgres query layer is updated in the follow-up issue.
+   */
+  async findByFilterAsync(filter: TaskFilter): Promise<Task[]> {
+    const { userId, status, scheduledBefore, dueBefore, overdue, search } = filter;
+
+    // Fetch all tasks visible to the user, then filter in JS.
+    // The follow-up repository issue will push these predicates into SQL.
+    const all = await this.findAllAsync(userId);
+
+    const today = new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00');
+
+    return all.filter((t) => {
+      // status filter
+      if (status !== 'all' && t.status !== status) return false;
+
+      // scheduled_before: COALESCE(scheduled_date, due_date) <= scheduledBefore
+      if (scheduledBefore !== undefined) {
+        const priorityRaw = t.scheduledDate ?? t.dueDate;
+        if (!priorityRaw) return false;
+        if (priorityRaw > scheduledBefore) return false;
+      }
+
+      // due_before: due_date <= dueBefore
+      if (dueBefore !== undefined) {
+        if (!t.dueDate) return false;
+        if (t.dueDate > dueBefore) return false;
+      }
+
+      // overdue: status != 'done' AND COALESCE(scheduled_date, due_date) < today
+      if (overdue !== undefined) {
+        const priorityRaw = t.scheduledDate ?? t.dueDate;
+        const isOverdue = t.status !== 'done' && priorityRaw !== null && priorityRaw !== undefined
+          ? new Date(priorityRaw + 'T00:00:00') < today
+          : false;
+        if (overdue !== isOverdue) return false;
+      }
+
+      // search: case-insensitive substring match on title
+      if (search !== undefined && search !== '') {
+        if (!t.title.toLowerCase().includes(search.toLowerCase())) return false;
+      }
+
+      return true;
+    });
   }
 
   async findAllIncludingLegacyAsync(): Promise<Task[]> {

--- a/apps/api_server/src/repositories/users_repository.ts
+++ b/apps/api_server/src/repositories/users_repository.ts
@@ -13,6 +13,7 @@ interface UserRow {
   role: string;
   is_facilities_manager: number;
   email_notifications_enabled: number | boolean;
+  timezone: string;
   created_at: string;
   updated_at: string;
 }
@@ -37,6 +38,7 @@ function rowToUser(row: UserRow): User {
     role: row.role,
     isFacilitiesManager,
     emailNotificationsEnabled,
+    timezone: row.timezone ?? 'America/Los_Angeles',
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -128,8 +130,8 @@ export class UsersRepository {
   async createAsync(data: CreateUserDto): Promise<User> {
     if (env.dbClient === 'postgres') {
       const result = await getPostgresPool().query<UserRow>(
-        `INSERT INTO users (name, email, google_sub, photo_url, role, is_facilities_manager, email_notifications_enabled)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
+        `INSERT INTO users (name, email, google_sub, photo_url, role, is_facilities_manager, email_notifications_enabled, timezone)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
          RETURNING *`,
         [
           data.name,
@@ -139,6 +141,7 @@ export class UsersRepository {
           data.role ?? 'member',
           data.isFacilitiesManager ?? false,
           data.emailNotificationsEnabled ?? true,
+          data.timezone ?? 'America/Los_Angeles',
         ],
       );
       return rowToUser(result.rows[0]);
@@ -150,7 +153,7 @@ export class UsersRepository {
   create(data: CreateUserDto): User {
     const result = getDb()
       .prepare(
-        `INSERT INTO users (name, email, google_sub, photo_url, role, is_facilities_manager, email_notifications_enabled) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO users (name, email, google_sub, photo_url, role, is_facilities_manager, email_notifications_enabled, timezone) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         data.name,
@@ -160,6 +163,7 @@ export class UsersRepository {
         data.role ?? 'member',
         data.isFacilitiesManager ? 1 : 0,
         (data.emailNotificationsEnabled ?? true) ? 1 : 0,
+        data.timezone ?? 'America/Los_Angeles',
       );
     return this.findById(result.lastInsertRowid as number);
   }
@@ -177,8 +181,9 @@ export class UsersRepository {
                 role = $5,
                 is_facilities_manager = $6,
                 email_notifications_enabled = $7,
-                updated_at = $8
-          WHERE id = $9
+                timezone = $8,
+                updated_at = $9
+          WHERE id = $10
           RETURNING *`,
         [
           data.name ?? existing.name,
@@ -192,6 +197,7 @@ export class UsersRepository {
           data.emailNotificationsEnabled !== undefined
             ? data.emailNotificationsEnabled
             : existing.emailNotificationsEnabled,
+          data.timezone ?? existing.timezone,
           now,
           id,
         ],
@@ -207,7 +213,7 @@ export class UsersRepository {
     const now = new Date().toISOString();
     getDb()
       .prepare(
-        `UPDATE users SET name = ?, email = ?, google_sub = ?, photo_url = ?, role = ?, is_facilities_manager = ?, email_notifications_enabled = ?, updated_at = ? WHERE id = ?`,
+        `UPDATE users SET name = ?, email = ?, google_sub = ?, photo_url = ?, role = ?, is_facilities_manager = ?, email_notifications_enabled = ?, timezone = ?, updated_at = ? WHERE id = ?`,
       )
       .run(
         data.name ?? existing.name,
@@ -221,6 +227,7 @@ export class UsersRepository {
         data.emailNotificationsEnabled !== undefined
             ? (data.emailNotificationsEnabled ? 1 : 0)
             : (existing.emailNotificationsEnabled ? 1 : 0),
+        data.timezone ?? existing.timezone,
         now,
         id,
       );

--- a/apps/api_server/src/services/dashboard_summary_service.ts
+++ b/apps/api_server/src/services/dashboard_summary_service.ts
@@ -14,6 +14,7 @@ import type { Task } from '../models/task';
 import type { RecurringTaskRule } from '../models/recurring_task_rule';
 import type { ProjectInstance } from '../models/project_instance';
 import type { ProjectTemplate } from '../models/project_template';
+import { priorityDate } from './task_date_status';
 
 const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const MONTHS = ['', 'January', 'February', 'March', 'April', 'May', 'June',
@@ -37,12 +38,6 @@ function patternDescription(rule: RecurringTaskRule): string {
     return `Annually in ${MONTHS[month] ?? 'January'}`;
   }
   return rule.frequency;
-}
-
-function priorityDate(task: Task): Date | null {
-  const raw = task.scheduledDate ?? task.dueDate;
-  if (!raw) return null;
-  return new Date(raw + 'T00:00:00');
 }
 
 function stripDate(d: Date): Date {

--- a/apps/api_server/src/services/dashboard_summary_service.ts
+++ b/apps/api_server/src/services/dashboard_summary_service.ts
@@ -9,6 +9,7 @@ import type {
   DashboardProjectItem,
   DashboardProjectStepPreview,
   DashboardUnreadPreview,
+  PastDeadlineTaskSummary,
 } from '../models/dashboard_summary';
 import type { Task } from '../models/task';
 import type { RecurringTaskRule } from '../models/recurring_task_rule';
@@ -86,12 +87,26 @@ export class DashboardSummaryService {
       return d != null && d < today;
     }).sort(compareTasks);
 
-    // pastDeadlineCount: open tasks where dueDate < today AND NOT overdue
+    // pastDeadlineTasks / pastDeadlineCount: open tasks where dueDate < today AND NOT overdue
     // (i.e. past hard deadline but not already counted in pastDueCount).
-    // The two counts are mutually exclusive by design.
-    const pastDeadlineCount = openTasks.filter(
-      (t) => isPastDeadline(t, today) && !isOverdue(t, today),
-    ).length;
+    // The two counts/lists are mutually exclusive by design.
+    const pastDeadlineTasksRaw = openTasks
+      .filter((t) => isPastDeadline(t, today) && !isOverdue(t, today))
+      .sort((a, b) => {
+        const aDate = a.dueDate ? new Date(a.dueDate + 'T00:00:00').getTime() : 9e15;
+        const bDate = b.dueDate ? new Date(b.dueDate + 'T00:00:00').getTime() : 9e15;
+        return aDate - bDate;
+      });
+
+    const pastDeadlineCount = pastDeadlineTasksRaw.length;
+
+    const pastDeadlineTasks: PastDeadlineTaskSummary[] = pastDeadlineTasksRaw.map((t) => ({
+      id: t.id,
+      title: t.title,
+      dueDate: t.dueDate ?? null,
+      scheduledDate: t.scheduledDate ?? null,
+      sourceType: t.sourceType ?? null,
+    }));
 
     const todayOpen = openTasks.filter((t) => {
       const d = priorityDate(t);
@@ -193,6 +208,7 @@ export class DashboardSummaryService {
         openCount: openTasks.length,
         pastDueCount: pastDue.length,
         pastDeadlineCount,
+        pastDeadlineTasks,
         todayRemainingCount: todayOpen.length,
         todayTotalCount: todayAll.length,
         thisWeekRemainingCount: thisWeekOpen.length,

--- a/apps/api_server/src/services/dashboard_summary_service.ts
+++ b/apps/api_server/src/services/dashboard_summary_service.ts
@@ -14,7 +14,7 @@ import type { Task } from '../models/task';
 import type { RecurringTaskRule } from '../models/recurring_task_rule';
 import type { ProjectInstance } from '../models/project_instance';
 import type { ProjectTemplate } from '../models/project_template';
-import { priorityDate, todayDateInTimezone } from './task_date_status';
+import { isPastDeadline, isOverdue, priorityDate, todayDateInTimezone } from './task_date_status';
 
 const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const MONTHS = ['', 'January', 'February', 'March', 'April', 'May', 'June',
@@ -85,6 +85,13 @@ export class DashboardSummaryService {
       const d = priorityDate(t);
       return d != null && d < today;
     }).sort(compareTasks);
+
+    // pastDeadlineCount: open tasks where dueDate < today AND NOT overdue
+    // (i.e. past hard deadline but not already counted in pastDueCount).
+    // The two counts are mutually exclusive by design.
+    const pastDeadlineCount = openTasks.filter(
+      (t) => isPastDeadline(t, today) && !isOverdue(t, today),
+    ).length;
 
     const todayOpen = openTasks.filter((t) => {
       const d = priorityDate(t);
@@ -185,6 +192,7 @@ export class DashboardSummaryService {
       tasks: {
         openCount: openTasks.length,
         pastDueCount: pastDue.length,
+        pastDeadlineCount,
         todayRemainingCount: todayOpen.length,
         todayTotalCount: todayAll.length,
         thisWeekRemainingCount: thisWeekOpen.length,

--- a/apps/api_server/src/services/dashboard_summary_service.ts
+++ b/apps/api_server/src/services/dashboard_summary_service.ts
@@ -14,7 +14,7 @@ import type { Task } from '../models/task';
 import type { RecurringTaskRule } from '../models/recurring_task_rule';
 import type { ProjectInstance } from '../models/project_instance';
 import type { ProjectTemplate } from '../models/project_template';
-import { priorityDate } from './task_date_status';
+import { priorityDate, todayDateInTimezone } from './task_date_status';
 
 const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const MONTHS = ['', 'January', 'February', 'March', 'April', 'May', 'June',
@@ -66,7 +66,7 @@ export class DashboardSummaryService {
   private projectTemplatesRepo = new ProjectTemplatesRepository();
   private messagesRepo = new MessagesRepository();
 
-  async getSummaryAsync(userId: number): Promise<DashboardSummary> {
+  async getSummaryAsync(userId: number, timezone = 'America/Los_Angeles'): Promise<DashboardSummary> {
     const [tasks, rules, instances, templates, threads] = await Promise.all([
       this.tasksRepo.findAllAsync(userId),
       this.rulesRepo.findAllAsync(userId),
@@ -75,8 +75,7 @@ export class DashboardSummaryService {
       this.messagesRepo.findAllThreadsForUserAsync(userId),
     ]);
 
-    const now = new Date();
-    const today = stripDate(now);
+    const today = todayDateInTimezone(timezone);
     const weekEnd = endOfIsoWeek(today);
 
     // ── Tasks ──────────────────────────────────────────────────────────────────

--- a/apps/api_server/src/services/task_date_status.ts
+++ b/apps/api_server/src/services/task_date_status.ts
@@ -9,6 +9,35 @@ export interface TaskDateShape {
 }
 
 /**
+ * Returns the YYYY-MM-DD string representing "today" in the given IANA timezone.
+ * Uses Intl.DateTimeFormat so the result is correct for the user's local calendar
+ * date regardless of the server's timezone (typically UTC in production).
+ *
+ * @param timezone  IANA timezone name, e.g. "America/Los_Angeles".
+ *                  Falls back to UTC if the string is not recognised.
+ */
+export function todayInTimezone(timezone: string): string {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  return formatter.format(new Date());
+}
+
+/**
+ * Returns a Date object representing midnight (00:00:00) at the start of "today"
+ * in the given IANA timezone.  Suitable for direct comparison with the Date values
+ * returned by priorityDate().
+ *
+ * @param timezone  IANA timezone name, e.g. "America/Los_Angeles".
+ */
+export function todayDateInTimezone(timezone: string): Date {
+  return new Date(todayInTimezone(timezone) + 'T00:00:00');
+}
+
+/**
  * Returns the canonical "priority date" for a task: scheduledDate takes
  * precedence over dueDate. Date strings must be in YYYY-MM-DD format.
  * Returns null when neither date is set.

--- a/apps/api_server/src/services/task_date_status.ts
+++ b/apps/api_server/src/services/task_date_status.ts
@@ -1,0 +1,73 @@
+import type { TaskStatus } from '../models/task';
+
+/** Minimal task shape accepted by the date-status predicates.
+ *  Intentionally narrower than the full Task interface to avoid tight coupling. */
+export interface TaskDateShape {
+  status: TaskStatus;
+  scheduledDate?: string | null;
+  dueDate?: string | null;
+}
+
+/**
+ * Returns the canonical "priority date" for a task: scheduledDate takes
+ * precedence over dueDate. Date strings must be in YYYY-MM-DD format.
+ * Returns null when neither date is set.
+ */
+export function priorityDate(task: Pick<TaskDateShape, 'scheduledDate' | 'dueDate'>): Date | null {
+  const raw = task.scheduledDate ?? task.dueDate;
+  if (!raw) return null;
+  return new Date(raw + 'T00:00:00');
+}
+
+/**
+ * A task is overdue when:
+ *   - status is not 'done', AND
+ *   - COALESCE(scheduledDate, dueDate) is set and is strictly before today.
+ *
+ * @param task  Minimal task shape with status and optional date fields.
+ * @param today The reference date to compare against (caller-supplied; do NOT
+ *              call new Date() internally so that tests can pin time).
+ */
+export function isOverdue(task: TaskDateShape, today: Date): boolean {
+  if (task.status === 'done') return false;
+  const d = priorityDate(task);
+  return d !== null && d < today;
+}
+
+/**
+ * A task is past its hard deadline when:
+ *   - status is not 'done', AND
+ *   - dueDate is set and is strictly before today.
+ *
+ * Note: this ignores scheduledDate — it only looks at the dueDate field,
+ * which represents the latest acceptable completion date regardless of
+ * when the work is actually scheduled.
+ *
+ * @param task  Minimal task shape with status and optional date fields.
+ * @param today The reference date to compare against.
+ */
+export function isPastDeadline(task: TaskDateShape, today: Date): boolean {
+  if (task.status === 'done') return false;
+  if (!task.dueDate) return false;
+  const d = new Date(task.dueDate + 'T00:00:00');
+  return d < today;
+}
+
+/** Convenience object returned by taskDateStatus. */
+export interface TaskDateStatusResult {
+  overdue: boolean;
+  pastDeadline: boolean;
+  priorityDate: Date | null;
+}
+
+/**
+ * Returns a structured result describing the date status of a task.
+ * Useful when callers need multiple flags at once without re-parsing dates.
+ */
+export function taskDateStatus(task: TaskDateShape, today: Date): TaskDateStatusResult {
+  return {
+    overdue: isOverdue(task, today),
+    pastDeadline: isPastDeadline(task, today),
+    priorityDate: priorityDate(task),
+  };
+}

--- a/apps/api_server/src/services/weekly_planning_service.ts
+++ b/apps/api_server/src/services/weekly_planning_service.ts
@@ -143,7 +143,7 @@ export class WeeklyPlanningService {
         id: event.id,
         title: event.title,
         notes: detailBits.join(' • '),
-        dueDate: dayKey,
+        dueDate: null,
         scheduledDate: dayKey,
         scheduledOrder: null,
         locked: true,

--- a/apps/api_server/src/services/weekly_planning_service.ts
+++ b/apps/api_server/src/services/weekly_planning_service.ts
@@ -2,6 +2,7 @@ import { CalendarShadowEventsRepository } from '../repositories/calendar_shadow_
 import { ProjectInstancesRepository } from '../repositories/project_instances_repository';
 import { TasksRepository } from '../repositories/tasks_repository';
 import type { Task } from '../models/task';
+import { priorityDate } from './task_date_status';
 
 export interface WeeklyPlanDay {
   date: string;
@@ -72,8 +73,9 @@ export class WeeklyPlanningService {
     const weekTasks = await this.tasksRepo.findByWeekAsync(startStr, endStr, userId);
 
     for (const task of weekTasks) {
-      const dateKey = task.scheduledDate ?? task.dueDate;
-      if (!dateKey) continue;
+      const pd = priorityDate(task);
+      if (!pd) continue;
+      const dateKey = isoDate(pd);
       const day = dayMap.get(dateKey);
       if (!day) continue;
       day.tasks.push(task);

--- a/apps/api_server/src/services/weekly_planning_service.ts
+++ b/apps/api_server/src/services/weekly_planning_service.ts
@@ -31,10 +31,30 @@ export function parseWeekLabel(weekLabel: string): Date {
   return result;
 }
 
-/** Return the ISO week label (YYYY-WNN) for today. */
-export function currentWeekLabel(): string {
-  const now = new Date();
-  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+/**
+ * Return the ISO week label (YYYY-WNN) for today.
+ *
+ * @param timezone  Optional IANA timezone name (e.g. "America/Los_Angeles").
+ *                  When provided, "today" is resolved in that timezone so the
+ *                  week label matches the user's local calendar date.
+ *                  Defaults to UTC to preserve backward-compatible behaviour
+ *                  for callers that do not supply a timezone.
+ */
+export function currentWeekLabel(timezone?: string): string {
+  let todayStr: string;
+  if (timezone) {
+    const formatter = new Intl.DateTimeFormat('en-CA', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    todayStr = formatter.format(new Date());
+  } else {
+    const now = new Date();
+    todayStr = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-${String(now.getUTCDate()).padStart(2, '0')}`;
+  }
+  const d = new Date(todayStr + 'T00:00:00Z');
   d.setUTCDate(d.getUTCDate() + 3 - ((d.getUTCDay() + 6) % 7));
   const jan4 = new Date(Date.UTC(d.getUTCFullYear(), 0, 4));
   const weekNum =

--- a/apps/desktop_flutter/lib/app/core/formatters/date_formatters.dart
+++ b/apps/desktop_flutter/lib/app/core/formatters/date_formatters.dart
@@ -82,22 +82,6 @@ class DateFormatters {
     return _parseIsoDate(scheduledDate) ?? _parseIsoDate(dueDate);
   }
 
-  // ignore: deprecated_member_use_from_same_package
-  @Deprecated('Use isOverdue')
-  static bool isPastDue({
-    required String? dueDate,
-    required String? scheduledDate,
-    required bool isDone,
-    DateTime? today,
-  }) {
-    return isOverdue(
-      dueDate: dueDate,
-      scheduledDate: scheduledDate,
-      isDone: isDone,
-      today: today,
-    );
-  }
-
   static bool isDueToday({
     required String? dueDate,
     required String? scheduledDate,

--- a/apps/desktop_flutter/lib/app/core/formatters/date_formatters.dart
+++ b/apps/desktop_flutter/lib/app/core/formatters/date_formatters.dart
@@ -39,9 +39,11 @@ class DateFormatters {
     return '$weekday, $month ${date.day}, ${date.year}';
   }
 
-  static bool isPastDue({
-    required String? dueDate,
-    required String? scheduledDate,
+  /// Returns true when the task is not done and its priority date (scheduledDate
+  /// ?? dueDate) is strictly before today.
+  static bool isOverdue({
+    String? dueDate,
+    String? scheduledDate,
     required bool isDone,
     DateTime? today,
   }) {
@@ -54,6 +56,45 @@ class DateFormatters {
         : DateTime(today.year, today.month, today.day);
     return comparisonDate.isBefore(
       DateTime(current.year, current.month, current.day),
+    );
+  }
+
+  /// Returns true when the task is not done and dueDate is strictly before
+  /// today. scheduledDate is intentionally ignored — this checks only the hard
+  /// deadline.
+  static bool isPastDeadline({
+    String? dueDate,
+    required bool isDone,
+    DateTime? today,
+  }) {
+    if (isDone) return false;
+    final due = _parseIsoDate(dueDate);
+    if (due == null) return false;
+    final current = today == null
+        ? DateTime.now()
+        : DateTime(today.year, today.month, today.day);
+    return due.isBefore(DateTime(current.year, current.month, current.day));
+  }
+
+  /// Returns the parsed scheduledDate if present, otherwise the parsed dueDate.
+  /// Returns null when both are absent or unparseable.
+  static DateTime? priorityDate({String? dueDate, String? scheduledDate}) {
+    return _parseIsoDate(scheduledDate) ?? _parseIsoDate(dueDate);
+  }
+
+  // ignore: deprecated_member_use_from_same_package
+  @Deprecated('Use isOverdue')
+  static bool isPastDue({
+    required String? dueDate,
+    required String? scheduledDate,
+    required bool isDone,
+    DateTime? today,
+  }) {
+    return isOverdue(
+      dueDate: dueDate,
+      scheduledDate: scheduledDate,
+      isDone: isDone,
+      today: today,
     );
   }
 

--- a/apps/desktop_flutter/lib/app/core/tasks/task_visual_style.dart
+++ b/apps/desktop_flutter/lib/app/core/tasks/task_visual_style.dart
@@ -3,6 +3,15 @@ import 'package:flutter/material.dart';
 import '../../../features/tasks/models/task.dart';
 import '../formatters/date_formatters.dart';
 
+/// Describes the semantic state of a task for visual rendering purposes.
+enum TaskVisualState {
+  done,
+  overdue,
+  pastDeadline,
+  dueToday,
+  sourceBased,
+}
+
 class TaskVisualStyle {
   const TaskVisualStyle({
     required this.accent,
@@ -11,6 +20,8 @@ class TaskVisualStyle {
     required this.badgeBackground,
     required this.text,
     required this.mutedText,
+    this.label,
+    this.state,
   });
 
   final Color accent;
@@ -19,14 +30,26 @@ class TaskVisualStyle {
   final Color badgeBackground;
   final Color text;
   final Color mutedText;
+
+  /// Optional pill label for this visual state (e.g. "Past deadline").
+  /// Null when no label pill should be rendered.
+  final String? label;
+
+  /// The semantic state that produced this style.
+  final TaskVisualState? state;
 }
 
 class TaskVisualStyles {
   static TaskVisualStyle resolve(Task task, {DateTime? today}) {
     final isDone = task.status == TaskStatus.done;
-    final isPastDue = DateFormatters.isPastDue(
+    final isOverdue = DateFormatters.isOverdue(
       dueDate: task.dueDate,
       scheduledDate: task.scheduledDate,
+      isDone: isDone,
+      today: today,
+    );
+    final isPastDeadline = DateFormatters.isPastDeadline(
+      dueDate: task.dueDate,
       isDone: isDone,
       today: today,
     );
@@ -37,6 +60,13 @@ class TaskVisualStyles {
       today: today,
     );
 
+    // Precedence order:
+    // 1. done → done style
+    // 2. overdue → past-due (red)
+    // 3. pastDeadline && !overdue → amber
+    // 4. dueToday → today style (orange)
+    // 5. otherwise source-based color
+
     if (isDone) {
       return const TaskVisualStyle(
         accent: Color(0xFF94A3B8),
@@ -45,10 +75,11 @@ class TaskVisualStyles {
         badgeBackground: Color(0xFFEDE7DC),
         text: Color(0xFF94A3B8),
         mutedText: Color(0xFF94A3B8),
+        state: TaskVisualState.done,
       );
     }
 
-    if (isPastDue) {
+    if (isOverdue) {
       return const TaskVisualStyle(
         accent: Color(0xFFDC5B58),
         background: Color(0xFFFFECEA),
@@ -56,6 +87,20 @@ class TaskVisualStyles {
         badgeBackground: Color(0xFFF7D2CE),
         text: Color(0xFF1E293B),
         mutedText: Color(0xFFA84A47),
+        state: TaskVisualState.overdue,
+      );
+    }
+
+    if (isPastDeadline) {
+      return const TaskVisualStyle(
+        accent: Color(0xFFF59E0B),
+        background: Color(0xFFFEF3C7),
+        border: Color(0xFFFBBF24),
+        badgeBackground: Color(0xFFFDE68A),
+        text: Color(0xFF1E293B),
+        mutedText: Color(0xFFB45309),
+        label: 'Past deadline',
+        state: TaskVisualState.pastDeadline,
       );
     }
 
@@ -67,6 +112,7 @@ class TaskVisualStyles {
         badgeBackground: Color(0xFFF5DDB0),
         text: Color(0xFF1E293B),
         mutedText: Color(0xFF9B6B24),
+        state: TaskVisualState.dueToday,
       );
     }
 
@@ -84,6 +130,7 @@ class TaskVisualStyles {
           badgeBackground: Color(0xFFF6DCAB),
           text: Color(0xFF1E293B),
           mutedText: Color(0xFF9B6B24),
+          state: TaskVisualState.sourceBased,
         ),
       'recurring_rule' => _variant(_rhythmVariants, variantKey),
       'project_step' => _variant(_projectVariants, variantKey),
@@ -96,6 +143,7 @@ class TaskVisualStyles {
           badgeBackground: Color(0xFFF3EEE6),
           text: Color(0xFF1E293B),
           mutedText: Color(0xFF64748B),
+          state: TaskVisualState.sourceBased,
         ),
     };
   }

--- a/apps/desktop_flutter/lib/app/core/tasks/task_visual_style.dart
+++ b/apps/desktop_flutter/lib/app/core/tasks/task_visual_style.dart
@@ -40,6 +40,11 @@ class TaskVisualStyle {
 }
 
 class TaskVisualStyles {
+  /// The accent color used for [TaskVisualState.pastDeadline] rows.
+  /// Exposed here so legend widgets can reference the same value without
+  /// duplicating the hex literal.
+  static const Color pastDeadlineAccent = Color(0xFFF59E0B);
+
   static TaskVisualStyle resolve(Task task, {DateTime? today}) {
     final isDone = task.status == TaskStatus.done;
     final isOverdue = DateFormatters.isOverdue(
@@ -93,7 +98,7 @@ class TaskVisualStyles {
 
     if (isPastDeadline) {
       return const TaskVisualStyle(
-        accent: Color(0xFFF59E0B),
+        accent: pastDeadlineAccent,
         background: Color(0xFFFEF3C7),
         border: Color(0xFFFBBF24),
         badgeBackground: Color(0xFFFDE68A),

--- a/apps/desktop_flutter/lib/app/core/ui/rhythm_inspector.dart
+++ b/apps/desktop_flutter/lib/app/core/ui/rhythm_inspector.dart
@@ -39,12 +39,14 @@ class RhythmProjectStepInspectorSaveRequest {
     required this.title,
     required this.notes,
     required this.dueDate,
+    required this.scheduledDate,
     required this.assigneeId,
   });
 
   final String title;
   final String? notes;
   final String? dueDate;
+  final String? scheduledDate;
   final int? assigneeId;
 }
 
@@ -387,8 +389,8 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
   late final TextEditingController _titleController;
   late final TextEditingController _notesController;
   late List<TaskCollaborator> _collaborators;
-  late String? _primaryDate;
-  late bool _usesScheduledDate;
+  late String? _scheduledDate;
+  late String? _dueDate;
   late String? _preferredAgent;
   bool _editing = false;
   bool _saving = false;
@@ -402,10 +404,8 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
     _titleController = TextEditingController(text: widget.task.title);
     _notesController = TextEditingController(text: widget.task.notes ?? '');
     _collaborators = [...widget.task.collaborators];
-    _usesScheduledDate = widget.task.sourceType != 'project_step' &&
-        (widget.task.scheduledDate != null || widget.task.dueDate == null);
-    _primaryDate =
-        _usesScheduledDate ? widget.task.scheduledDate : widget.task.dueDate;
+    _scheduledDate = widget.task.scheduledDate;
+    _dueDate = widget.task.dueDate;
     _preferredAgent = widget.task.preferredAgent;
   }
 
@@ -423,9 +423,10 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
     final ownerLabel =
         _memberName(widget.task.ownerId, widget.workspaceMembers);
     final sourceLabel = _taskSourceLabel(widget.task);
-    final scheduleLabel = _primaryDate == null
-        ? 'No date set'
-        : DateFormatters.fullDate(_primaryDate, fallback: _primaryDate!);
+    final firstDate = _scheduledDate ?? _dueDate;
+    final headerDateLabel = firstDate == null
+        ? null
+        : DateFormatters.fullDate(firstDate, fallback: firstDate);
 
     return _RhythmInspectorShell(
       kicker: _readOnly ? 'TASK INSPECTOR · READ ONLY' : 'TASK INSPECTOR',
@@ -452,8 +453,8 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
           _statusColor(widget.task.status, colors.success),
         ),
         if (sourceLabel != null) _headerPill(context, sourceLabel, colors.info),
-        if (_primaryDate != null)
-          _headerPill(context, scheduleLabel, colors.warning),
+        if (headerDateLabel != null)
+          _headerPill(context, headerDateLabel, colors.warning),
       ],
       headerBody: _editing && !_readOnly
           ? TextField(
@@ -487,9 +488,8 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
                       _titleController.text = widget.task.title;
                       _notesController.text = widget.task.notes ?? '';
                       _collaborators = [...widget.task.collaborators];
-                      _primaryDate = _usesScheduledDate
-                          ? widget.task.scheduledDate
-                          : widget.task.dueDate;
+                      _scheduledDate = widget.task.scheduledDate;
+                      _dueDate = widget.task.dueDate;
                       _preferredAgent = widget.task.preferredAgent;
                     });
                   },
@@ -534,37 +534,76 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
           _InspectorSection(
             title: 'Schedule',
             subtitle: _editing
-                ? 'Update the planning date for this task.'
+                ? 'Update the planning and due dates for this task.'
                 : 'Operational planning metadata.',
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 if (_editing && !_readOnly) ...[
+                  Text(
+                    'Scheduled',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: colors.textMuted,
+                          fontWeight: FontWeight.w700,
+                        ),
+                  ),
+                  const SizedBox(height: 6),
                   RhythmDateButton(
-                    date: _primaryDate,
+                    date: _scheduledDate,
+                    placeholder: 'Set scheduled date',
                     onTap: () async {
                       final result = await pickRhythmDate(
                         context,
-                        current: _primaryDate,
+                        current: _scheduledDate,
                       );
                       if (result != null && mounted) {
-                        setState(() => _primaryDate = result);
+                        setState(() => _scheduledDate = result);
                       }
                     },
-                    onClear: () => setState(() => _primaryDate = null),
+                    onClear: () => setState(() => _scheduledDate = null),
+                  ),
+                  const SizedBox(height: 14),
+                  Text(
+                    'Due',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: colors.textMuted,
+                          fontWeight: FontWeight.w700,
+                        ),
+                  ),
+                  const SizedBox(height: 6),
+                  RhythmDateButton(
+                    date: _dueDate,
+                    placeholder: 'Set due date',
+                    onTap: () async {
+                      final result = await pickRhythmDate(
+                        context,
+                        current: _dueDate,
+                      );
+                      if (result != null && mounted) {
+                        setState(() => _dueDate = result);
+                      }
+                    },
+                    onClear: () => setState(() => _dueDate = null),
                   ),
                 ] else ...[
-                  _MetaRow(label: 'Date', value: scheduleLabel),
-                  if (widget.task.scheduledDate != null &&
-                      widget.task.dueDate != null &&
-                      widget.task.scheduledDate != widget.task.dueDate)
+                  if (_scheduledDate != null)
+                    _MetaRow(
+                      label: 'Scheduled',
+                      value: DateFormatters.fullDate(
+                        _scheduledDate,
+                        fallback: _scheduledDate!,
+                      ),
+                    ),
+                  if (_dueDate != null)
                     _MetaRow(
                       label: 'Due',
                       value: DateFormatters.fullDate(
-                        widget.task.dueDate,
-                        fallback: widget.task.dueDate!,
+                        _dueDate,
+                        fallback: _dueDate!,
                       ),
                     ),
+                  if (_scheduledDate == null && _dueDate == null)
+                    _MetaRow(label: 'Scheduled', value: 'No date set'),
                 ],
               ],
             ),
@@ -753,9 +792,8 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
         RhythmTaskInspectorSaveRequest(
           title: title,
           notes: notes.isEmpty ? null : notes,
-          dueDate: _usesScheduledDate ? widget.task.dueDate : _primaryDate,
-          scheduledDate:
-              _usesScheduledDate ? _primaryDate : widget.task.scheduledDate,
+          dueDate: _dueDate,
+          scheduledDate: _scheduledDate,
           preferredAgent: _preferredAgent,
         ),
       );
@@ -792,6 +830,7 @@ class _RhythmProjectStepInspectorState
     extends State<_RhythmProjectStepInspector> {
   late final TextEditingController _titleController;
   late final TextEditingController _notesController;
+  late String? _scheduledDate;
   late String? _dueDate;
   late int? _assigneeId;
   bool _editing = false;
@@ -802,6 +841,7 @@ class _RhythmProjectStepInspectorState
     super.initState();
     _titleController = TextEditingController(text: widget.step.title);
     _notesController = TextEditingController(text: widget.step.notes ?? '');
+    _scheduledDate = widget.step.scheduledDate;
     _dueDate = widget.step.dueDate;
     _assigneeId = widget.step.assigneeId;
   }
@@ -829,12 +869,18 @@ class _RhythmProjectStepInspectorState
           widget.step.status == 'done' ? 'Done' : 'Open',
           widget.step.status == 'done' ? colors.success : colors.warning,
         ),
-        _headerPill(
-          context,
-          DateFormatters.fullDate(_dueDate,
-              fallback: _dueDate ?? 'No due date'),
-          colors.info,
-        ),
+        if (_scheduledDate != null)
+          _headerPill(
+            context,
+            DateFormatters.fullDate(_scheduledDate, fallback: _scheduledDate!),
+            colors.info,
+          )
+        else if (_dueDate != null)
+          _headerPill(
+            context,
+            DateFormatters.fullDate(_dueDate, fallback: _dueDate!),
+            colors.info,
+          ),
       ],
       headerBody: _editing
           ? TextField(
@@ -867,6 +913,7 @@ class _RhythmProjectStepInspectorState
                       _editing = false;
                       _titleController.text = widget.step.title;
                       _notesController.text = widget.step.notes ?? '';
+                      _scheduledDate = widget.step.scheduledDate;
                       _dueDate = widget.step.dueDate;
                       _assigneeId = widget.step.assigneeId;
                     });
@@ -915,6 +962,37 @@ class _RhythmProjectStepInspectorState
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 if (_editing) ...[
+                  Text(
+                    'Scheduled',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: context.rhythm.textMuted,
+                          fontWeight: FontWeight.w700,
+                        ),
+                  ),
+                  const SizedBox(height: 6),
+                  RhythmDateButton(
+                    date: _scheduledDate,
+                    placeholder: 'Set scheduled date',
+                    onTap: () async {
+                      final result = await pickRhythmDate(
+                        context,
+                        current: _scheduledDate,
+                      );
+                      if (result != null && mounted) {
+                        setState(() => _scheduledDate = result);
+                      }
+                    },
+                    onClear: () => setState(() => _scheduledDate = null),
+                  ),
+                  const SizedBox(height: 14),
+                  Text(
+                    'Due',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: context.rhythm.textMuted,
+                          fontWeight: FontWeight.w700,
+                        ),
+                  ),
+                  const SizedBox(height: 6),
                   RhythmDateButton(
                     date: _dueDate,
                     placeholder: 'Set due date',
@@ -938,13 +1016,22 @@ class _RhythmProjectStepInspectorState
                   ),
                 ] else ...[
                   _MetaRow(label: 'Project', value: widget.projectTitle),
-                  _MetaRow(
-                    label: 'Due',
-                    value: DateFormatters.fullDate(
-                      _dueDate,
-                      fallback: _dueDate ?? 'No due date',
+                  if (_scheduledDate != null)
+                    _MetaRow(
+                      label: 'Scheduled',
+                      value: DateFormatters.fullDate(
+                        _scheduledDate,
+                        fallback: _scheduledDate!,
+                      ),
                     ),
-                  ),
+                  if (_dueDate != null)
+                    _MetaRow(
+                      label: 'Due',
+                      value: DateFormatters.fullDate(
+                        _dueDate,
+                        fallback: _dueDate!,
+                      ),
+                    ),
                   _MetaRow(
                     label: 'Assigned to',
                     value: _memberName(_assigneeId, widget.workspaceMembers) ??
@@ -1041,6 +1128,7 @@ class _RhythmProjectStepInspectorState
           title: title,
           notes: notes.isEmpty ? null : notes,
           dueDate: _dueDate,
+          scheduledDate: _scheduledDate,
           assigneeId: _assigneeId,
         ),
       );

--- a/apps/desktop_flutter/lib/app/core/ui/rhythm_inspector.dart
+++ b/apps/desktop_flutter/lib/app/core/ui/rhythm_inspector.dart
@@ -585,6 +585,10 @@ class _RhythmTaskInspectorState extends State<_RhythmTaskInspector> {
                     },
                     onClear: () => setState(() => _dueDate = null),
                   ),
+                  if (_isScheduledAfterDeadline(_scheduledDate, _dueDate)) ...[
+                    const SizedBox(height: 12),
+                    const _ScheduledAfterDeadlineWarning(),
+                  ],
                 ] else ...[
                   if (_scheduledDate != null)
                     _MetaRow(
@@ -1007,6 +1011,10 @@ class _RhythmProjectStepInspectorState
                     },
                     onClear: () => setState(() => _dueDate = null),
                   ),
+                  if (_isScheduledAfterDeadline(_scheduledDate, _dueDate)) ...[
+                    const SizedBox(height: 12),
+                    const _ScheduledAfterDeadlineWarning(),
+                  ],
                   const SizedBox(height: 12),
                   RhythmAssigneeField(
                     workspaceMembers: widget.workspaceMembers,
@@ -1136,6 +1144,64 @@ class _RhythmProjectStepInspectorState
     } finally {
       if (mounted) setState(() => _saving = false);
     }
+  }
+}
+
+/// Returns true when both dates are non-null and [dueDate] is strictly before
+/// [scheduledDate]. Dates are compared as ISO-8601 date strings (YYYY-MM-DD).
+///
+/// Exposed with `@visibleForTesting` so inspector widget tests can exercise
+/// the predicate directly without spinning up the full dialog.
+@visibleForTesting
+bool isScheduledAfterDeadline(String? scheduledDate, String? dueDate) {
+  if (scheduledDate == null || dueDate == null) return false;
+  final scheduled = DateTime.tryParse(scheduledDate);
+  final due = DateTime.tryParse(dueDate);
+  if (scheduled == null || due == null) return false;
+  return due.isBefore(scheduled);
+}
+
+bool _isScheduledAfterDeadline(String? scheduledDate, String? dueDate) =>
+    isScheduledAfterDeadline(scheduledDate, dueDate);
+
+/// A non-blocking amber warning row shown when the scheduled date falls after
+/// the due date.
+class _ScheduledAfterDeadlineWarning extends StatelessWidget {
+  const _ScheduledAfterDeadlineWarning();
+
+  @override
+  Widget build(BuildContext context) {
+    const amberColor = Color(0xFFF59E0B);
+    return Semantics(
+      label: 'Warning: this task is scheduled after its deadline.',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+        decoration: BoxDecoration(
+          color: amberColor.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(RhythmRadius.sm),
+          border: Border.all(color: amberColor.withValues(alpha: 0.30)),
+        ),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.warning_amber_rounded,
+              size: 16,
+              color: amberColor,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                'Heads up: this is scheduled after its deadline.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: amberColor,
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/apps/desktop_flutter/lib/app/core/ui/rhythm_task_create_bar.dart
+++ b/apps/desktop_flutter/lib/app/core/ui/rhythm_task_create_bar.dart
@@ -10,7 +10,7 @@ import 'rhythm_ui.dart';
 typedef RhythmTaskCreateCallback = void Function(
   String title, {
   String? notes,
-  String? dueDate,
+  String? scheduledDate,
   int? collaboratorId,
 });
 
@@ -37,7 +37,7 @@ class RhythmTaskCreateBar extends StatefulWidget {
 class _RhythmTaskCreateBarState extends State<RhythmTaskCreateBar> {
   final _titleController = TextEditingController();
   final _notesController = TextEditingController();
-  String? _selectedDueDate;
+  String? _selectedScheduledDate;
   WorkspaceMember? _selectedCollaborator;
 
   @override
@@ -53,13 +53,13 @@ class _RhythmTaskCreateBarState extends State<RhythmTaskCreateBar> {
     widget.onSubmit(
       title,
       notes: widget.showNotes ? _notesController.text.trim() : null,
-      dueDate: _selectedDueDate,
+      scheduledDate: _selectedScheduledDate,
       collaboratorId: _selectedCollaborator?.userId,
     );
     _titleController.clear();
     _notesController.clear();
     setState(() {
-      _selectedDueDate = null;
+      _selectedScheduledDate = null;
       _selectedCollaborator = null;
     });
   }
@@ -133,15 +133,19 @@ class _RhythmTaskCreateBarState extends State<RhythmTaskCreateBar> {
           );
 
           final dateButton = RhythmDateButton(
-            date: _selectedDueDate,
-            placeholder: 'Due date',
+            date: _selectedScheduledDate,
+            placeholder: 'Scheduled',
             onTap: () async {
-              final result =
-                  await pickRhythmDate(context, current: _selectedDueDate);
-              if (result != null) setState(() => _selectedDueDate = result);
+              final result = await pickRhythmDate(
+                context,
+                current: _selectedScheduledDate,
+              );
+              if (result != null) {
+                setState(() => _selectedScheduledDate = result);
+              }
             },
-            onClear: _selectedDueDate != null
-                ? () => setState(() => _selectedDueDate = null)
+            onClear: _selectedScheduledDate != null
+                ? () => setState(() => _selectedScheduledDate = null)
                 : null,
           );
 

--- a/apps/desktop_flutter/lib/features/dashboard/controllers/dashboard_controller.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/controllers/dashboard_controller.dart
@@ -148,9 +148,10 @@ class DashboardController extends ChangeNotifier {
         final projectName = instance.name ?? 'Project';
         for (final step in instance.steps) {
           if (step.status == 'done') continue;
-          if (step.dueDate.isEmpty) continue;
+          final stepDateStr = step.scheduledDate ?? step.dueDate;
+          if (stepDateStr == null || stepDateStr.isEmpty) continue;
 
-          final parsed = DateTime.tryParse(step.dueDate);
+          final parsed = DateTime.tryParse(stepDateStr);
           if (parsed == null) continue;
           final taskDate = DateTime(parsed.year, parsed.month, parsed.day);
 
@@ -267,20 +268,26 @@ class DashboardController extends ChangeNotifier {
     String stepId, {
     String? title,
     String? dueDate,
+    String? scheduledDate,
     String? status,
     String? notes,
     int? assigneeId,
     bool includeNotes = false,
+    bool includeDueDate = false,
+    bool includeScheduledDate = false,
   }) async {
     try {
       await _repository.updateProjectInstanceStep(
         stepId,
         title: title,
         dueDate: dueDate,
+        scheduledDate: scheduledDate,
         status: status,
         notes: notes,
         assigneeId: assigneeId,
         includeNotes: includeNotes,
+        includeDueDate: includeDueDate,
+        includeScheduledDate: includeScheduledDate,
       );
       await refresh();
     } catch (e) {

--- a/apps/desktop_flutter/lib/features/dashboard/controllers/dashboard_controller.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/controllers/dashboard_controller.dart
@@ -189,14 +189,14 @@ class DashboardController extends ChangeNotifier {
   Future<void> createTask(
     String title, {
     String? notes,
-    String? dueDate,
+    String? scheduledDate,
     int? collaboratorId,
   }) async {
     try {
       await _repository.createTask(
         title,
         notes: notes,
-        dueDate: dueDate,
+        scheduledDate: scheduledDate,
         collaboratorId: collaboratorId,
       );
       await refresh();

--- a/apps/desktop_flutter/lib/features/dashboard/controllers/dashboard_controller.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/controllers/dashboard_controller.dart
@@ -21,6 +21,7 @@ class DashboardController extends ChangeNotifier {
   int _activeProjectsCount = 0;
   int _messageThreadCount = 0;
   int _pastDueTaskCount = 0;
+  int _pastDeadlineCount = 0;
   int _todayTasksTotalCount = 0;
   int _todayTasksRemainingCount = 0;
   int _thisWeekTasksTotalCount = 0;
@@ -50,6 +51,7 @@ class DashboardController extends ChangeNotifier {
   int get activeProjectsCount => _activeProjectsCount;
   int get messageThreadCount => _messageThreadCount;
   int get pastDueTaskCount => _pastDueTaskCount;
+  int get pastDeadlineCount => _pastDeadlineCount;
   int get todayTasksTotalCount => _todayTasksTotalCount;
   int get todayTasksRemainingCount => _todayTasksRemainingCount;
   int get thisWeekTasksTotalCount => _thisWeekTasksTotalCount;
@@ -86,6 +88,7 @@ class DashboardController extends ChangeNotifier {
 
       _openTaskCount = t.openCount;
       _pastDueTaskCount = t.pastDueCount;
+      _pastDeadlineCount = t.pastDeadlineCount;
       _todayTasksRemainingCount = t.todayRemainingCount;
       _todayTasksTotalCount = t.todayTotalCount;
       _thisWeekTasksRemainingCount = t.thisWeekRemainingCount;

--- a/apps/desktop_flutter/lib/features/dashboard/data/dashboard_data_source.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/data/dashboard_data_source.dart
@@ -96,7 +96,7 @@ class DashboardDataSource {
   Future<Task> createTask(
     String title, {
     String? notes,
-    String? dueDate,
+    String? scheduledDate,
   }) async {
     final response = await http.post(
       Uri.parse('$_baseUrl/tasks'),
@@ -104,7 +104,7 @@ class DashboardDataSource {
       body: jsonEncode({
         'title': title,
         if (notes != null && notes.isNotEmpty) 'notes': notes,
-        if (dueDate != null) 'dueDate': dueDate,
+        if (scheduledDate != null) 'scheduledDate': scheduledDate,
       }),
     );
     assertOk(response);

--- a/apps/desktop_flutter/lib/features/dashboard/data/dashboard_data_source.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/data/dashboard_data_source.dart
@@ -170,17 +170,22 @@ class DashboardDataSource {
     String stepId, {
     String? title,
     String? dueDate,
+    String? scheduledDate,
     String? status,
     String? notes,
     int? assigneeId,
     bool includeNotes = false,
+    bool includeDueDate = false,
+    bool includeScheduledDate = false,
   }) async {
     final response = await http.patch(
       Uri.parse('$_baseUrl/project-instances/steps/$stepId'),
       headers: AuthSessionStore.headers(json: true),
       body: jsonEncode({
         if (title != null) 'title': title,
-        if (dueDate != null) 'dueDate': dueDate,
+        if (includeDueDate || dueDate != null) 'dueDate': dueDate,
+        if (includeScheduledDate || scheduledDate != null)
+          'scheduledDate': scheduledDate,
         if (status != null) 'status': status,
         if (includeNotes || notes != null) 'notes': notes,
         if (assigneeId != null) 'assigneeId': assigneeId,

--- a/apps/desktop_flutter/lib/features/dashboard/models/dashboard_overview_models.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/models/dashboard_overview_models.dart
@@ -4,6 +4,7 @@ class DashboardSummaryTaskSlice {
   DashboardSummaryTaskSlice({
     required this.openCount,
     required this.pastDueCount,
+    required this.pastDeadlineCount,
     required this.todayRemainingCount,
     required this.todayTotalCount,
     required this.thisWeekRemainingCount,
@@ -23,6 +24,7 @@ class DashboardSummaryTaskSlice {
     return DashboardSummaryTaskSlice(
       openCount: (json['openCount'] as num?)?.toInt() ?? 0,
       pastDueCount: (json['pastDueCount'] as num?)?.toInt() ?? 0,
+      pastDeadlineCount: (json['pastDeadlineCount'] as num?)?.toInt() ?? 0,
       todayRemainingCount: (json['todayRemainingCount'] as num?)?.toInt() ?? 0,
       todayTotalCount: (json['todayTotalCount'] as num?)?.toInt() ?? 0,
       thisWeekRemainingCount:
@@ -39,6 +41,7 @@ class DashboardSummaryTaskSlice {
 
   final int openCount;
   final int pastDueCount;
+  final int pastDeadlineCount;
   final int todayRemainingCount;
   final int todayTotalCount;
   final int thisWeekRemainingCount;

--- a/apps/desktop_flutter/lib/features/dashboard/models/dashboard_overview_models.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/models/dashboard_overview_models.dart
@@ -233,7 +233,8 @@ class DashboardProjectStepPreview {
     required this.id,
     required this.title,
     required this.status,
-    required this.dueDate,
+    this.dueDate,
+    this.scheduledDate,
     this.notes,
     this.assigneeId,
     this.assigneeName,
@@ -244,7 +245,8 @@ class DashboardProjectStepPreview {
         id: json['id'] as String,
         title: json['title'] as String,
         status: json['status'] as String? ?? 'open',
-        dueDate: json['dueDate'] as String? ?? '',
+        dueDate: json['dueDate'] as String?,
+        scheduledDate: json['scheduledDate'] as String?,
         notes: json['notes'] as String?,
         assigneeId: (json['assigneeId'] as num?)?.toInt(),
         assigneeName: json['assigneeName'] as String?,
@@ -253,7 +255,8 @@ class DashboardProjectStepPreview {
   final String id;
   final String title;
   final String status;
-  final String dueDate;
+  final String? dueDate;
+  final String? scheduledDate;
   final String? notes;
   final int? assigneeId;
   final String? assigneeName;

--- a/apps/desktop_flutter/lib/features/dashboard/repositories/dashboard_repository.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/repositories/dashboard_repository.dart
@@ -32,13 +32,13 @@ class DashboardRepository {
   Future<Task> createTask(
     String title, {
     String? notes,
-    String? dueDate,
+    String? scheduledDate,
     int? collaboratorId,
   }) async {
     final task = await _dataSource.createTask(
       title,
       notes: notes,
-      dueDate: dueDate,
+      scheduledDate: scheduledDate,
     );
     if (collaboratorId != null) {
       await _dataSource.addCollaboratorToTask(task.id, collaboratorId);

--- a/apps/desktop_flutter/lib/features/dashboard/repositories/dashboard_repository.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/repositories/dashboard_repository.dart
@@ -84,19 +84,25 @@ class DashboardRepository {
     String stepId, {
     String? title,
     String? dueDate,
+    String? scheduledDate,
     String? status,
     String? notes,
     int? assigneeId,
     bool includeNotes = false,
+    bool includeDueDate = false,
+    bool includeScheduledDate = false,
   }) =>
       _dataSource.updateProjectInstanceStep(
         stepId,
         title: title,
         dueDate: dueDate,
+        scheduledDate: scheduledDate,
         status: status,
         notes: notes,
         assigneeId: assigneeId,
         includeNotes: includeNotes,
+        includeDueDate: includeDueDate,
+        includeScheduledDate: includeScheduledDate,
       );
 
   /// Builds unread message previews using an already-fetched [threads] list

--- a/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
@@ -589,7 +589,10 @@ class _DashboardBodyState extends State<_DashboardBody> {
   List<Task> _tasksForDate(List<Task> tasks, DateTime date) {
     final target = DateTime(date.year, date.month, date.day);
     return tasks.where((task) {
-      final taskDate = _taskPriorityDate(task);
+      final taskDate = DateFormatters.priorityDate(
+        dueDate: task.dueDate,
+        scheduledDate: task.scheduledDate,
+      );
       return taskDate != null &&
           taskDate.year == target.year &&
           taskDate.month == target.month &&
@@ -1642,26 +1645,6 @@ class _ProgressFeatureDetails extends StatelessWidget {
   }
 }
 
-bool _isPastDue(Task task) {
-  if (task.status == TaskStatus.done) return false;
-  final date = _taskPriorityDate(task);
-  if (date == null) return false;
-  final today = DateTime.now();
-  final stripped = DateTime(today.year, today.month, today.day);
-  return date.isBefore(stripped);
-}
-
-DateTime? _taskPriorityDate(Task task) {
-  final scheduled = task.scheduledDate == null
-      ? null
-      : DateTime.tryParse(task.scheduledDate!);
-  if (scheduled != null) {
-    return DateTime(scheduled.year, scheduled.month, scheduled.day);
-  }
-  final due = task.dueDate == null ? null : DateTime.tryParse(task.dueDate!);
-  return due == null ? null : DateTime(due.year, due.month, due.day);
-}
-
 String _taskSourceLabel(Task task) {
   final sourceName = task.sourceName?.trim();
   if (sourceName != null && sourceName.isNotEmpty) return sourceName;
@@ -1676,7 +1659,13 @@ String _taskSourceLabel(Task task) {
 }
 
 RhythmBadgeTone _taskTone(Task task, {bool showPastDue = false}) {
-  if (showPastDue && _isPastDue(task)) return RhythmBadgeTone.danger;
+  final overdue = showPastDue &&
+      DateFormatters.isOverdue(
+        dueDate: task.dueDate,
+        scheduledDate: task.scheduledDate,
+        isDone: task.status == TaskStatus.done,
+      );
+  if (overdue) return RhythmBadgeTone.danger;
   return switch (task.sourceType) {
     'recurring_rule' => RhythmBadgeTone.success,
     'project_step' => RhythmBadgeTone.warning,
@@ -1892,10 +1881,21 @@ class _TaskPreviewRow extends StatelessWidget {
     final isDone = task.status == TaskStatus.done;
     final tone = _taskTone(task, showPastDue: showPastDue);
     final accent = _toneColor(colors, tone);
-    final isPastDue = showPastDue && _isPastDue(task);
-    final dueLabel = task.dueDate != null
-        ? DateFormatters.fullDate(task.dueDate, fallback: task.dueDate!)
-        : null;
+    final isPastDue = showPastDue &&
+        DateFormatters.isOverdue(
+          dueDate: task.dueDate,
+          scheduledDate: task.scheduledDate,
+          isDone: isDone,
+        );
+    final hasSched =
+        task.scheduledDate != null && task.scheduledDate!.trim().isNotEmpty;
+    final hasDue = task.dueDate != null && task.dueDate!.trim().isNotEmpty;
+    final primaryDateStr = hasSched ? task.scheduledDate : task.dueDate;
+    final primaryLabel = _compactDate(primaryDateStr);
+    final showDueHint = hasSched &&
+        hasDue &&
+        task.scheduledDate!.trim() != task.dueDate!.trim();
+    final dueHintLabel = showDueHint ? _compactDate(task.dueDate) : null;
     final sourceName = task.sourceName?.trim();
     final hasSourceName = sourceName != null && sourceName.isNotEmpty;
 
@@ -1960,14 +1960,31 @@ class _TaskPreviewRow extends StatelessWidget {
                     ],
                   ),
                 ),
-                if (dueLabel != null) ...[
+                if (primaryLabel != null) ...[
                   const SizedBox(width: 6),
-                  RhythmMetaChip(
-                    label: dueLabel,
-                    icon: Icons.flag_outlined,
-                    tone: isPastDue
-                        ? RhythmMetaChipTone.danger
-                        : RhythmMetaChipTone.neutral,
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      RhythmMetaChip(
+                        label: primaryLabel,
+                        icon: Icons.flag_outlined,
+                        tone: isPastDue
+                            ? RhythmMetaChipTone.danger
+                            : RhythmMetaChipTone.neutral,
+                      ),
+                      if (dueHintLabel != null)
+                        Text(
+                          'Due $dueHintLabel',
+                          style:
+                              Theme.of(context).textTheme.labelSmall?.copyWith(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSurfaceVariant,
+                                    fontSize: 10,
+                                  ),
+                        ),
+                    ],
                   ),
                 ],
               ],
@@ -2080,4 +2097,28 @@ class _HandoffPreviewRow extends StatelessWidget {
       ),
     );
   }
+}
+
+String? _compactDate(String? isoDate) {
+  if (isoDate == null || isoDate.trim().isEmpty) return null;
+  final match = RegExp(r'^(\d{4})-(\d{2})-(\d{2})').firstMatch(isoDate.trim());
+  if (match == null) return isoDate;
+  final month = int.tryParse(match.group(2)!);
+  final day = int.tryParse(match.group(3)!);
+  if (month == null || day == null || month < 1 || month > 12) return isoDate;
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${months[month - 1]} $day';
 }

--- a/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
@@ -1881,7 +1881,7 @@ class _TaskPreviewRow extends StatelessWidget {
     final isDone = task.status == TaskStatus.done;
     final tone = _taskTone(task, showPastDue: showPastDue);
     final accent = _toneColor(colors, tone);
-    final isPastDue = showPastDue &&
+    final isOverdue = showPastDue &&
         DateFormatters.isOverdue(
           dueDate: task.dueDate,
           scheduledDate: task.scheduledDate,
@@ -1969,7 +1969,7 @@ class _TaskPreviewRow extends StatelessWidget {
                       RhythmMetaChip(
                         label: primaryLabel,
                         icon: Icons.flag_outlined,
-                        tone: isPastDue
+                        tone: isOverdue
                             ? RhythmMetaChipTone.danger
                             : RhythmMetaChipTone.neutral,
                       ),

--- a/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
@@ -484,6 +484,7 @@ class _DashboardBodyState extends State<_DashboardBody> {
           stepId: step.stepId,
           title: step.title,
           dueDate: step.dueDate,
+          scheduledDate: step.scheduledDate,
           status: step.status,
           notes: step.notes,
           assigneeId: step.assigneeId,
@@ -497,9 +498,12 @@ class _DashboardBodyState extends State<_DashboardBody> {
           step.id,
           title: request.title,
           dueDate: request.dueDate,
+          scheduledDate: request.scheduledDate,
           notes: request.notes,
           assigneeId: request.assigneeId,
           includeNotes: true,
+          includeDueDate: true,
+          includeScheduledDate: true,
         ),
       );
       return;
@@ -555,6 +559,7 @@ class _DashboardBodyState extends State<_DashboardBody> {
         stepId: step.id,
         title: step.title,
         dueDate: step.dueDate,
+        scheduledDate: step.scheduledDate,
         status: step.status,
         notes: step.notes,
         assigneeId: step.assigneeId,
@@ -571,9 +576,12 @@ class _DashboardBodyState extends State<_DashboardBody> {
         step.id,
         title: request.title,
         dueDate: request.dueDate,
+        scheduledDate: request.scheduledDate,
         notes: request.notes,
         assigneeId: request.assigneeId,
         includeNotes: true,
+        includeDueDate: true,
+        includeScheduledDate: true,
       ),
     );
   }

--- a/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
@@ -196,11 +196,11 @@ class _DashboardBodyState extends State<_DashboardBody> {
           ),
           RhythmTaskCreateBar(
             addLabel: 'Add task',
-            onSubmit: (title, {notes, dueDate, collaboratorId}) {
+            onSubmit: (title, {notes, scheduledDate, collaboratorId}) {
               context.read<DashboardController>().createTask(
                     title,
                     notes: notes,
-                    dueDate: dueDate,
+                    scheduledDate: scheduledDate,
                     collaboratorId: collaboratorId,
                   );
             },

--- a/apps/desktop_flutter/lib/features/imports/views/import_dialog.dart
+++ b/apps/desktop_flutter/lib/features/imports/views/import_dialog.dart
@@ -139,7 +139,7 @@ Example:
         await tasksCtrl.createTask(
           item['title'] as String,
           notes: item['notes'] as String?,
-          dueDate: item['dueDate'] as String?,
+          scheduledDate: item['dueDate'] as String?,
         );
         tasks++;
       }

--- a/apps/desktop_flutter/lib/features/projects/models/project_instance.dart
+++ b/apps/desktop_flutter/lib/features/projects/models/project_instance.dart
@@ -7,8 +7,9 @@ class ProjectInstanceStep {
     required this.instanceId,
     required this.stepId,
     required this.title,
-    required this.dueDate,
     required this.status,
+    this.dueDate,
+    this.scheduledDate,
     this.notes,
     this.assigneeId,
     this.assigneeName,
@@ -20,8 +21,9 @@ class ProjectInstanceStep {
       instanceId: asString(json['instanceId']) ?? '',
       stepId: asString(json['stepId']) ?? '',
       title: asString(json['title']) ?? '',
-      dueDate: asString(json['dueDate']) ?? '',
       status: asString(json['status']) ?? 'open',
+      dueDate: asString(json['dueDate']),
+      scheduledDate: asString(json['scheduledDate']),
       notes: asString(json['notes']),
       assigneeId: asInt(json['assigneeId']),
       assigneeName: asString(json['assigneeName']),
@@ -32,7 +34,8 @@ class ProjectInstanceStep {
   final String instanceId;
   final String stepId;
   final String title;
-  final String dueDate;
+  final String? dueDate;
+  final String? scheduledDate;
   final String status;
   final String? notes;
   final int? assigneeId;

--- a/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
+++ b/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
@@ -246,14 +246,19 @@ class _ProjectsViewState extends State<ProjectsView> {
     ProjectInstanceStep step, {
     String? title,
     String? dueDate,
+    String? scheduledDate,
     String? status,
     String? notes,
     int? assigneeId,
+    bool includeDueDate = false,
+    bool includeScheduledDate = false,
   }) async {
     try {
       final body = <String, dynamic>{
         if (title != null) 'title': title,
-        if (dueDate != null) 'dueDate': dueDate,
+        if (includeDueDate || dueDate != null) 'dueDate': dueDate,
+        if (includeScheduledDate || scheduledDate != null)
+          'scheduledDate': scheduledDate,
         if (status != null) 'status': status,
         if (notes != null) 'notes': notes.isEmpty ? null : notes,
         'assigneeId': assigneeId,
@@ -292,8 +297,11 @@ class _ProjectsViewState extends State<ProjectsView> {
         step,
         title: request.title,
         dueDate: request.dueDate,
+        scheduledDate: request.scheduledDate,
         notes: request.notes,
         assigneeId: request.assigneeId,
+        includeDueDate: true,
+        includeScheduledDate: true,
       ),
     );
   }
@@ -579,14 +587,19 @@ class _TemplateDetailState extends State<_TemplateDetail>
     ProjectInstanceStep step, {
     String? title,
     String? dueDate,
+    String? scheduledDate,
     String? status,
     String? notes,
     int? assigneeId,
+    bool includeDueDate = false,
+    bool includeScheduledDate = false,
   }) async {
     try {
       final body = <String, dynamic>{
         if (title != null) 'title': title,
-        if (dueDate != null) 'dueDate': dueDate,
+        if (includeDueDate || dueDate != null) 'dueDate': dueDate,
+        if (includeScheduledDate || scheduledDate != null)
+          'scheduledDate': scheduledDate,
         if (status != null) 'status': status,
         if (notes != null) 'notes': notes.isEmpty ? null : notes,
         'assigneeId': assigneeId,
@@ -625,8 +638,11 @@ class _TemplateDetailState extends State<_TemplateDetail>
         step,
         title: request.title,
         dueDate: request.dueDate,
+        scheduledDate: request.scheduledDate,
         notes: request.notes,
         assigneeId: request.assigneeId,
+        includeDueDate: true,
+        includeScheduledDate: true,
       ),
     );
   }
@@ -1283,7 +1299,7 @@ class _InstanceStepTile extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'Due: ${DateFormatters.fullDate(step.dueDate, fallback: step.dueDate)}',
+              'Due: ${DateFormatters.fullDate(step.dueDate, fallback: step.dueDate ?? 'No due date')}',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: colorScheme.onSurfaceVariant,
                   ),
@@ -2122,7 +2138,8 @@ class _SuccessView extends StatelessWidget {
                   ),
                 ),
                 Text(
-                  DateFormatters.fullDate(s.dueDate, fallback: s.dueDate),
+                  DateFormatters.fullDate(s.dueDate,
+                      fallback: s.dueDate ?? 'No due date'),
                   style: const TextStyle(color: Colors.grey, fontSize: 11),
                 ),
               ],

--- a/apps/desktop_flutter/lib/features/tasks/controllers/tasks_controller.dart
+++ b/apps/desktop_flutter/lib/features/tasks/controllers/tasks_controller.dart
@@ -34,14 +34,14 @@ class TasksController extends ChangeNotifier {
   Future<void> createTask(
     String title, {
     String? notes,
-    String? dueDate,
+    String? scheduledDate,
     int? collaboratorId,
   }) async {
     try {
       final task = await _repository.create(
         title,
         notes: notes,
-        dueDate: dueDate,
+        scheduledDate: scheduledDate,
         collaboratorId: collaboratorId,
       );
       _tasks = [..._tasks, task];

--- a/apps/desktop_flutter/lib/features/tasks/data/tasks_local_data_source.dart
+++ b/apps/desktop_flutter/lib/features/tasks/data/tasks_local_data_source.dart
@@ -26,7 +26,7 @@ class TasksLocalDataSource {
   Future<Task> create(
     String title, {
     String? notes,
-    String? dueDate,
+    String? scheduledDate,
     int? ownerId,
     String? preferredAgent,
   }) async {
@@ -36,7 +36,7 @@ class TasksLocalDataSource {
       body: jsonEncode({
         'title': title,
         if (notes != null && notes.isNotEmpty) 'notes': notes,
-        if (dueDate != null) 'dueDate': dueDate,
+        if (scheduledDate != null) 'scheduledDate': scheduledDate,
         if (ownerId != null) 'ownerId': ownerId,
         'preferredAgent': preferredAgent,
       }),

--- a/apps/desktop_flutter/lib/features/tasks/repositories/tasks_repository.dart
+++ b/apps/desktop_flutter/lib/features/tasks/repositories/tasks_repository.dart
@@ -11,7 +11,7 @@ class TasksRepository {
   Future<Task> create(
     String title, {
     String? notes,
-    String? dueDate,
+    String? scheduledDate,
     int? ownerId,
     int? collaboratorId,
     String? preferredAgent,
@@ -19,7 +19,7 @@ class TasksRepository {
     final task = await _dataSource.create(
       title,
       notes: notes,
-      dueDate: dueDate,
+      scheduledDate: scheduledDate,
       ownerId: ownerId,
       preferredAgent: preferredAgent,
     );

--- a/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
@@ -456,7 +456,7 @@ class _TasksViewState extends State<TasksView> {
     final colors = context.rhythm;
     final isDone = task.status == TaskStatus.done;
     final visualStyle = TaskVisualStyles.resolve(task);
-    final isPastDue = DateFormatters.isPastDue(
+    final isOverdue = DateFormatters.isOverdue(
       dueDate: task.dueDate,
       scheduledDate: task.scheduledDate,
       isDone: isDone,
@@ -559,7 +559,7 @@ class _TasksViewState extends State<TasksView> {
                     RhythmMetaChip(
                       label: primaryLabel,
                       icon: Icons.flag_outlined,
-                      tone: isPastDue
+                      tone: isOverdue
                           ? RhythmMetaChipTone.danger
                           : RhythmMetaChipTone.neutral,
                     ),

--- a/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
@@ -460,7 +460,17 @@ class _TasksViewState extends State<TasksView> {
       scheduledDate: task.scheduledDate,
       isDone: isDone,
     );
-    final dueLabel = _compactDate(task.dueDate);
+    // Primary badge uses scheduledDate ?? dueDate (same semantics as
+    // DateFormatters.priorityDate) so the row badge matches the grouping logic.
+    final hasSched =
+        task.scheduledDate != null && task.scheduledDate!.trim().isNotEmpty;
+    final hasDue = task.dueDate != null && task.dueDate!.trim().isNotEmpty;
+    final primaryDateStr = hasSched ? task.scheduledDate : task.dueDate;
+    final primaryLabel = _compactDate(primaryDateStr);
+    final showDueHint = hasSched &&
+        hasDue &&
+        task.scheduledDate!.trim() != task.dueDate!.trim();
+    final dueHintLabel = showDueHint ? _compactDate(task.dueDate) : null;
     final sourceName = task.sourceName?.trim();
     final hasSourceName = sourceName != null && sourceName.isNotEmpty;
     final accentColor = visualStyle.accent;
@@ -539,14 +549,30 @@ class _TasksViewState extends State<TasksView> {
                   color: Color(0xFFF59E0B),
                 ),
               ],
-              if (dueLabel != null) ...[
+              if (primaryLabel != null) ...[
                 const SizedBox(width: 6),
-                RhythmMetaChip(
-                  label: dueLabel,
-                  icon: Icons.flag_outlined,
-                  tone: isPastDue
-                      ? RhythmMetaChipTone.danger
-                      : RhythmMetaChipTone.neutral,
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    RhythmMetaChip(
+                      label: primaryLabel,
+                      icon: Icons.flag_outlined,
+                      tone: isPastDue
+                          ? RhythmMetaChipTone.danger
+                          : RhythmMetaChipTone.neutral,
+                    ),
+                    if (dueHintLabel != null)
+                      Text(
+                        'Due $dueHintLabel',
+                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSurfaceVariant,
+                              fontSize: 10,
+                            ),
+                      ),
+                  ],
                 ),
               ],
               RhythmMenuButton<_TaskAction>(

--- a/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
@@ -198,6 +198,7 @@ class _TasksViewState extends State<TasksView> {
         RhythmColorLegend(
           items: const [
             (Color(0xFFDC5B58), 'Past due'),
+            (TaskVisualStyles.pastDeadlineAccent, 'Past deadline'),
             (Color(0xFFE29A3A), 'Today'),
             (Color(0xFF4E5FE0), 'Rhythm'),
             (Color(0xFF2E7FC4), 'Project'),

--- a/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
@@ -80,13 +80,13 @@ class _TasksViewState extends State<TasksView> {
                                 onSubmit: (
                                   title, {
                                   notes,
-                                  dueDate,
+                                  scheduledDate,
                                   collaboratorId,
                                 }) {
                                   context.read<TasksController>().createTask(
                                         title,
                                         notes: notes,
-                                        dueDate: dueDate,
+                                        scheduledDate: scheduledDate,
                                         collaboratorId: collaboratorId,
                                       );
                                 },

--- a/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/controllers/weekly_planner_controller.dart
@@ -182,9 +182,17 @@ class WeeklyPlannerController extends ChangeNotifier {
     }
   }
 
-  Future<void> createTask(String title, {String? dueDate, int? ownerId}) async {
+  Future<void> createTask(
+    String title, {
+    String? scheduledDate,
+    int? ownerId,
+  }) async {
     try {
-      await _tasksRepository.create(title, dueDate: dueDate, ownerId: ownerId);
+      await _tasksRepository.create(
+        title,
+        scheduledDate: scheduledDate,
+        ownerId: ownerId,
+      );
       await load();
     } catch (e) {
       _errorMessage = e.toString();

--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -986,7 +986,7 @@ class _DayColumnState extends State<_DayColumn> {
     if (result != null && result.title.isNotEmpty) {
       await widget.controller.createTask(
         result.title,
-        dueDate: widget.date,
+        scheduledDate: widget.date,
         ownerId: result.ownerId,
       );
     }

--- a/apps/desktop_flutter/test/app/core/tasks/task_visual_style_test.dart
+++ b/apps/desktop_flutter/test/app/core/tasks/task_visual_style_test.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rhythm_desktop/app/core/tasks/task_visual_style.dart';
+import 'package:rhythm_desktop/features/tasks/models/task.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Task _makeTask({
+  TaskStatus status = TaskStatus.open,
+  String? dueDate,
+  String? scheduledDate,
+  String? sourceType,
+}) {
+  return Task(
+    id: 'test-id',
+    title: 'Test task',
+    status: status,
+    createdAt: '2025-01-01',
+    updatedAt: '2025-01-01',
+    dueDate: dueDate,
+    scheduledDate: scheduledDate,
+    sourceType: sourceType,
+  );
+}
+
+void main() {
+  // Fixed reference date: 2025-06-15
+  final today = DateTime(2025, 6, 15);
+  const yesterday = '2025-06-14';
+  const todayStr = '2025-06-15';
+  const tomorrow = '2025-06-16';
+  const nextWeek = '2025-06-22';
+
+  // ---------------------------------------------------------------------------
+  // Branch 1: done
+  // ---------------------------------------------------------------------------
+  group('resolve — done state', () {
+    test('done task resolves to done style regardless of dates', () {
+      final task = _makeTask(
+        status: TaskStatus.done,
+        dueDate: yesterday,
+        scheduledDate: yesterday,
+      );
+      final style = TaskVisualStyles.resolve(task, today: today);
+      expect(style.state, TaskVisualState.done);
+      expect(style.accent, const Color(0xFF94A3B8));
+      expect(style.label, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Branch 2: overdue (red)
+  // ---------------------------------------------------------------------------
+  group('resolve — overdue state', () {
+    test('past scheduledDate → overdue (red)', () {
+      final task = _makeTask(
+        dueDate: nextWeek,
+        scheduledDate: yesterday,
+      );
+      final style = TaskVisualStyles.resolve(task, today: today);
+      expect(style.state, TaskVisualState.overdue);
+      expect(style.accent, const Color(0xFFDC5B58));
+      expect(style.label, isNull);
+    });
+
+    test('past dueDate with no scheduledDate → overdue (red)', () {
+      final task = _makeTask(dueDate: yesterday);
+      final style = TaskVisualStyles.resolve(task, today: today);
+      expect(style.state, TaskVisualState.overdue);
+      expect(style.accent, const Color(0xFFDC5B58));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Branch 3: pastDeadline (amber) — dueDate in past, scheduledDate in future
+  // ---------------------------------------------------------------------------
+  group('resolve — pastDeadline state', () {
+    test(
+        'dueDate past + scheduledDate future → pastDeadline (amber), '
+        'NOT overdue', () {
+      final task = _makeTask(
+        dueDate: yesterday,
+        scheduledDate: tomorrow,
+      );
+      final style = TaskVisualStyles.resolve(task, today: today);
+      expect(style.state, TaskVisualState.pastDeadline);
+      expect(style.accent, const Color(0xFFF59E0B));
+      expect(style.background, const Color(0xFFFEF3C7));
+      expect(style.label, 'Past deadline');
+    });
+
+    test('dueDate today, scheduledDate future → NOT pastDeadline', () {
+      final task = _makeTask(
+        dueDate: todayStr,
+        scheduledDate: tomorrow,
+      );
+      final style = TaskVisualStyles.resolve(task, today: today);
+      // dueDate is not before today, so no pastDeadline
+      expect(style.state, isNot(TaskVisualState.pastDeadline));
+    });
+
+    test('dueDate past, scheduledDate today → overdue wins over pastDeadline',
+        () {
+      // scheduledDate today means isOverdue is false (not strictly before),
+      // but dueDate is past → only isPastDeadline is true, and isOverdue=false
+      // So this is pastDeadline, not overdue.
+      final task = _makeTask(
+        dueDate: yesterday,
+        scheduledDate: todayStr,
+      );
+      final style = TaskVisualStyles.resolve(task, today: today);
+      // scheduledDate is today (not overdue), dueDate is past (pastDeadline)
+      expect(style.state, TaskVisualState.pastDeadline);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Precedence: overdue wins over pastDeadline
+  // ---------------------------------------------------------------------------
+  group('resolve — precedence: overdue beats pastDeadline', () {
+    test(
+        'scheduledDate in past AND dueDate in past → overdue wins (red, not amber)',
+        () {
+      // Both isOverdue and isPastDeadline are true.
+      // Overdue must win (red).
+      final task = _makeTask(
+        dueDate: yesterday,
+        scheduledDate: yesterday,
+      );
+      final style = TaskVisualStyles.resolve(task, today: today);
+      expect(style.state, TaskVisualState.overdue);
+      expect(style.accent, const Color(0xFFDC5B58),
+          reason: 'Red overdue color must win over amber pastDeadline');
+      expect(style.label, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Branch 4: dueToday
+  // ---------------------------------------------------------------------------
+  group('resolve — dueToday state', () {
+    test('scheduledDate today → dueToday (orange)', () {
+      final task = _makeTask(scheduledDate: todayStr);
+      final style = TaskVisualStyles.resolve(task, today: today);
+      expect(style.state, TaskVisualState.dueToday);
+      expect(style.accent, const Color(0xFFE29A3A));
+      expect(style.label, isNull);
+    });
+
+    test('dueDate today, no scheduledDate → dueToday (orange)', () {
+      final task = _makeTask(dueDate: todayStr);
+      final style = TaskVisualStyles.resolve(task, today: today);
+      expect(style.state, TaskVisualState.dueToday);
+      expect(style.accent, const Color(0xFFE29A3A));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Branch 5: source-based / default
+  // ---------------------------------------------------------------------------
+  group('resolve — source-based / default', () {
+    test('no dates, no source → default style', () {
+      final task = _makeTask();
+      final style = TaskVisualStyles.resolve(task, today: today);
+      expect(style.state, TaskVisualState.sourceBased);
+      expect(style.accent, const Color(0xFF64748B));
+      expect(style.label, isNull);
+    });
+
+    test('future due date → default style (not overdue, not today)', () {
+      final task = _makeTask(dueDate: nextWeek);
+      final style = TaskVisualStyles.resolve(task, today: today);
+      expect(style.state, TaskVisualState.sourceBased);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // No regression on existing colors
+  // ---------------------------------------------------------------------------
+  group('resolve — no regression on existing colors', () {
+    test('overdue accent is still DC5B58', () {
+      final task = _makeTask(dueDate: yesterday, scheduledDate: yesterday);
+      expect(
+        TaskVisualStyles.resolve(task, today: today).accent,
+        const Color(0xFFDC5B58),
+      );
+    });
+
+    test('dueToday accent is still E29A3A', () {
+      final task = _makeTask(dueDate: todayStr);
+      expect(
+        TaskVisualStyles.resolve(task, today: today).accent,
+        const Color(0xFFE29A3A),
+      );
+    });
+
+    test('done accent is still 94A3B8', () {
+      final task = _makeTask(status: TaskStatus.done, dueDate: yesterday);
+      expect(
+        TaskVisualStyles.resolve(task, today: today).accent,
+        const Color(0xFF94A3B8),
+      );
+    });
+
+    test('pastDeadline accent is F59E0B (amber-500)', () {
+      final task = _makeTask(dueDate: yesterday, scheduledDate: tomorrow);
+      expect(
+        TaskVisualStyles.resolve(task, today: today).accent,
+        const Color(0xFFF59E0B),
+      );
+    });
+
+    test('pastDeadline background is FEF3C7 (amber-100)', () {
+      final task = _makeTask(dueDate: yesterday, scheduledDate: tomorrow);
+      expect(
+        TaskVisualStyles.resolve(task, today: today).background,
+        const Color(0xFFFEF3C7),
+      );
+    });
+  });
+}

--- a/apps/desktop_flutter/test/app/core/ui/rhythm_inspector_date_warning_test.dart
+++ b/apps/desktop_flutter/test/app/core/ui/rhythm_inspector_date_warning_test.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rhythm_desktop/app/core/ui/rhythm_inspector.dart';
+import 'package:rhythm_desktop/app/core/ui/tokens/rhythm_theme.dart';
+import 'package:rhythm_desktop/features/tasks/models/task.dart';
+import 'package:rhythm_desktop/features/tasks/models/task_collaborator.dart';
+
+// ---------------------------------------------------------------------------
+// Unit tests – predicate logic
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('isScheduledAfterDeadline predicate', () {
+    test('returns false when scheduledDate is null', () {
+      expect(isScheduledAfterDeadline(null, '2026-06-01'), isFalse);
+    });
+
+    test('returns false when dueDate is null', () {
+      expect(isScheduledAfterDeadline('2026-06-10', null), isFalse);
+    });
+
+    test('returns false when both dates are null', () {
+      expect(isScheduledAfterDeadline(null, null), isFalse);
+    });
+
+    test('returns false when dueDate == scheduledDate', () {
+      expect(isScheduledAfterDeadline('2026-06-10', '2026-06-10'), isFalse);
+    });
+
+    test('returns false when dueDate is after scheduledDate', () {
+      expect(isScheduledAfterDeadline('2026-06-01', '2026-06-10'), isFalse);
+    });
+
+    test('returns true when dueDate is strictly before scheduledDate', () {
+      expect(isScheduledAfterDeadline('2026-06-10', '2026-06-01'), isTrue);
+    });
+
+    test('returns false for malformed date strings', () {
+      expect(isScheduledAfterDeadline('not-a-date', '2026-06-01'), isFalse);
+      expect(isScheduledAfterDeadline('2026-06-10', 'bad'), isFalse);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Widget tests – warning appears in the task inspector
+  //
+  // These tests pump showRhythmTaskInspector via a trigger button. The aside
+  // panel contains a DropdownButtonFormField that overflows at the constrained
+  // test surface size; this is a pre-existing issue unrelated to the warning
+  // feature. We use onError suppression scoped to the overflow string so the
+  // warning assertions can run, and we verify the warning text directly.
+  // -------------------------------------------------------------------------
+
+  group('Inspector scheduled-after-deadline warning', () {
+    Widget wrap(Widget widget) {
+      return MaterialApp(
+        theme: ThemeData.light().copyWith(
+          extensions: const [RhythmColorRoles.light],
+        ),
+        home: Scaffold(body: widget),
+      );
+    }
+
+    Task makeTask({String? scheduledDate, String? dueDate}) => Task(
+          id: 'test-1',
+          title: 'Test task',
+          status: TaskStatus.open,
+          collaborators: const <TaskCollaborator>[],
+          createdAt: '2026-01-01',
+          updatedAt: '2026-01-01',
+          scheduledDate: scheduledDate,
+          dueDate: dueDate,
+        );
+
+    const warningText = 'Heads up: this is scheduled after its deadline.';
+
+    /// Opens the task inspector and enters edit mode, suppressing the
+    /// pre-existing overflow error in the aside dropdown panel.
+    Future<void> openInspectorInEditMode(
+      WidgetTester tester,
+      Task task, {
+      RhythmTaskInspectorSave? onSave,
+    }) async {
+      await tester.binding.setSurfaceSize(const Size(1400, 900));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      final savedOnError = FlutterError.onError;
+      FlutterError.onError = (details) {
+        if (details.exceptionAsString().contains('overflowed')) return;
+        savedOnError?.call(details);
+      };
+      addTearDown(() => FlutterError.onError = savedOnError);
+
+      await tester.pumpWidget(
+        wrap(
+          Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => showRhythmTaskInspector(
+                context,
+                task: task,
+                workspaceMembers: const [],
+                onSaveDetails: onSave ?? (_) async {},
+              ),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Edit details'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+      'warning is visible in edit mode when dueDate is before scheduledDate',
+      (tester) async {
+        bool saved = false;
+        await openInspectorInEditMode(
+          tester,
+          makeTask(scheduledDate: '2026-06-10', dueDate: '2026-06-01'),
+          onSave: (_) async => saved = true,
+        );
+
+        expect(find.text(warningText), findsOneWidget,
+            reason: 'Warning must appear when due < scheduled');
+
+        // Save must still proceed without blocking.
+        await tester.tap(find.text('Save changes'));
+        await tester.pumpAndSettle();
+        expect(saved, isTrue,
+            reason: 'Save must proceed without confirmation dialog');
+      },
+    );
+
+    testWidgets(
+      'warning is hidden in edit mode when dueDate is after scheduledDate',
+      (tester) async {
+        await openInspectorInEditMode(
+          tester,
+          makeTask(scheduledDate: '2026-06-01', dueDate: '2026-06-10'),
+        );
+
+        expect(find.text(warningText), findsNothing,
+            reason: 'Warning must be hidden when due >= scheduled');
+      },
+    );
+
+    testWidgets(
+      'warning is hidden in edit mode when either date is null',
+      (tester) async {
+        await openInspectorInEditMode(
+          tester,
+          makeTask(scheduledDate: '2026-06-10', dueDate: null),
+        );
+
+        expect(find.text(warningText), findsNothing,
+            reason: 'Warning must be hidden when dueDate is null');
+      },
+    );
+
+    testWidgets(
+      'warning is not shown in view mode even with conflicting dates',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(1400, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final savedOnError = FlutterError.onError;
+        FlutterError.onError = (details) {
+          if (details.exceptionAsString().contains('overflowed')) return;
+          savedOnError?.call(details);
+        };
+        addTearDown(() => FlutterError.onError = savedOnError);
+
+        await tester.pumpWidget(
+          wrap(
+            Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => showRhythmTaskInspector(
+                  context,
+                  task: makeTask(
+                    scheduledDate: '2026-06-10',
+                    dueDate: '2026-06-01',
+                  ),
+                  workspaceMembers: const [],
+                  onSaveDetails: (_) async {},
+                ),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+        // Do NOT tap 'Edit details' — inspector stays in view mode.
+
+        expect(find.text(warningText), findsNothing,
+            reason: 'Warning must not appear in view mode');
+      },
+    );
+  });
+}

--- a/apps/desktop_flutter/test/controller_regressions_test.dart
+++ b/apps/desktop_flutter/test/controller_regressions_test.dart
@@ -214,6 +214,7 @@ DashboardSummary _buildSummary({
       tasks: DashboardSummaryTaskSlice(
         openCount: openCount,
         pastDueCount: 0,
+        pastDeadlineCount: 0,
         todayRemainingCount: 0,
         todayTotalCount: 0,
         thisWeekRemainingCount: thisWeekRemainingCount,
@@ -311,6 +312,7 @@ class _FakeDashboardHandoffDataSource extends _FakeDashboardDataSource {
       tasks: DashboardSummaryTaskSlice(
         openCount: 3,
         pastDueCount: 0,
+        pastDeadlineCount: 0,
         todayRemainingCount: 1,
         todayTotalCount: 1,
         thisWeekRemainingCount: 0,
@@ -361,6 +363,7 @@ class _FakeDashboardStableOrderingDataSource extends _FakeDashboardDataSource {
       tasks: DashboardSummaryTaskSlice(
         openCount: 2,
         pastDueCount: 0,
+        pastDeadlineCount: 0,
         todayRemainingCount: 2,
         todayTotalCount: 2,
         thisWeekRemainingCount: 0,

--- a/apps/desktop_flutter/test/date_formatters_test.dart
+++ b/apps/desktop_flutter/test/date_formatters_test.dart
@@ -1,0 +1,245 @@
+// ignore_for_file: deprecated_member_use
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rhythm_desktop/app/core/formatters/date_formatters.dart';
+
+void main() {
+  // Convenience: a fixed "today" so tests are deterministic.
+  final today = DateTime(2025, 6, 15);
+  final yesterday = '2025-06-14';
+  final todayStr = '2025-06-15';
+  final tomorrow = '2025-06-16';
+
+  // ---------------------------------------------------------------------------
+  // isOverdue
+  // ---------------------------------------------------------------------------
+  group('DateFormatters.isOverdue', () {
+    test('scheduled-only: past scheduled → overdue', () {
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: yesterday,
+          isDone: false,
+          today: today,
+        ),
+        isTrue,
+      );
+    });
+
+    test('scheduled-only: future scheduled → not overdue', () {
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: tomorrow,
+          isDone: false,
+          today: today,
+        ),
+        isFalse,
+      );
+    });
+
+    test('due-only: past due → overdue', () {
+      expect(
+        DateFormatters.isOverdue(
+          dueDate: yesterday,
+          isDone: false,
+          today: today,
+        ),
+        isTrue,
+      );
+    });
+
+    test('due-only: future due → not overdue', () {
+      expect(
+        DateFormatters.isOverdue(
+          dueDate: tomorrow,
+          isDone: false,
+          today: today,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+        'both set: scheduled takes priority — future scheduled + past due → not overdue (bug repro)',
+        () {
+      // A task whose dueDate is past but scheduledDate is in the future should
+      // NOT be considered overdue; the user scheduled it for a later date.
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: tomorrow,
+          dueDate: yesterday,
+          isDone: false,
+          today: today,
+        ),
+        isFalse,
+      );
+    });
+
+    test('both set: past scheduled + future due → overdue', () {
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: yesterday,
+          dueDate: tomorrow,
+          isDone: false,
+          today: today,
+        ),
+        isTrue,
+      );
+    });
+
+    test('both null → not overdue', () {
+      expect(
+        DateFormatters.isOverdue(isDone: false, today: today),
+        isFalse,
+      );
+    });
+
+    test('done status → never overdue even with past date', () {
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: yesterday,
+          dueDate: yesterday,
+          isDone: true,
+          today: today,
+        ),
+        isFalse,
+      );
+    });
+
+    test('today edge: date == today → not overdue (strict <)', () {
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: todayStr,
+          isDone: false,
+          today: today,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isPastDeadline
+  // ---------------------------------------------------------------------------
+  group('DateFormatters.isPastDeadline', () {
+    test('past dueDate → past deadline', () {
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: yesterday,
+          isDone: false,
+          today: today,
+        ),
+        isTrue,
+      );
+    });
+
+    test('future dueDate → not past deadline', () {
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: tomorrow,
+          isDone: false,
+          today: today,
+        ),
+        isFalse,
+      );
+    });
+
+    test('dueDate null → not past deadline', () {
+      expect(
+        DateFormatters.isPastDeadline(isDone: false, today: today),
+        isFalse,
+      );
+    });
+
+    test('done status → never past deadline even with past dueDate', () {
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: yesterday,
+          isDone: true,
+          today: today,
+        ),
+        isFalse,
+      );
+    });
+
+    test('today edge: dueDate == today → not past deadline (strict <)', () {
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: todayStr,
+          isDone: false,
+          today: today,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+        'scheduledDate is ignored — future scheduled + past due → past deadline',
+        () {
+      // isPastDeadline only cares about dueDate, never scheduledDate.
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: yesterday,
+          isDone: false,
+          today: today,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // priorityDate
+  // ---------------------------------------------------------------------------
+  group('DateFormatters.priorityDate', () {
+    test('returns scheduledDate when both set', () {
+      final result = DateFormatters.priorityDate(
+        scheduledDate: '2025-07-01',
+        dueDate: '2025-08-01',
+      );
+      expect(result, equals(DateTime(2025, 7, 1)));
+    });
+
+    test('returns dueDate when scheduledDate absent', () {
+      final result = DateFormatters.priorityDate(dueDate: '2025-08-01');
+      expect(result, equals(DateTime(2025, 8, 1)));
+    });
+
+    test('returns scheduledDate when dueDate absent', () {
+      final result = DateFormatters.priorityDate(scheduledDate: '2025-07-01');
+      expect(result, equals(DateTime(2025, 7, 1)));
+    });
+
+    test('returns null when both absent', () {
+      expect(DateFormatters.priorityDate(), isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isPastDue — deprecated alias
+  // ---------------------------------------------------------------------------
+  group('DateFormatters.isPastDue (deprecated alias)', () {
+    test('delegates to isOverdue: past scheduled → true', () {
+      expect(
+        DateFormatters.isPastDue(
+          dueDate: null,
+          scheduledDate: yesterday,
+          isDone: false,
+          today: today,
+        ),
+        isTrue,
+      );
+    });
+
+    test('delegates to isOverdue: done → false', () {
+      expect(
+        DateFormatters.isPastDue(
+          dueDate: yesterday,
+          scheduledDate: null,
+          isDone: true,
+          today: today,
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/apps/desktop_flutter/test/date_formatters_test.dart
+++ b/apps/desktop_flutter/test/date_formatters_test.dart
@@ -215,6 +215,215 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  // Canonical cross-stack date-status predicate matrix
+  //
+  // Anchor date: 2026-05-11 (today).
+  // Every row mirrors the identical matrix in
+  // apps/api_server/src/__tests__/task_date_status.test.ts so both stacks
+  // can be verified to agree bit-for-bit.
+  // ---------------------------------------------------------------------------
+  group('cross-stack matrix (anchor: 2026-05-11)', () {
+    final matrixToday = DateTime(2026, 5, 11);
+
+    test('case 1: done task, both dates in past → neither flag set', () {
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: '2026-04-01',
+          dueDate: '2026-04-01',
+          isDone: true,
+          today: matrixToday,
+        ),
+        isFalse,
+      );
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: '2026-04-01',
+          isDone: true,
+          today: matrixToday,
+        ),
+        isFalse,
+      );
+    });
+
+    test('case 2: open, no dates → neither flag set', () {
+      expect(
+        DateFormatters.isOverdue(isDone: false, today: matrixToday),
+        isFalse,
+      );
+      expect(
+        DateFormatters.isPastDeadline(isDone: false, today: matrixToday),
+        isFalse,
+      );
+    });
+
+    test('case 3: open, future scheduled, no due → neither flag set', () {
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: '2026-05-15',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isFalse,
+      );
+      // isPastDeadline ignores scheduledDate — no dueDate means not past deadline
+      expect(
+        DateFormatters.isPastDeadline(
+          isDone: false,
+          today: matrixToday,
+        ),
+        isFalse,
+      );
+    });
+
+    test('case 4: open, past scheduled, no due → overdue only', () {
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: '2026-05-05',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isTrue,
+      );
+      // isPastDeadline ignores scheduledDate — no dueDate means not past deadline
+      expect(
+        DateFormatters.isPastDeadline(
+          isDone: false,
+          today: matrixToday,
+        ),
+        isFalse,
+      );
+    });
+
+    test('case 5: open, no scheduled, future due → neither flag set', () {
+      expect(
+        DateFormatters.isOverdue(
+          dueDate: '2026-05-15',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isFalse,
+      );
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: '2026-05-15',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isFalse,
+      );
+    });
+
+    test('case 6: open, no scheduled, past due → both flags set', () {
+      expect(
+        DateFormatters.isOverdue(
+          dueDate: '2026-05-05',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isTrue,
+      );
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: '2026-05-05',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+        'case 7: scheduled future, deadline past → past-deadline only — the original reported bug',
+        () {
+      // scheduledDate wins for isOverdue (future → not overdue).
+      // isPastDeadline only checks dueDate (past → true).
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: '2026-05-15',
+          dueDate: '2026-05-05',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isFalse,
+      );
+      // isPastDeadline ignores scheduledDate — only dueDate matters (past → true)
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: '2026-05-05',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isTrue,
+      );
+    });
+
+    test('case 8: open, past scheduled, future due → overdue only', () {
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: '2026-05-05',
+          dueDate: '2026-05-15',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isTrue,
+      );
+      // isPastDeadline ignores scheduledDate — future dueDate means not past deadline
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: '2026-05-15',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isFalse,
+      );
+    });
+
+    test(
+        'case 9: open, both dates == today → neither flag set (today is not past)',
+        () {
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: '2026-05-11',
+          dueDate: '2026-05-11',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isFalse,
+      );
+      // isPastDeadline ignores scheduledDate — dueDate == today is not past
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: '2026-05-11',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isFalse,
+      );
+    });
+
+    test('case 10: open, both dates == yesterday → both flags set', () {
+      expect(
+        DateFormatters.isOverdue(
+          scheduledDate: '2026-05-10',
+          dueDate: '2026-05-10',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isTrue,
+      );
+      // isPastDeadline ignores scheduledDate — dueDate in past → true
+      expect(
+        DateFormatters.isPastDeadline(
+          dueDate: '2026-05-10',
+          isDone: false,
+          today: matrixToday,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // isPastDue — deprecated alias
   // ---------------------------------------------------------------------------
   group('DateFormatters.isPastDue (deprecated alias)', () {

--- a/apps/desktop_flutter/test/date_formatters_test.dart
+++ b/apps/desktop_flutter/test/date_formatters_test.dart
@@ -422,33 +422,4 @@ void main() {
       );
     });
   });
-
-  // ---------------------------------------------------------------------------
-  // isPastDue — deprecated alias
-  // ---------------------------------------------------------------------------
-  group('DateFormatters.isPastDue (deprecated alias)', () {
-    test('delegates to isOverdue: past scheduled → true', () {
-      expect(
-        DateFormatters.isPastDue(
-          dueDate: null,
-          scheduledDate: yesterday,
-          isDone: false,
-          today: today,
-        ),
-        isTrue,
-      );
-    });
-
-    test('delegates to isOverdue: done → false', () {
-      expect(
-        DateFormatters.isPastDue(
-          dueDate: yesterday,
-          scheduledDate: null,
-          isDone: true,
-          today: today,
-        ),
-        isFalse,
-      );
-    });
-  });
 }

--- a/apps/mcp_server/src/tools/__tests__/dashboard.test.ts
+++ b/apps/mcp_server/src/tools/__tests__/dashboard.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { registerDashboardTools } from '../dashboard.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: true;
+}>;
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  shape: Record<string, unknown>;
+  handler: ToolHandler;
+}
+
+function makeStubServer(): { server: unknown; tools: Map<string, RegisteredTool> } {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    tool(name: string, description: string, shape: Record<string, unknown>, handler: ToolHandler) {
+      tools.set(name, { name, description, shape, handler });
+    },
+  };
+  return { server, tools };
+}
+
+const API_URL = 'http://x';
+const API_TOKEN = 'tok';
+
+function makeFetchOk(body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  });
+}
+
+/** Build a minimal DashboardSummary fixture. */
+function makeSummary(overrides: Partial<{
+  tasks: unknown;
+  rhythms: unknown;
+  projects: unknown;
+  messages: unknown;
+}> = {}) {
+  return {
+    tasks: {
+      openCount: 3,
+      pastDueCount: 1,
+      pastDeadlineCount: 0,
+      todayRemainingCount: 1,
+      todayTotalCount: 1,
+      thisWeekRemainingCount: 2,
+      thisWeekTotalCount: 2,
+      unscheduledCount: 0,
+      recent: [],
+      pastDue: [],
+      today: [],
+      thisWeek: [],
+      unscheduled: [],
+      ...(typeof overrides.tasks === 'object' && overrides.tasks != null ? overrides.tasks : {}),
+    },
+    rhythms: { activeCount: 2, items: [] },
+    projects: { activeCount: 0, items: [] },
+    messages: { threadCount: 0, unreadPreviews: [] },
+    ...overrides,
+  };
+}
+
+describe('registerDashboardTools', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('rhythm_get_dashboard', () => {
+    it('(a) calls GET /dashboard/summary in a single round-trip', async () => {
+      const mockFetch = makeFetchOk(makeSummary());
+      vi.stubGlobal('fetch', mockFetch);
+
+      const { server, tools } = makeStubServer();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      registerDashboardTools(server as any, API_URL, API_TOKEN);
+
+      await tools.get('rhythm_get_dashboard')!.handler({});
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(`${API_URL}/dashboard/summary`);
+    });
+
+    it('(b) output JSON includes pastDeadlineCount', async () => {
+      const summary = makeSummary({ tasks: { pastDeadlineCount: 4 } });
+      vi.stubGlobal('fetch', makeFetchOk(summary));
+
+      const { server, tools } = makeStubServer();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      registerDashboardTools(server as any, API_URL, API_TOKEN);
+
+      const res = await tools.get('rhythm_get_dashboard')!.handler({});
+      const output = JSON.parse(res.content[0].text);
+      expect(output.pastDeadlineCount).toBe(4);
+    });
+
+    it(
+      '(c) a task with scheduledDate 5 days from now and dueDate 2 days ago appears in ' +
+      'tasksDueThisWeek (not tasksPastDue) and increments pastDeadlineCount',
+      async () => {
+        const now = new Date();
+        const in5Days = new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+        const minus2Days = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+
+        const task = {
+          id: 'task-1',
+          title: 'Deferred task',
+          scheduledDate: in5Days,
+          dueDate: minus2Days,
+          status: 'open',
+        };
+
+        const summary = makeSummary({
+          tasks: {
+            openCount: 1,
+            pastDueCount: 0,
+            // Backend determined this task misses its hard deadline but isn't "pastDue"
+            // because scheduledDate is in the future.
+            pastDeadlineCount: 1,
+            todayRemainingCount: 0,
+            todayTotalCount: 0,
+            thisWeekRemainingCount: 1,
+            thisWeekTotalCount: 1,
+            unscheduledCount: 0,
+            recent: [task],
+            pastDue: [],      // NOT in pastDue — scheduledDate is in the future
+            today: [],
+            thisWeek: [task], // IS in thisWeek — scheduledDate falls within 7 days
+            unscheduled: [],
+          },
+        });
+
+        vi.stubGlobal('fetch', makeFetchOk(summary));
+
+        const { server, tools } = makeStubServer();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registerDashboardTools(server as any, API_URL, API_TOKEN);
+
+        const res = await tools.get('rhythm_get_dashboard')!.handler({});
+        const output = JSON.parse(res.content[0].text);
+
+        // Must be in tasksDueThisWeek (scheduled-priority date window)
+        const thisWeekIds = (output.tasksDueThisWeek as Array<{ id: string }>).map((t) => t.id);
+        expect(thisWeekIds).toContain('task-1');
+
+        // Must NOT be in tasksPastDue
+        const pastDueIds = (output.tasksPastDue as Array<{ id: string }>).map((t) => t.id);
+        expect(pastDueIds).not.toContain('task-1');
+
+        // pastDeadlineCount must be 1
+        expect(output.pastDeadlineCount).toBe(1);
+
+        // operativeDate must reflect scheduledDate, not dueDate
+        const taskInWeek = (output.tasksDueThisWeek as Array<{ id: string; operativeDate: string }>)
+          .find((t) => t.id === 'task-1')!;
+        expect(taskInWeek.operativeDate).toBe(in5Days);
+      },
+    );
+
+    it('(d) tool description mentions both scheduledDate state and pastDeadlineCount', () => {
+      const { server, tools } = makeStubServer();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      registerDashboardTools(server as any, API_URL, API_TOKEN);
+
+      const tool = tools.get('rhythm_get_dashboard')!;
+      expect(tool.description.toLowerCase()).toContain('scheduleddate');
+      expect(tool.description.toLowerCase()).toContain('pastdeadlinecount');
+    });
+
+    it('(e) returns isError: true when backend returns 500', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'internal server error' }),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const { server, tools } = makeStubServer();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      registerDashboardTools(server as any, API_URL, API_TOKEN);
+
+      const res = await tools.get('rhythm_get_dashboard')!.handler({});
+      expect(res.isError).toBe(true);
+      expect(res.content[0].text).toContain('Rhythm API error 500');
+    });
+
+    it('(f) backward-compat: output JSON still includes openTaskCount and recentThreads', async () => {
+      const summary = makeSummary({
+        messages: {
+          threadCount: 2,
+          unreadPreviews: [
+            {
+              threadId: 7,
+              threadTitle: 'Team chat',
+              senderName: 'Alice',
+              preview: 'Hello',
+              updatedAt: '2025-01-01T10:00:00Z',
+              unreadCount: 3,
+            },
+          ],
+        },
+      });
+      vi.stubGlobal('fetch', makeFetchOk(summary));
+
+      const { server, tools } = makeStubServer();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      registerDashboardTools(server as any, API_URL, API_TOKEN);
+
+      const res = await tools.get('rhythm_get_dashboard')!.handler({});
+      const output = JSON.parse(res.content[0].text);
+
+      expect(output).toHaveProperty('openTaskCount');
+      expect(output).toHaveProperty('recentThreads');
+      expect((output.recentThreads as Array<{ id: number }>)[0].id).toBe(7);
+    });
+  });
+});

--- a/apps/mcp_server/src/tools/__tests__/tasks.test.ts
+++ b/apps/mcp_server/src/tools/__tests__/tasks.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { registerTaskTools } from '../tasks.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: true;
+}>;
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  shape: Record<string, unknown>;
+  handler: ToolHandler;
+}
+
+function makeStubServer(): { server: unknown; tools: Map<string, RegisteredTool> } {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    tool(name: string, description: string, shape: Record<string, unknown>, handler: ToolHandler) {
+      tools.set(name, { name, description, shape, handler });
+    },
+  };
+  return { server, tools };
+}
+
+const API_URL = 'http://x';
+const API_TOKEN = 'tok';
+
+function makeFetchOk(body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  });
+}
+
+describe('registerTaskTools — rhythm_list_tasks', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('(a) forwards scheduled_before as a query string param', async () => {
+    const mockFetch = makeFetchOk([]);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerTaskTools(server as any, API_URL, API_TOKEN);
+
+    await tools.get('rhythm_list_tasks')!.handler({ scheduled_before: '2025-05-15' });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('scheduled_before=2025-05-15');
+  });
+
+  it('(b) forwards overdue=true as a query string param when overdue is true', async () => {
+    const mockFetch = makeFetchOk([]);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerTaskTools(server as any, API_URL, API_TOKEN);
+
+    await tools.get('rhythm_list_tasks')!.handler({ overdue: true });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('overdue=true');
+  });
+
+  it('(c) forwards overdue=false explicitly when overdue is false', async () => {
+    const mockFetch = makeFetchOk([]);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerTaskTools(server as any, API_URL, API_TOKEN);
+
+    await tools.get('rhythm_list_tasks')!.handler({ overdue: false });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('overdue=false');
+  });
+
+  it('(d) omits overdue param when not provided', async () => {
+    const mockFetch = makeFetchOk([]);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerTaskTools(server as any, API_URL, API_TOKEN);
+
+    await tools.get('rhythm_list_tasks')!.handler({ status: 'open' });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).not.toContain('overdue');
+  });
+
+  it('(e) omits scheduled_before param when not provided', async () => {
+    const mockFetch = makeFetchOk([]);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerTaskTools(server as any, API_URL, API_TOKEN);
+
+    await tools.get('rhythm_list_tasks')!.handler({ status: 'open' });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).not.toContain('scheduled_before');
+  });
+
+  it('(f) still forwards existing due_before and search params alongside new params', async () => {
+    const mockFetch = makeFetchOk([]);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerTaskTools(server as any, API_URL, API_TOKEN);
+
+    await tools.get('rhythm_list_tasks')!.handler({
+      due_before: '2025-06-01',
+      scheduled_before: '2025-05-20',
+      overdue: true,
+      search: 'bulletin',
+    });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('due_before=2025-06-01');
+    expect(url).toContain('scheduled_before=2025-05-20');
+    expect(url).toContain('overdue=true');
+    expect(url).toContain('search=bulletin');
+  });
+
+  it('(g) returns isError: true on non-ok response', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'server error' }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerTaskTools(server as any, API_URL, API_TOKEN);
+
+    const res = await tools.get('rhythm_list_tasks')!.handler({});
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('Rhythm API error 500');
+  });
+});

--- a/apps/mcp_server/src/tools/dashboard.ts
+++ b/apps/mcp_server/src/tools/dashboard.ts
@@ -68,12 +68,15 @@ export function registerDashboardTools(server: McpServer, apiUrl: string, apiTok
     'rhythm_get_dashboard',
     'Get a summary snapshot of open tasks, active rhythms, active projects, and recent message threads. ' +
     'Task counts and lists are based on scheduledDate (when you plan to do the work); if scheduledDate is ' +
-    'absent, dueDate is used as the fallback. pastDeadlineCount surfaces tasks whose hard dueDate has ' +
-    'already passed independently of whether they are overdue by their scheduled date — useful for ' +
-    'distinguishing "I missed a deadline" from "I\'m behind on something I said I\'d do." ' +
-    'pastDeadlineTasks is an array of concise task summaries ({ id, title, dueDate, scheduledDate, sourceType }) ' +
-    'for every task counted in pastDeadlineCount, sorted by dueDate ascending (most-overdue deadline first). ' +
-    'Tasks already counted in pastDueCount are NOT included in pastDeadlineTasks (mutually exclusive). ' +
+    'absent, dueDate is used as the fallback. ' +
+    'Fields returned — task counts: ' +
+    'pastDueCount (tasks overdue by scheduledDate — the user is behind on planned work); ' +
+    'pastDeadlineCount (open tasks whose hard dueDate has passed even if scheduledDate has not — a deadline was missed); ' +
+    'todayRemainingCount, thisWeekRemainingCount, unscheduledCount. ' +
+    'pastDeadlineTasks: concise summaries ({ id, title, dueDate, scheduledDate, sourceType }) for every task in ' +
+    'pastDeadlineCount, sorted by dueDate ASC (most-overdue first), mutually exclusive with tasksPastDue. ' +
+    'Task list items include operativeDate = scheduledDate ?? dueDate for easy sorting. ' +
+    'Project on-deck steps include scheduledDate (when step is planned) and dueDate (step hard deadline). ' +
     'Useful for giving Claude context at the start of a session.',
     {},
     async () => {

--- a/apps/mcp_server/src/tools/dashboard.ts
+++ b/apps/mcp_server/src/tools/dashboard.ts
@@ -1,10 +1,19 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiGet, toolResult, toolError } from '../api_client.js';
 
+interface PastDeadlineTaskSummary {
+  id: string;
+  title: string;
+  dueDate: string | null;
+  scheduledDate: string | null;
+  sourceType: string | null;
+}
+
 interface DashboardTaskSummary {
   openCount: number;
   pastDueCount: number;
   pastDeadlineCount: number;
+  pastDeadlineTasks: PastDeadlineTaskSummary[];
   todayRemainingCount: number;
   todayTotalCount: number;
   thisWeekRemainingCount: number;
@@ -62,6 +71,9 @@ export function registerDashboardTools(server: McpServer, apiUrl: string, apiTok
     'absent, dueDate is used as the fallback. pastDeadlineCount surfaces tasks whose hard dueDate has ' +
     'already passed independently of whether they are overdue by their scheduled date — useful for ' +
     'distinguishing "I missed a deadline" from "I\'m behind on something I said I\'d do." ' +
+    'pastDeadlineTasks is an array of concise task summaries ({ id, title, dueDate, scheduledDate, sourceType }) ' +
+    'for every task counted in pastDeadlineCount, sorted by dueDate ascending (most-overdue deadline first). ' +
+    'Tasks already counted in pastDueCount are NOT included in pastDeadlineTasks (mutually exclusive). ' +
     'Useful for giving Claude context at the start of a session.',
     {},
     async () => {
@@ -88,6 +100,10 @@ export function registerDashboardTools(server: McpServer, apiUrl: string, apiTok
           // though their scheduledDate has not (i.e. the user intends to do it
           // later but a deadline was already missed).
           pastDeadlineCount: tasks.pastDeadlineCount,
+          // pastDeadlineTasks: concise summaries for every task in pastDeadlineCount,
+          // sorted by dueDate ASC (most-overdue deadline first). Mutually exclusive
+          // with tasksPastDue — a task appears in at most one of the two lists.
+          pastDeadlineTasks: tasks.pastDeadlineTasks ?? [],
           todayRemainingCount: tasks.todayRemainingCount,
           thisWeekRemainingCount: tasks.thisWeekRemainingCount,
           unscheduledCount: tasks.unscheduledCount,

--- a/apps/mcp_server/src/tools/dashboard.ts
+++ b/apps/mcp_server/src/tools/dashboard.ts
@@ -1,84 +1,119 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiGet, toolResult, toolError } from '../api_client.js';
 
-interface Task {
-  id: string;
-  title: string;
-  dueDate?: string | null;
-  status: string;
+interface DashboardTaskSummary {
+  openCount: number;
+  pastDueCount: number;
+  pastDeadlineCount: number;
+  todayRemainingCount: number;
+  todayTotalCount: number;
+  thisWeekRemainingCount: number;
+  thisWeekTotalCount: number;
+  unscheduledCount: number;
+  recent: Array<{ id: string; title: string; scheduledDate?: string | null; dueDate?: string | null }>;
+  pastDue: Array<{ id: string; title: string; scheduledDate?: string | null; dueDate?: string | null }>;
+  today: Array<{ id: string; title: string; scheduledDate?: string | null; dueDate?: string | null }>;
+  thisWeek: Array<{ id: string; title: string; scheduledDate?: string | null; dueDate?: string | null }>;
+  unscheduled: Array<{ id: string; title: string }>;
 }
 
-interface ProjectInstance {
-  id: string;
-  name: string;
-  anchorDate?: string;
-  steps?: Array<{ id: string; title: string; status: string; dueDate?: string | null }>;
+interface DashboardRhythmSummary {
+  activeCount: number;
+  items: Array<{ id: string; title: string; subtitle: string; completedCount: number; totalCount: number }>;
 }
 
-interface RecurringRule {
-  id: string;
-  enabled: boolean;
+interface DashboardProjectSummary {
+  activeCount: number;
+  items: Array<{
+    id: string;
+    title: string;
+    subtitle: string;
+    completedCount: number;
+    totalCount: number;
+    nextDueDate: string | null;
+    onDeckSteps: Array<{ id: string; title: string; status: string; dueDate: string | null }>;
+  }>;
 }
 
-interface MessageThread {
-  id: number;
-  title: string;
-  unreadCount?: number;
-  updatedAt?: string;
+interface DashboardMessageSummary {
+  threadCount: number;
+  unreadPreviews: Array<{
+    threadId: number;
+    threadTitle: string;
+    senderName: string;
+    preview: string;
+    updatedAt: string;
+    unreadCount: number;
+  }>;
+}
+
+interface DashboardSummary {
+  tasks: DashboardTaskSummary;
+  rhythms: DashboardRhythmSummary;
+  projects: DashboardProjectSummary;
+  messages: DashboardMessageSummary;
 }
 
 export function registerDashboardTools(server: McpServer, apiUrl: string, apiToken: string) {
   server.tool(
     'rhythm_get_dashboard',
-    'Get a summary snapshot of open tasks, active rhythms, active projects, and recent message threads. Useful for giving Claude context at the start of a session.',
+    'Get a summary snapshot of open tasks, active rhythms, active projects, and recent message threads. ' +
+    'Task counts and lists are based on scheduledDate (when you plan to do the work); if scheduledDate is ' +
+    'absent, dueDate is used as the fallback. pastDeadlineCount surfaces tasks whose hard dueDate has ' +
+    'already passed independently of whether they are overdue by their scheduled date — useful for ' +
+    'distinguishing "I missed a deadline" from "I\'m behind on something I said I\'d do." ' +
+    'Useful for giving Claude context at the start of a session.',
     {},
     async () => {
       try {
-        const [tasks, rhythms, instances, threads] = await Promise.all([
-          apiGet<Task[]>(apiUrl, apiToken, '/tasks?status=open'),
-          apiGet<RecurringRule[]>(apiUrl, apiToken, '/recurring-rules'),
-          apiGet<ProjectInstance[]>(apiUrl, apiToken, '/project-instances?status=active'),
-          apiGet<MessageThread[]>(apiUrl, apiToken, '/message-threads'),
-        ]);
+        const summary = await apiGet<DashboardSummary>(apiUrl, apiToken, '/dashboard/summary');
 
-        // Tasks due within the next 7 days
-        const now = new Date();
-        const in7Days = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
-        const tasksDueThisWeek = tasks
-          .filter((t) => t.dueDate && new Date(t.dueDate) <= in7Days)
-          .slice(0, 10)
-          .map((t) => ({ id: t.id, title: t.title, dueDate: t.dueDate }));
+        const { tasks, rhythms, projects, messages } = summary;
 
-        // Active rhythms count
-        const activeRhythmCount = rhythms.filter((r) => r.enabled).length;
-
-        // Active projects with next open step
-        const activeProjects = instances.map((inst) => {
-          const nextStep = (inst.steps ?? []).find((s) => s.status === 'open');
-          return {
-            id: inst.id,
-            name: inst.name,
-            anchorDate: inst.anchorDate,
-            nextStep: nextStep ? { id: nextStep.id, title: nextStep.title, dueDate: nextStep.dueDate } : null,
-          };
+        // Build a compact representation for the briefing consumer.
+        // We surface scheduledDate ?? dueDate as the operative date for each task list item.
+        const mapTaskItem = (t: { id: string; title: string; scheduledDate?: string | null; dueDate?: string | null }) => ({
+          id: t.id,
+          title: t.title,
+          scheduledDate: t.scheduledDate ?? null,
+          dueDate: t.dueDate ?? null,
+          operativeDate: t.scheduledDate ?? t.dueDate ?? null,
         });
 
-        // Most recent 5 threads
-        const recentThreads = [...threads]
-          .sort((a, b) => {
-            const da = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
-            const db = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
-            return db - da;
-          })
-          .slice(0, 5)
-          .map((t) => ({ id: t.id, title: t.title, unreadCount: t.unreadCount ?? 0, lastActivity: t.updatedAt }));
-
         const dashboard = {
-          openTaskCount: tasks.length,
-          tasksDueThisWeek,
-          activeRhythmCount,
-          activeProjects,
-          recentThreads,
+          // ── Tasks ───────────────────────────────────────────────────────────
+          openTaskCount: tasks.openCount,
+          pastDueCount: tasks.pastDueCount,
+          // pastDeadlineCount: open tasks whose hard dueDate has passed even
+          // though their scheduledDate has not (i.e. the user intends to do it
+          // later but a deadline was already missed).
+          pastDeadlineCount: tasks.pastDeadlineCount,
+          todayRemainingCount: tasks.todayRemainingCount,
+          thisWeekRemainingCount: tasks.thisWeekRemainingCount,
+          unscheduledCount: tasks.unscheduledCount,
+          // tasksDueThisWeek kept for backward-compat with existing consumers;
+          // populated from thisWeek (scheduled-priority date, not raw dueDate).
+          tasksDueThisWeek: (tasks.thisWeek ?? []).slice(0, 10).map(mapTaskItem),
+          tasksPastDue: (tasks.pastDue ?? []).slice(0, 10).map(mapTaskItem),
+          tasksToday: (tasks.today ?? []).slice(0, 10).map(mapTaskItem),
+          // ── Rhythms ─────────────────────────────────────────────────────────
+          activeRhythmCount: rhythms.activeCount,
+          rhythms: rhythms.items,
+          // ── Projects ────────────────────────────────────────────────────────
+          activeProjects: projects.items.map((p) => ({
+            id: p.id,
+            name: p.title,
+            subtitle: p.subtitle,
+            nextDueDate: p.nextDueDate,
+            onDeckSteps: p.onDeckSteps,
+          })),
+          // ── Messages ────────────────────────────────────────────────────────
+          recentThreads: messages.unreadPreviews.map((u) => ({
+            id: u.threadId,
+            title: u.threadTitle,
+            unreadCount: u.unreadCount,
+            lastActivity: u.updatedAt,
+          })),
         };
 
         return toolResult(JSON.stringify(dashboard, null, 2));

--- a/apps/mcp_server/src/tools/projects.ts
+++ b/apps/mcp_server/src/tools/projects.ts
@@ -5,7 +5,10 @@ import { registerTool } from './_tool.js';
 
 export function registerProjectTools(server: McpServer, apiUrl: string, apiToken: string) {
   registerTool(server, 'rhythm_list_project_templates',
-    'List all project templates, including their steps.',
+    'List all project templates, including their steps. ' +
+    'Fields returned per step: id, title, offsetDays, offsetDescription, sortOrder. ' +
+    'Steps do not carry date fields at the template level — dates are computed when a template is instantiated ' +
+    'from anchorDate + offsetDays.',
     {},
     async () => {
       try {
@@ -61,7 +64,10 @@ export function registerProjectTools(server: McpServer, apiUrl: string, apiToken
   );
 
   registerTool(server, 'rhythm_create_project_instance',
-    'Instantiate a template as an active project with an anchor date.',
+    'Instantiate a template as an active project with an anchor date. ' +
+    'Each step in the returned instance includes: ' +
+    'scheduledDate (when the step is planned to be done; anchorDate + offsetDays; drives overdue state) and ' +
+    'dueDate (hard external deadline for the step; drives past-deadline state).',
     {
       template_id: z.string().describe('Project template ID to instantiate.'),
       anchor_date: z.string().describe('Key event date in YYYY-MM-DD format.'),
@@ -82,7 +88,10 @@ export function registerProjectTools(server: McpServer, apiUrl: string, apiToken
   );
 
   registerTool(server, 'rhythm_list_project_instances',
-    "List active projects with step progress. Defaults to active projects.",
+    'List active projects with step progress. Defaults to active projects. ' +
+    'Fields returned per step: id, title, status, notes, ' +
+    'scheduledDate (when the step is planned to be done; drives overdue state), ' +
+    'dueDate (hard external deadline for the step; drives past-deadline state).',
     {
       status: z.enum(['active', 'completed', 'all']).optional().describe("Filter by status. Defaults to 'active'."),
     },
@@ -98,7 +107,10 @@ export function registerProjectTools(server: McpServer, apiUrl: string, apiToken
   );
 
   registerTool(server, 'rhythm_update_project_step',
-    'Mark a project step as done or update its notes.',
+    'Mark a project step as done or update its notes. ' +
+    'Fields returned: id, title, status, notes, ' +
+    'scheduledDate (when the step is planned to be done; drives overdue state), ' +
+    'dueDate (hard external deadline for the step; drives past-deadline state).',
     {
       instance_id: z.string().describe('Project instance ID.'),
       step_id: z.string().describe('Step ID within the instance.'),

--- a/apps/mcp_server/src/tools/tasks.ts
+++ b/apps/mcp_server/src/tools/tasks.ts
@@ -6,6 +6,10 @@ import { registerTool } from './_tool.js';
 export function registerTaskTools(server: McpServer, apiUrl: string, apiToken: string) {
   registerTool(server, 'rhythm_list_tasks',
     'List tasks with optional filters. Returns open tasks by default. ' +
+    'Each task has two date fields with different semantics: scheduledDate is the intended work date — ' +
+    'when the task should be started or completed in normal workflow; dueDate is the hard external deadline — ' +
+    'a commitment to someone else or a fixed event. Use scheduled_before to answer "what should I be working ' +
+    'on by date X"; use due_before only when you specifically need hard-deadline filtering. ' +
     'Results are sorted in the following canonical order: ' +
     '(1) overdue open tasks first (status != done AND COALESCE(scheduledDate, dueDate) < today), ' +
     '(2) then by COALESCE(scheduledDate, dueDate) ascending with NULLs last, ' +
@@ -14,14 +18,18 @@ export function registerTaskTools(server: McpServer, apiUrl: string, apiToken: s
     'This surfaces already-broken items before the day\'s upcoming work.',
     {
       status: z.enum(['open', 'done', 'all']).optional().describe("Filter by status. Defaults to 'open'."),
-      due_before: z.string().optional().describe('Return tasks due on or before this ISO 8601 date (YYYY-MM-DD).'),
+      due_before: z.string().optional().describe('Return tasks where the HARD DEADLINE (dueDate) is on or before this YYYY-MM-DD date. Use only when you specifically need deadline-based filtering. For "what is due to be done by date X", use scheduled_before instead.'),
+      scheduled_before: z.string().optional().describe('Return tasks where scheduledDate (or dueDate as fallback if no scheduledDate) is on or before this YYYY-MM-DD date. This is usually what you want — it answers "what should I be working on by date X".'),
+      overdue: z.boolean().optional().describe('When true, returns only tasks that are overdue: status is not done AND scheduled date has passed.'),
       search: z.string().optional().describe('Case-insensitive substring match against task title.'),
     },
-    async ({ status = 'open', due_before, search }: { status?: string; due_before?: string; search?: string }) => {
+    async ({ status = 'open', due_before, scheduled_before, overdue, search }: { status?: string; due_before?: string; scheduled_before?: string; overdue?: boolean; search?: string }) => {
       try {
         const params = new URLSearchParams();
         if (status !== 'all') params.set('status', status);
         if (due_before) params.set('due_before', due_before);
+        if (scheduled_before) params.set('scheduled_before', scheduled_before);
+        if (overdue !== undefined) params.set('overdue', overdue ? 'true' : 'false');
         if (search) params.set('search', search);
         const qs = params.toString();
         const tasks = await apiGet<unknown[]>(apiUrl, apiToken, `/tasks${qs ? `?${qs}` : ''}`);

--- a/apps/mcp_server/src/tools/tasks.ts
+++ b/apps/mcp_server/src/tools/tasks.ts
@@ -15,7 +15,11 @@ export function registerTaskTools(server: McpServer, apiUrl: string, apiToken: s
     '(2) then by COALESCE(scheduledDate, dueDate) ascending with NULLs last, ' +
     '(3) then by scheduledOrder ascending with NULLs last, ' +
     '(4) then by createdAt ascending. ' +
-    'This surfaces already-broken items before the day\'s upcoming work.',
+    'This surfaces already-broken items before the day\'s upcoming work. ' +
+    'Fields returned per task: id, title, status, notes, ' +
+    'scheduledDate (when the user plans to do it; drives overdue state), ' +
+    'dueDate (hard external deadline; drives past-deadline state), ' +
+    'createdAt, updatedAt.',
     {
       status: z.enum(['open', 'done', 'all']).optional().describe("Filter by status. Defaults to 'open'."),
       due_before: z.string().optional().describe('Return tasks where the HARD DEADLINE (dueDate) is on or before this YYYY-MM-DD date. Use only when you specifically need deadline-based filtering. For "what is due to be done by date X", use scheduled_before instead.'),
@@ -41,7 +45,11 @@ export function registerTaskTools(server: McpServer, apiUrl: string, apiToken: s
   );
 
   registerTool(server, 'rhythm_create_task',
-    'Create a new task.',
+    'Create a new task. ' +
+    'Fields returned: id, title, status, notes, ' +
+    'scheduledDate (when the user plans to do it; drives overdue state), ' +
+    'dueDate (hard external deadline; drives past-deadline state), ' +
+    'createdAt, updatedAt.',
     {
       title: z.string().describe('Task title.'),
       notes: z.string().optional().describe('Optional notes or description.'),
@@ -62,7 +70,11 @@ export function registerTaskTools(server: McpServer, apiUrl: string, apiToken: s
   );
 
   registerTool(server, 'rhythm_update_task',
-    'Update one or more fields of an existing task.',
+    'Update one or more fields of an existing task. ' +
+    'Fields returned: id, title, status, notes, ' +
+    'scheduledDate (when the user plans to do it; drives overdue state), ' +
+    'dueDate (hard external deadline; drives past-deadline state), ' +
+    'createdAt, updatedAt.',
     {
       id: z.string().describe('Task ID.'),
       title: z.string().optional().describe('New title.'),
@@ -89,7 +101,9 @@ export function registerTaskTools(server: McpServer, apiUrl: string, apiToken: s
   );
 
   registerTool(server, 'rhythm_complete_task',
-    'Mark a task as done.',
+    'Mark a task as done. Returns a confirmation string with the task title. ' +
+    'Date fields on the task: scheduledDate (when the user planned to do it; drives overdue state), ' +
+    'dueDate (hard external deadline; drives past-deadline state).',
     {
       id: z.string().describe('Task ID to mark as done.'),
     },

--- a/apps/mcp_server/src/tools/tasks.ts
+++ b/apps/mcp_server/src/tools/tasks.ts
@@ -5,7 +5,13 @@ import { registerTool } from './_tool.js';
 
 export function registerTaskTools(server: McpServer, apiUrl: string, apiToken: string) {
   registerTool(server, 'rhythm_list_tasks',
-    'List tasks with optional filters. Returns open tasks by default.',
+    'List tasks with optional filters. Returns open tasks by default. ' +
+    'Results are sorted in the following canonical order: ' +
+    '(1) overdue open tasks first (status != done AND COALESCE(scheduledDate, dueDate) < today), ' +
+    '(2) then by COALESCE(scheduledDate, dueDate) ascending with NULLs last, ' +
+    '(3) then by scheduledOrder ascending with NULLs last, ' +
+    '(4) then by createdAt ascending. ' +
+    'This surfaces already-broken items before the day\'s upcoming work.',
     {
       status: z.enum(['open', 'done', 'all']).optional().describe("Filter by status. Defaults to 'open'."),
       due_before: z.string().optional().describe('Return tasks due on or before this ISO 8601 date (YYYY-MM-DD).'),


### PR DESCRIPTION
## Summary

- Adds `scheduledDate` as the primary operative date across the full stack (Node API, MCP tools, Flutter UI), with `dueDate` reserved for hard external deadlines
- Introduces `pastDeadlineCount`/`pastDeadlineTasks` in the dashboard summary and amber visual state for tasks whose deadline has passed but scheduled date has not
- Removes `isPastDue` alias and all date-heuristic dead code

## Issues implemented

- #519 — Add `scheduled_date` column to project_instance_steps
- #521 — Shared Node date-status helper (isOverdue / isPastDeadline)
- #522 — Shared Dart date-status helper
- #539 — user.timezone column threaded into date helpers
- #520 — Backfill scheduled_date from due_date (one-time migration)
- #523 — Query-param filters on GET /tasks
- #525 — SQL-backed findByFilterAsync on tasks repository
- #542 — Canonical overdue-first sort order for findByFilterAsync
- #524 — pastDeadlineCount in dashboard summary
- #538 — Calendar shadow events use scheduledDate only
- #526 — MCP rhythm_get_dashboard uses scheduledDate priority + pastDeadlineCount
- #527 — MCP rhythm_list_tasks extended with scheduled_before/overdue params
- #540 — pastDeadlineTasks array in MCP dashboard
- #528 — MCP tool descriptions document scheduledDate vs dueDate semantics
- #529 — Flutter quick-add bar writes to scheduledDate
- #530 — Flutter inspector shows two explicit date fields
- #541 — Flutter inspector soft warning when dueDate < scheduledDate
- #531 — Flutter task list row shows scheduled-priority date
- #532 — Flutter dashboard row shows scheduled-priority date
- #533 — Flutter past-deadline visual state (amber)
- #534 — Flutter color legend entry for Past deadline
- #535 — Cross-stack date-status predicate matrix tests
- #536 — Cleanup: remove isPastDue alias and date heuristic dead code

## Test plan

- [ ] API server: 384 tests pass (npm test in apps/api_server)
- [ ] Flutter: 180 tests pass (flutter test in apps/desktop_flutter)
- [ ] Flutter analyze clean (flutter analyze --no-fatal-infos)
- [ ] Run app locally: quick-add sets scheduledDate, inspector shows two date fields, amber state for past-deadline tasks, overdue tasks remain red
- [ ] Restart server against existing DB: verify backfill migration runs once and logs row counts

Generated with Claude Code