### PR TITLE
fix: add missing scheduled_date migration to project_instance_steps

### DIFF
--- a/apps/api_server/src/database/postgres_bootstrap.ts
+++ b/apps/api_server/src/database/postgres_bootstrap.ts
@@ -408,6 +408,9 @@ export async function runPostgresBootstrap(pool: Pool): Promise<void> {
   // Phase 8: step assignees + rhythm collaborators
   await pool.query(`ALTER TABLE project_template_steps ADD COLUMN IF NOT EXISTS assignee_id INTEGER REFERENCES users(id) ON DELETE SET NULL`);
   await pool.query(`ALTER TABLE project_instance_steps ADD COLUMN IF NOT EXISTS assignee_id INTEGER REFERENCES users(id) ON DELETE SET NULL`);
+
+  // scheduledDate on project_instance_steps (added with issue #519)
+  await pool.query(`ALTER TABLE project_instance_steps ADD COLUMN IF NOT EXISTS scheduled_date TEXT`);
   await pool.query(`
     CREATE TABLE IF NOT EXISTS rhythm_collaborators (
       rhythm_id TEXT NOT NULL REFERENCES recurring_task_rules(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary
- The `UPDATE project_instance_steps` query was updated in #519 to include `scheduled_date`, but the idempotent Postgres bootstrap was never updated to `ADD COLUMN IF NOT EXISTS scheduled_date`
- This caused **every PATCH /project-instances/steps/:stepId request to fail with a 500**, making it impossible to mark project steps as done from the Rhythm app
- Fix: adds the missing `ALTER TABLE project_instance_steps ADD COLUMN IF NOT EXISTS scheduled_date TEXT` to the bootstrap migration sequence

## Test plan
- [ ] Deploy to production (Synology restarts the rhythm-api container)
- [ ] Open a project in the Rhythm app and mark a step as done — should succeed instead of silently failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)