### PR TITLE
API Notification Bug

### DIFF
--- a/.clideck-workflow/smoketests/api-notification-bug-rvayd3/smoketest-result.json
+++ b/.clideck-workflow/smoketests/api-notification-bug-rvayd3/smoketest-result.json
@@ -1,0 +1,7 @@
+{
+  "smoketestResult": {
+    "status": "passed",
+    "failures": []
+  },
+  "updatedAt": "2026-05-12T17:39:05.832Z"
+}

--- a/.clideck-workflow/smoketests/api-notification-bug-rvayd3/smoketest.md
+++ b/.clideck-workflow/smoketests/api-notification-bug-rvayd3/smoketest.md
@@ -1,0 +1,28 @@
+# Smoke Test: API Notification Bug
+
+Baseline: `state.plan` and `state.plan.coherenceRules`.
+
+Evidence source: diff from base `59f5fec6e2778ef833451ff1cecfd3b03417a394` to `HEAD` on `/Users/ajhochhalter/Documents/wt-api-notification-bug-rvayd3-553`.
+
+- [x] ✅ Diff scope is limited to `apps/api_server/src/app.ts` and `apps/api_server/src/__tests__/notifications_agent_local_bypass.test.ts`.
+  - Evidence: `git diff --name-only 59f5fec6e2778ef833451ff1cecfd3b03417a394...HEAD` returned only those two files.
+- [x] ✅ `apps/api_server/src/app.ts` only reorders the two notification route mounts so `app.use('/notifications/agent', notificationsAgentRouter)` is registered before `app.use('/notifications', notificationsRouter)`.
+  - Evidence: `git diff --numstat ... -- apps/api_server/src/app.ts` returned `1 1`; the diff only moves `/notifications/agent` above `/notifications`. Current `app.ts` lines 67-68 register agent first, generic second.
+- [x] ✅ Generic notification auth remains unchanged: `notificationsRouter` still applies `requireAuth`, and `notifications_agent_routes.ts` AGENT_LOCAL bypass logic is not modified.
+  - Evidence: `git diff --quiet ... -- notifications_routes.ts notifications_agent_routes.ts` exited `0`; source inspection shows `notificationsRouter.use(requireAuth)` and unchanged `if (!env.agentLocal) notificationsAgentRouter.use(requireAuth)`.
+- [x] ✅ New bypass test uses the required module-load pattern: sets `process.env.AGENT_LOCAL = 'true'` before dynamically importing `createApp`, calls `vi.resetModules()`, uses in-memory SQLite with migrations and `setDb`, and mocks `ws_gateway`.
+  - Evidence: test lines include `vi.mock('../services/ws_gateway')`, `process.env.AGENT_LOCAL = 'true'`, `vi.resetModules()`, dynamic imports for migrations/db/app, `new Database(':memory:')`, `runMigrations(db)`, and `setDb(db)`.
+- [x] ✅ New bypass test proves planned runtime behavior: unauthenticated `POST /notifications/agent` with `AGENT_LOCAL=true` returns `201` with a positive `id`, and invalid payload still returns `400`.
+  - Evidence: test name explicitly says no Authorization header with `AGENT_LOCAL=true`; request headers only include `Content-Type`; assertions include `res.status` `201`, `data.id` greater than `0`, and invalid-payload `res.status` `400`.
+- [x] ✅ Existing notification-agent auth tests still pass, proving the normal unauthenticated path still returns `401` when `AGENT_LOCAL` is not enabled.
+  - Evidence: `cd apps/api_server && npx vitest run src/__tests__/notifications_agent_local_bypass.test.ts src/__tests__/notifications_agent.test.ts src/__tests__/notifications.test.ts` exited `0`; 3 files and 21 tests passed, including `notifications_agent.test.ts`.
+- [x] ✅ Existing generic notification tests still pass, proving `/notifications`, `/notifications/read-all`, and `/notifications/:id/read` remain authenticated and unchanged.
+  - Evidence: same focused vitest command exited `0`; 3 files and 21 tests passed, including `notifications.test.ts`.
+- [x] ✅ TypeScript verification passes for `apps/api_server`.
+  - Evidence: `cd apps/api_server && npx tsc --noEmit` exited `0`.
+
+## Results
+
+Passed. The implementation matches the planned route-order fix, adds the planned AGENT_LOCAL local-bypass regression test, preserves generic notification auth behavior, and passes focused API server verification.
+
+Note: the first vitest attempt was blocked by a local `better-sqlite3` Node ABI mismatch (`NODE_MODULE_VERSION 137` vs required `127`). Running `npm rebuild better-sqlite3` in the worktree fixed the local native dependency; the rerun passed.

--- a/apps/api_server/src/__tests__/notifications_agent_local_bypass.test.ts
+++ b/apps/api_server/src/__tests__/notifications_agent_local_bypass.test.ts
@@ -1,0 +1,68 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { AddressInfo } from 'node:net';
+import Database from 'better-sqlite3';
+
+vi.mock('../services/ws_gateway', () => ({
+  broadcast: vi.fn(),
+  attachWsGateway: vi.fn(),
+}));
+
+describe('POST /notifications/agent — AGENT_LOCAL bypass', () => {
+  let baseUrl: string;
+  let closeServer: () => Promise<void>;
+  let prevAgentLocal: string | undefined;
+
+  beforeEach(async () => {
+    prevAgentLocal = process.env.AGENT_LOCAL;
+    process.env.AGENT_LOCAL = 'true';
+
+    vi.resetModules();
+
+    const { runMigrations } = await import('../database/migrations');
+    const { setDb } = await import('../database/db');
+    const { createApp } = await import('../app');
+
+    const db = new Database(':memory:');
+    db.pragma('foreign_keys = ON');
+    runMigrations(db);
+    setDb(db);
+
+    const server = createApp().listen(0);
+    await new Promise<void>((r) => server.once('listening', () => r()));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    closeServer = () =>
+      new Promise<void>((res, rej) =>
+        server.close((e) => (e ? rej(e) : res())),
+      );
+  });
+
+  afterEach(async () => {
+    if (prevAgentLocal === undefined) {
+      delete process.env.AGENT_LOCAL;
+    } else {
+      process.env.AGENT_LOCAL = prevAgentLocal;
+    }
+    await closeServer();
+    vi.clearAllMocks();
+  });
+
+  it('returns 201 for POST /notifications/agent with no Authorization header when AGENT_LOCAL=true', async () => {
+    const res = await fetch(`${baseUrl}/notifications/agent`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Smoke', body: 'No auth header' }),
+    });
+    expect(res.status).toBe(201);
+    const data = (await res.json()) as { id: number };
+    expect(data.id).toBeGreaterThan(0);
+  });
+
+  it('still validates payload when AGENT_LOCAL=true', async () => {
+    const res = await fetch(`${baseUrl}/notifications/agent`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ body: 'missing title' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api_server/src/app.ts
+++ b/apps/api_server/src/app.ts
@@ -64,11 +64,11 @@ export function createApp() {
   app.use('/message-threads', messagesRouter);
   app.use('/facilities', facilitiesRouter);
   app.use('/workspaces', workspaceRouter);
+  app.use('/notifications/agent', notificationsAgentRouter);
   app.use('/notifications', notificationsRouter);
   app.use('/claude-triggers', claudeTriggersRouter);
   app.use('/agent-configs', agentConfigsRouter);
   app.use('/agent-sessions', agentSessionsRouter);
-  app.use('/notifications/agent', notificationsAgentRouter);
 
   app.use(errorHandler);
 


### PR DESCRIPTION
# API Notification Bug

## What you asked for
Here's a self-contained prompt you can paste:

---

Fix a route registration order bug in the api_server that causes `rhythm_notify` MCP calls to always fail.

**Root cause:** In `apps/api_server/src/app.ts`, `notificationsRouter` is mounted at `/notifications` (line 67) before `notificationsAgentRouter` is mounted at `/notifications/agent` (line 71). Express prefix-matches `/notifications` first, so any request to `/notifications/agent` hits `notificationsRouter`, which applies `requireAuth` to all routes (line 8 of `notifications_routes.ts`). The MCP tool sends no auth header — it relies on the `AGENT_LOCAL=true` bypass in `notificationsAgentRouter` — so `requireAuth` rejects the request and the intended route is never reached.

**The fix:** In `apps/api_server/src/app.ts`, move the `notificationsAgentRouter` mount above the `notificationsRouter` mount so the more-specific path is matched first.

**Files involved:**
- `apps/api_server/src/app.ts` — one-line reorder (move line 71 above line 67)
- No other files need to change

**Workflow:** Run this through the dev-planner skill, then the issue-pipeline skill, then write a smoke test that POSTs to `http://localhost:4001/notifications/agent` without an Authorization header and asserts a 201 response (verifying the auth bypass works when `AGENT_LOCAL=true`). Follow the Git/PR workflow from CLAUDE.md — feature branch, PR open, do not merge.

## What was built
- Reorder route mounts so /notifications/agent is matched before /notifications
- Add a vitest case asserting AGENT_LOCAL=true allows unauthenticated POST /notifications/agent to return 201

## Manual setup needed
- **Set AGENT_LOCAL=true in the API server environment**
  - Open apps/api_server/.env (or your production environment config / systemd service file).
  - Add or confirm the line: AGENT_LOCAL=true
  - Restart the API server so the new env var takes effect.
  - Verify: POST http://localhost:4001/notifications/agent with Content-Type: application/json and body {"title":"Test","body":"Test"} (no Authorization header) should return HTTP 201.

## What we verified
All smoketest items passed.
