### PR TITLE
Fix: Update Ready button now triggers direct DMG download

### DIFF
--- a/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
+++ b/apps/desktop_flutter/lib/app/core/layout/app_shell.dart
@@ -417,30 +417,42 @@ class _TopRightAccountClusterState extends State<_TopRightAccountCluster> {
         if (hasUpdate)
           Container(
             margin: const EdgeInsets.only(right: 10),
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-            decoration: BoxDecoration(
+            child: Material(
               color: context.rhythm.surfaceRaised,
               borderRadius: BorderRadius.circular(999),
-              border: Border.all(color: context.rhythm.borderSubtle),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  Icons.system_update_alt,
-                  size: 14,
-                  color: context.rhythm.accent,
-                ),
-                const SizedBox(width: 6),
-                Text(
-                  'Update ready',
-                  style: TextStyle(
-                    color: context.rhythm.textPrimary,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
+              child: InkWell(
+                onTap: widget.updateController.openDownload,
+                borderRadius: BorderRadius.circular(999),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 6,
+                  ),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(999),
+                    border: Border.all(color: context.rhythm.borderSubtle),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.system_update_alt,
+                        size: 14,
+                        color: context.rhythm.accent,
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        'Update ready',
+                        style: TextStyle(
+                          color: context.rhythm.textPrimary,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-              ],
+              ),
             ),
           ),
         // Bell icon with unread badge


### PR DESCRIPTION
## Summary
- The \"Update ready\" pill in the top nav bar was a plain `Container` with no tap handler — purely decorative
- Wrapped it in `Material` + `InkWell` (same pattern as the bell icon) wired to `UpdateController.openDownload()`
- Tapping now opens the latest release `.dmg` directly via `launchUrl`, falling back to `.zip` or the GitHub release page if no DMG asset exists

## Test plan
- [ ] Confirm \"Update ready\" pill is visible when a newer GitHub release exists
- [ ] Tap the pill — browser/Finder should open the DMG download link
- [ ] Confirm the pill shows a hover/ripple effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)