### PR TITLE
feat(mcp): bump rhythm-mcp-server 0.4.0 → 0.5.0

### DIFF
--- a/apps/mcp_server/package-lock.json
+++ b/apps/mcp_server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ajhochy/rhythm-mcp-server",
-  "version": "0.2.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ajhochy/rhythm-mcp-server",
-      "version": "0.2.0",
+      "version": "0.5.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
         "zod": "^3.22.0"

--- a/apps/mcp_server/package.json
+++ b/apps/mcp_server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ajhochy/rhythm-mcp-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "MCP server for Rhythm — manage tasks, projects, and rhythms via Claude",
   "type": "commonjs",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps `@ajhochy/rhythm-mcp-server` from 0.4.0 → 0.5.0
- Picks up `rhythm_notify` tool (commit 9cf0fff), which was added after the previous 0.4.0 bump and is therefore missing from the currently-published 0.4.0 package on npm

## Release flow (after merge)
1. After PR #547 is merged and `NPM_TOKEN` secret is set
2. ```bash
   git tag mcp-server-v0.5.0
   git push origin mcp-server-v0.5.0
   ```
3. CI publishes to npm. MCP clients using `@latest` (e.g. local `~/.claude/settings.json`) pick it up on next launch (may need `rm -rf ~/.npm/_npx` to bust the npx cache).

## Test plan
- [ ] CI green on this PR
- [ ] Merge after #547
- [ ] Tag and push `mcp-server-v0.5.0`
- [ ] Confirm publish workflow runs and `npm view @ajhochy/rhythm-mcp-server version` returns 0.5.0
- [ ] Confirm `rhythm_notify` tool appears in MCP client tool list after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)