### PR TITLE
ci: add npm publish workflow for rhythm-mcp-server

### DIFF
--- a/.github/workflows/mcp_server_publish.yml
+++ b/.github/workflows/mcp_server_publish.yml
@@ -1,0 +1,45 @@
+name: MCP Server Publish
+
+on:
+  push:
+    tags:
+      - 'mcp-server-v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mcp_server
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: apps/mcp_server/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#mcp-server-v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/mcp_server_publish.yml` that publishes `@ajhochy/rhythm-mcp-server` to npm when a tag matching `mcp-server-v*` is pushed.
- Verifies the tag version matches `apps/mcp_server/package.json` before publishing, to prevent mismatched releases.

## Why
Past MCP server publishes were manual `npm publish` runs. After landing this workflow, releases become: bump `package.json` → merge → tag `mcp-server-vX.Y.Z` → push tag → CI publishes.

## Prereqs before first use
- Add `NPM_TOKEN` repo secret (npm automation token with publish access for `@ajhochy/rhythm-mcp-server`).

## Test plan
- [ ] After merge, add `NPM_TOKEN` secret
- [ ] Bump package.json to 0.5.0 (separate PR), merge, tag `mcp-server-v0.5.0`, push tag
- [ ] Confirm workflow runs, version check passes, package is live on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)