### PR TITLE
feat(api_server): projects table + CRUD with VCS detection (M1-1, #586)

### DIFF
--- a/apps/api_server/src/__tests__/agent_sessions.test.ts
+++ b/apps/api_server/src/__tests__/agent_sessions.test.ts
@@ -366,4 +366,93 @@ describe('Agent Sessions API', () => {
     const msgsBody = (await msgsRes.json()) as { messages: unknown[] };
     expect(Array.isArray(msgsBody.messages)).toBe(true);
   });
+
+  // ── M1-2 #587: project_id FK + filtering ──────────────────────────────────
+
+  async function createProject(name: string, cwd: string): Promise<string> {
+    const res = await fetch(`${baseUrl}/projects`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ name, cwd }),
+    });
+    const project = (await res.json()) as { id: string };
+    return project.id;
+  }
+
+  it('POST /agent-sessions without projectId persists NULL', async () => {
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ agentId: 'claude-code', cwd: os.homedir(), name: 'No project' }),
+    });
+    expect(res.status).toBe(201);
+    const session = (await res.json()) as { projectId: string | null };
+    expect(session.projectId).toBeNull();
+  });
+
+  it('POST /agent-sessions with explicit projectId persists it', async () => {
+    const projectId = await createProject('Proj A', os.homedir());
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        agentId: 'claude-code',
+        cwd: os.homedir(),
+        name: 'In project',
+        projectId,
+      }),
+    });
+    expect(res.status).toBe(201);
+    const session = (await res.json()) as { projectId: string | null };
+    expect(session.projectId).toBe(projectId);
+  });
+
+  it('GET /agent-sessions?projectId=<id> filters by project', async () => {
+    const projectId = await createProject('Filter', os.homedir());
+    await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ agentId: 'claude-code', cwd: os.homedir(), name: 'In', projectId }),
+    });
+    await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ agentId: 'claude-code', cwd: os.homedir(), name: 'Out' }),
+    });
+
+    const res = await fetch(`${baseUrl}/agent-sessions?projectId=${projectId}`, {
+      headers: authHeaders,
+    });
+    const body = (await res.json()) as { sessions: Array<{ name: string; projectId: string | null }> };
+    expect(body.sessions.every((s) => s.projectId === projectId)).toBe(true);
+    expect(body.sessions.find((s) => s.name === 'In')).toBeDefined();
+    expect(body.sessions.find((s) => s.name === 'Out')).toBeUndefined();
+  });
+
+  it('GET /agent-sessions?projectId=null returns only unassigned sessions', async () => {
+    const projectId = await createProject('Nullbucket', os.homedir());
+    await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ agentId: 'claude-code', cwd: os.homedir(), name: 'AssignedX', projectId }),
+    });
+    await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ agentId: 'claude-code', cwd: os.homedir(), name: 'UnassignedY' }),
+    });
+
+    const res = await fetch(`${baseUrl}/agent-sessions?projectId=null`, { headers: authHeaders });
+    const body = (await res.json()) as { sessions: Array<{ name: string; projectId: string | null }> };
+    expect(body.sessions.every((s) => s.projectId === null)).toBe(true);
+    expect(body.sessions.find((s) => s.name === 'UnassignedY')).toBeDefined();
+    expect(body.sessions.find((s) => s.name === 'AssignedX')).toBeUndefined();
+  });
+
+  it('projects migration is idempotent (running it twice on same DB is a no-op)', async () => {
+    const { runMigrations: run } = await import('../database/migrations');
+    const { getDb } = await import('../database/db');
+    // Calling again must not throw.
+    expect(() => run(getDb())).not.toThrow();
+  });
 });

--- a/apps/api_server/src/__tests__/agent_sessions.test.ts
+++ b/apps/api_server/src/__tests__/agent_sessions.test.ts
@@ -417,7 +417,8 @@ describe('Agent Sessions API', () => {
     await fetch(`${baseUrl}/agent-sessions`, {
       method: 'POST',
       headers: authHeaders,
-      body: JSON.stringify({ agentId: 'claude-code', cwd: os.homedir(), name: 'Out' }),
+      // Explicit null so M1-3 cwd-prefix auto-assign does not pick up Filter.
+      body: JSON.stringify({ agentId: 'claude-code', cwd: os.homedir(), name: 'Out', projectId: null }),
     });
 
     const res = await fetch(`${baseUrl}/agent-sessions?projectId=${projectId}`, {
@@ -439,7 +440,8 @@ describe('Agent Sessions API', () => {
     await fetch(`${baseUrl}/agent-sessions`, {
       method: 'POST',
       headers: authHeaders,
-      body: JSON.stringify({ agentId: 'claude-code', cwd: os.homedir(), name: 'UnassignedY' }),
+      // Explicit null bypasses cwd-prefix auto-assign.
+      body: JSON.stringify({ agentId: 'claude-code', cwd: os.homedir(), name: 'UnassignedY', projectId: null }),
     });
 
     const res = await fetch(`${baseUrl}/agent-sessions?projectId=null`, { headers: authHeaders });
@@ -454,5 +456,104 @@ describe('Agent Sessions API', () => {
     const { getDb } = await import('../database/db');
     // Calling again must not throw.
     expect(() => run(getDb())).not.toThrow();
+  });
+
+  // ── M1-3 #588: auto-assign project on session create by cwd prefix ───────
+
+  it('auto-assigns project when omitted and cwd exactly matches a project', async () => {
+    const projectId = await createProject('Exact', '/Users/x/Documents/Rhythm');
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        agentId: 'claude-code',
+        cwd: '/Users/x/Documents/Rhythm',
+        name: 'Exact',
+      }),
+    });
+    const session = (await res.json()) as { projectId: string | null };
+    expect(session.projectId).toBe(projectId);
+  });
+
+  it('auto-assigns project when cwd is a prefix-deeper path', async () => {
+    const projectId = await createProject('Prefix', '/Users/x/Documents/Rhythm');
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        agentId: 'claude-code',
+        cwd: '/Users/x/Documents/Rhythm/apps/api_server',
+        name: 'Deep',
+      }),
+    });
+    const session = (await res.json()) as { projectId: string | null };
+    expect(session.projectId).toBe(projectId);
+  });
+
+  it('returns projectId=null when no project matches', async () => {
+    await createProject('Unrelated', '/Users/x/Documents/Rhythm');
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        agentId: 'claude-code',
+        cwd: '/Users/x/elsewhere',
+        name: 'NoMatch',
+      }),
+    });
+    const session = (await res.json()) as { projectId: string | null };
+    expect(session.projectId).toBeNull();
+  });
+
+  it('explicit projectId=null is not overridden by auto-assign', async () => {
+    await createProject('Wouldmatch', '/Users/x/Documents/Rhythm');
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        agentId: 'claude-code',
+        cwd: '/Users/x/Documents/Rhythm/apps',
+        name: 'IntentionalNull',
+        projectId: null,
+      }),
+    });
+    const session = (await res.json()) as { projectId: string | null };
+    expect(session.projectId).toBeNull();
+  });
+
+  it('longest cwd prefix wins when multiple projects match', async () => {
+    await createProject('Outer', '/Users/x/A');
+    const innerId = await createProject('Inner', '/Users/x/A/sub');
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        agentId: 'claude-code',
+        cwd: '/Users/x/A/sub/inner',
+        name: 'Nested',
+      }),
+    });
+    const session = (await res.json()) as { projectId: string | null };
+    expect(session.projectId).toBe(innerId);
+  });
+
+  it('skips archived projects in cwd-prefix lookup', async () => {
+    const archivedId = await createProject('Archived', '/Users/x/archived');
+    await fetch(`${baseUrl}/projects/${archivedId}`, {
+      method: 'PATCH',
+      headers: authHeaders,
+      body: JSON.stringify({ archivedAt: new Date().toISOString() }),
+    });
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        agentId: 'claude-code',
+        cwd: '/Users/x/archived/deeper',
+        name: 'SkipArchived',
+      }),
+    });
+    const session = (await res.json()) as { projectId: string | null };
+    expect(session.projectId).toBeNull();
   });
 });

--- a/apps/api_server/src/__tests__/projects_routes.test.ts
+++ b/apps/api_server/src/__tests__/projects_routes.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import Database from 'better-sqlite3';
+import type { AddressInfo } from 'node:net';
+
+import { createApp } from '../app';
+import { runMigrations } from '../database/migrations';
+import { setDb } from '../database/db';
+import { UsersRepository } from '../repositories/users_repository';
+import { SessionsRepository } from '../repositories/sessions_repository';
+
+interface ProjectResponse {
+  id: string;
+  name: string;
+  cwd: string;
+  icon: string | null;
+  vcsRoot: string | null;
+  vcsBranch: string | null;
+  vcsDirty: boolean;
+  vcsCheckedAt: string | null;
+  createdAt: string;
+  archivedAt: string | null;
+}
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  return db;
+}
+
+function makeTmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+describe('Projects API', () => {
+  let baseUrl: string;
+  let closeServer: () => Promise<void>;
+  let authHeaders: Record<string, string>;
+  const tmpDirs: string[] = [];
+
+  beforeEach(async () => {
+    setDb(makeDb());
+    const usersRepo = new UsersRepository();
+    const sessionsRepo = new SessionsRepository();
+    const user = usersRepo.create({ name: 'Test', email: 'test@example.com' });
+    const session = await sessionsRepo.createAsync(user.id);
+    authHeaders = {
+      Authorization: `Bearer ${session.token}`,
+      'Content-Type': 'application/json',
+    };
+
+    const server = createApp().listen(0);
+    await new Promise<void>((r) => server.once('listening', () => r()));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    closeServer = () =>
+      new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res())));
+  });
+
+  afterEach(async () => {
+    await closeServer();
+    while (tmpDirs.length) {
+      const dir = tmpDirs.pop()!;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function tmp(prefix: string): string {
+    const d = makeTmpDir(prefix);
+    tmpDirs.push(d);
+    return d;
+  }
+
+  it('POST /projects with a git cwd returns 201 and VCS fields populated', async () => {
+    const res = await fetch(`${baseUrl}/projects`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ name: 'Rhythm', cwd: process.cwd() }),
+    });
+    expect(res.status).toBe(201);
+    const project = (await res.json()) as ProjectResponse;
+    expect(project.name).toBe('Rhythm');
+    expect(project.cwd).toBe(process.cwd());
+    expect(project.vcsRoot).toBeTruthy();
+    expect(project.vcsCheckedAt).toBeTruthy();
+  });
+
+  it('POST /projects with a non-git cwd returns NULL VCS fields and vcsDirty=false', async () => {
+    const dir = tmp('projects-nongit-');
+    const res = await fetch(`${baseUrl}/projects`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ name: 'Plain', cwd: dir }),
+    });
+    expect(res.status).toBe(201);
+    const project = (await res.json()) as ProjectResponse;
+    expect(project.vcsRoot).toBeNull();
+    expect(project.vcsBranch).toBeNull();
+    expect(project.vcsDirty).toBe(false);
+    expect(project.vcsCheckedAt).toBeTruthy();
+  });
+
+  it('POST /projects rejects a relative path with 400', async () => {
+    const res = await fetch(`${baseUrl}/projects`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ name: 'Rel', cwd: 'relative/path' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('GET /projects lists active projects in created_at DESC order', async () => {
+    const a = tmp('proj-a-');
+    const b = tmp('proj-b-');
+    await fetch(`${baseUrl}/projects`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ name: 'A', cwd: a }),
+    });
+    // Ensure distinct created_at timestamps.
+    await new Promise((r) => setTimeout(r, 10));
+    await fetch(`${baseUrl}/projects`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ name: 'B', cwd: b }),
+    });
+
+    const res = await fetch(`${baseUrl}/projects`, { headers: authHeaders });
+    expect(res.status).toBe(200);
+    const list = (await res.json()) as ProjectResponse[];
+    expect(list.map((p) => p.name)).toEqual(['B', 'A']);
+  });
+
+  it('GET /projects excludes archived; ?includeArchived=true includes them', async () => {
+    const dir = tmp('proj-archive-');
+    const createRes = await fetch(`${baseUrl}/projects`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ name: 'Old', cwd: dir }),
+    });
+    const project = (await createRes.json()) as ProjectResponse;
+
+    await fetch(`${baseUrl}/projects/${project.id}`, {
+      method: 'PATCH',
+      headers: authHeaders,
+      body: JSON.stringify({ archivedAt: new Date().toISOString() }),
+    });
+
+    const defaultList = (await (
+      await fetch(`${baseUrl}/projects`, { headers: authHeaders })
+    ).json()) as ProjectResponse[];
+    expect(defaultList.find((p) => p.id === project.id)).toBeUndefined();
+
+    const fullList = (await (
+      await fetch(`${baseUrl}/projects?includeArchived=true`, { headers: authHeaders })
+    ).json()) as ProjectResponse[];
+    expect(fullList.find((p) => p.id === project.id)).toBeDefined();
+  });
+
+  it('PATCH /projects/:id re-probes VCS when cwd changes', async () => {
+    const nonGit = tmp('proj-patch-nongit-');
+    const createRes = await fetch(`${baseUrl}/projects`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ name: 'Switching', cwd: nonGit }),
+    });
+    const project = (await createRes.json()) as ProjectResponse;
+    expect(project.vcsRoot).toBeNull();
+
+    const patchRes = await fetch(`${baseUrl}/projects/${project.id}`, {
+      method: 'PATCH',
+      headers: authHeaders,
+      body: JSON.stringify({ cwd: process.cwd() }),
+    });
+    expect(patchRes.status).toBe(200);
+    const updated = (await patchRes.json()) as ProjectResponse;
+    expect(updated.cwd).toBe(process.cwd());
+    expect(updated.vcsRoot).toBeTruthy();
+  });
+
+  it('DELETE /projects/:id removes the row', async () => {
+    const dir = tmp('proj-delete-');
+    const createRes = await fetch(`${baseUrl}/projects`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ name: 'Doomed', cwd: dir }),
+    });
+    const project = (await createRes.json()) as ProjectResponse;
+
+    const delRes = await fetch(`${baseUrl}/projects/${project.id}`, {
+      method: 'DELETE',
+      headers: authHeaders,
+    });
+    expect(delRes.status).toBe(204);
+
+    const getRes = await fetch(`${baseUrl}/projects/${project.id}`, { headers: authHeaders });
+    expect(getRes.status).toBe(404);
+  });
+
+  it('POST /projects/:id/refresh-vcs updates vcs_checked_at', async () => {
+    const dir = tmp('proj-refresh-');
+    const createRes = await fetch(`${baseUrl}/projects`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ name: 'R', cwd: dir }),
+    });
+    const project = (await createRes.json()) as ProjectResponse;
+    const originalCheckedAt = project.vcsCheckedAt;
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const refreshRes = await fetch(`${baseUrl}/projects/${project.id}/refresh-vcs`, {
+      method: 'POST',
+      headers: authHeaders,
+    });
+    expect(refreshRes.status).toBe(200);
+    const refreshed = (await refreshRes.json()) as ProjectResponse;
+    expect(refreshed.vcsCheckedAt).toBeTruthy();
+    expect(refreshed.vcsCheckedAt).not.toBe(originalCheckedAt);
+  });
+});

--- a/apps/api_server/src/__tests__/vcs_probe.test.ts
+++ b/apps/api_server/src/__tests__/vcs_probe.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { probeVcs } from '../services/vcs_probe';
+
+function makeTmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+function initRepo(cwd: string): void {
+  git(cwd, ['init', '-q', '-b', 'main']);
+  git(cwd, ['config', 'user.email', 'test@example.com']);
+  git(cwd, ['config', 'user.name', 'Test']);
+  git(cwd, ['commit', '--allow-empty', '-q', '-m', 'init']);
+}
+
+describe('probeVcs', () => {
+  it('returns populated fields for a git repo (current working directory)', () => {
+    // The Rhythm repo itself is a git checkout; CI and local both run inside it.
+    const info = probeVcs(process.cwd());
+    expect(info).not.toBeNull();
+    expect(info!.vcsRoot).toBeTruthy();
+    // branch may be null in detached HEAD (CI sometimes detaches); accept either.
+    if (info!.vcsBranch !== null) {
+      expect(typeof info!.vcsBranch).toBe('string');
+    }
+    expect(typeof info!.vcsDirty).toBe('boolean');
+  });
+
+  it('returns null for a non-git temp directory', () => {
+    const tmp = makeTmpDir('vcs-probe-nongit-');
+    try {
+      expect(probeVcs(tmp)).toBeNull();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('flips vcsDirty true when an untracked file exists and false after cleanup', () => {
+    const tmp = makeTmpDir('vcs-probe-dirty-');
+    try {
+      initRepo(tmp);
+      const clean = probeVcs(tmp);
+      expect(clean).not.toBeNull();
+      expect(clean!.vcsDirty).toBe(false);
+
+      fs.writeFileSync(path.join(tmp, 'untracked.txt'), 'x');
+      const dirty = probeVcs(tmp);
+      expect(dirty!.vcsDirty).toBe(true);
+
+      fs.rmSync(path.join(tmp, 'untracked.txt'));
+      const cleanAgain = probeVcs(tmp);
+      expect(cleanAgain!.vcsDirty).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns vcsRoot but null vcsBranch when HEAD is detached', () => {
+    const tmp = makeTmpDir('vcs-probe-detached-');
+    try {
+      initRepo(tmp);
+      const sha = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: tmp,
+        encoding: 'utf8',
+      }).trim();
+      git(tmp, ['checkout', '-q', '--detach', sha]);
+      const info = probeVcs(tmp);
+      expect(info).not.toBeNull();
+      expect(info!.vcsRoot).toBeTruthy();
+      expect(info!.vcsBranch).toBeNull();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when the underlying shell call fails (e.g. git unavailable)', async () => {
+    vi.resetModules();
+    vi.doMock('child_process', () => ({
+      execFileSync: vi.fn(() => {
+        throw new Error('spawn failure');
+      }),
+    }));
+    const mod = await import('../services/vcs_probe');
+    expect(mod.probeVcs(process.cwd())).toBeNull();
+    vi.doUnmock('child_process');
+    vi.resetModules();
+  });
+});

--- a/apps/api_server/src/app.ts
+++ b/apps/api_server/src/app.ts
@@ -13,6 +13,7 @@ import { integrationsRouter } from './routes/integrations_routes';
 import { messagesRouter } from './routes/messages_routes';
 import { projectInstancesRouter } from './routes/project_instances_routes';
 import { projectTemplatesRouter } from './routes/project_templates_routes';
+import { projectsRouter } from './routes/projects_routes';
 import { recurringRulesRouter } from './routes/recurring_rules_routes';
 import { tasksRouter } from './routes/tasks_routes';
 import { usersRouter } from './routes/users_routes';
@@ -71,6 +72,7 @@ export function createApp() {
   app.use('/claude-triggers', claudeTriggersRouter);
   app.use('/agent-configs', agentConfigsRouter);
   app.use('/agent-sessions', agentSessionsRouter);
+  app.use('/projects', projectsRouter);
 
   // Opencode engine auth & health
   app.use('/opencode/auth', opencodeAuthRouter);

--- a/apps/api_server/src/controllers/agent_sessions_controller.ts
+++ b/apps/api_server/src/controllers/agent_sessions_controller.ts
@@ -4,6 +4,7 @@ import { AppError } from '../errors/app_error';
 import { AgentSessionsRepository } from '../repositories/agent_sessions_repository';
 import { AgentSessionMessagesRepository } from '../repositories/agent_session_messages_repository';
 import { AgentConfigsRepository } from '../repositories/agent_configs_repository';
+import { ProjectsRepository } from '../repositories/projects_repository';
 import type { AgentKind, CreateAgentSessionDto } from '../models/agent_session';
 import { opencodeClient, opencodeSessionMap } from '../services/opencode_engine';
 import { streamBridge } from '../services/opencode_stream_bridge';
@@ -110,7 +111,10 @@ export class AgentSessionsController {
       }
 
       // projectId: optional in body. Explicit `null` is honored (intentional
-      // "unassigned"). Omitted → null for now; M1-3 adds cwd-prefix auto-assign.
+      // "unassigned"). When the client omits the field entirely, fall back to
+      // cwd-prefix lookup against the projects table (longest match wins,
+      // archived projects skipped).
+      const expandedCwd = expandHome(cwd.trim());
       let projectId: string | null = null;
       if (Object.prototype.hasOwnProperty.call(body, 'projectId')) {
         const raw = body.projectId;
@@ -118,13 +122,16 @@ export class AgentSessionsController {
           throw AppError.badRequest('projectId must be a string or null');
         }
         projectId = (raw as string | null) ?? null;
+      } else {
+        const match = new ProjectsRepository().findByCwdPrefix(expandedCwd);
+        projectId = match?.id ?? null;
       }
 
       const dto: CreateAgentSessionDto = {
         agentKind: normalizedAgentId as AgentKind,
         taskId: taskId != null ? (taskId as string) : null,
         taskTitle: taskTitle != null ? (taskTitle as string) : null,
-        cwd: expandHome(cwd.trim()),
+        cwd: expandedCwd,
         name: name.trim(),
         projectId,
       };

--- a/apps/api_server/src/controllers/agent_sessions_controller.ts
+++ b/apps/api_server/src/controllers/agent_sessions_controller.ts
@@ -38,9 +38,18 @@ function expandHome(path: string): string {
 }
 
 export class AgentSessionsController {
-  list(_req: Request, res: Response, next: NextFunction): void {
+  list(req: Request, res: Response, next: NextFunction): void {
     try {
-      const sessions = repo.listAll(100);
+      const projectIdParam = req.query.projectId;
+      let sessions;
+      if (typeof projectIdParam === 'string') {
+        // Literal "null" → unassigned bucket; any other string → filter by id.
+        sessions = projectIdParam === 'null'
+          ? repo.listByProject(null, 100)
+          : repo.listByProject(projectIdParam, 100);
+      } else {
+        sessions = repo.listAll(100);
+      }
       const resumable = repo.listResumable();
       res.json({ sessions, resumable });
     } catch (err) {
@@ -100,12 +109,24 @@ export class AgentSessionsController {
         throw AppError.badRequest('taskTitle must be a string');
       }
 
+      // projectId: optional in body. Explicit `null` is honored (intentional
+      // "unassigned"). Omitted → null for now; M1-3 adds cwd-prefix auto-assign.
+      let projectId: string | null = null;
+      if (Object.prototype.hasOwnProperty.call(body, 'projectId')) {
+        const raw = body.projectId;
+        if (raw !== null && typeof raw !== 'string') {
+          throw AppError.badRequest('projectId must be a string or null');
+        }
+        projectId = (raw as string | null) ?? null;
+      }
+
       const dto: CreateAgentSessionDto = {
         agentKind: normalizedAgentId as AgentKind,
         taskId: taskId != null ? (taskId as string) : null,
         taskTitle: taskTitle != null ? (taskTitle as string) : null,
         cwd: expandHome(cwd.trim()),
         name: name.trim(),
+        projectId,
       };
 
       const session = repo.insert(dto);

--- a/apps/api_server/src/controllers/projects_controller.ts
+++ b/apps/api_server/src/controllers/projects_controller.ts
@@ -1,0 +1,152 @@
+import os from 'os';
+import path from 'path';
+import type { NextFunction, Request, Response } from 'express';
+import { AppError } from '../errors/app_error';
+import { ProjectsRepository, type ProjectVcsFields } from '../repositories/projects_repository';
+import { probeVcs } from '../services/vcs_probe';
+
+function expandHome(p: string): string {
+  if (p === '~' || p.startsWith('~/')) return p.replace('~', os.homedir());
+  return p;
+}
+
+function normalizeCwd(input: unknown): string {
+  if (typeof input !== 'string' || input.trim() === '') {
+    throw AppError.badRequest('cwd is required and must be a non-empty string');
+  }
+  const expanded = expandHome(input.trim());
+  if (!path.isAbsolute(expanded)) {
+    throw AppError.badRequest('cwd must be an absolute path');
+  }
+  // Strip trailing slashes (except root).
+  return expanded.length > 1 ? expanded.replace(/\/+$/, '') : expanded;
+}
+
+function probeFields(cwd: string): ProjectVcsFields {
+  const probed = probeVcs(cwd);
+  const checkedAt = new Date().toISOString();
+  if (!probed) {
+    return { vcsRoot: null, vcsBranch: null, vcsDirty: false, vcsCheckedAt: checkedAt };
+  }
+  return {
+    vcsRoot: probed.vcsRoot,
+    vcsBranch: probed.vcsBranch,
+    vcsDirty: probed.vcsDirty,
+    vcsCheckedAt: checkedAt,
+  };
+}
+
+const repo = new ProjectsRepository();
+
+export class ProjectsController {
+  list(req: Request, res: Response, next: NextFunction): void {
+    try {
+      const includeArchived = String(req.query.includeArchived ?? '').toLowerCase() === 'true';
+      res.json(repo.list({ includeArchived }));
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  getOne(req: Request, res: Response, next: NextFunction): void {
+    try {
+      const project = repo.findById(req.params.id);
+      if (!project) throw AppError.notFound('Project');
+      res.json(project);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  create(req: Request, res: Response, next: NextFunction): void {
+    try {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const { name, icon } = body;
+      if (typeof name !== 'string' || name.trim() === '') {
+        throw AppError.badRequest('name is required and must be a non-empty string');
+      }
+      if (icon !== undefined && icon !== null && typeof icon !== 'string') {
+        throw AppError.badRequest('icon must be a string');
+      }
+      const cwd = normalizeCwd(body.cwd);
+      const project = repo.insert({
+        name: name.trim(),
+        cwd,
+        icon: typeof icon === 'string' ? icon : null,
+        vcs: probeFields(cwd),
+      });
+      res.status(201).json(project);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  update(req: Request, res: Response, next: NextFunction): void {
+    try {
+      const existing = repo.findById(req.params.id);
+      if (!existing) throw AppError.notFound('Project');
+
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const fields: {
+        name?: string;
+        cwd?: string;
+        icon?: string | null;
+        archivedAt?: string | null;
+      } = {};
+
+      if (body.name !== undefined) {
+        if (typeof body.name !== 'string' || body.name.trim() === '') {
+          throw AppError.badRequest('name must be a non-empty string');
+        }
+        fields.name = body.name.trim();
+      }
+      if (body.icon !== undefined) {
+        if (body.icon !== null && typeof body.icon !== 'string') {
+          throw AppError.badRequest('icon must be a string or null');
+        }
+        fields.icon = body.icon as string | null;
+      }
+      if (body.archivedAt !== undefined) {
+        if (body.archivedAt !== null && typeof body.archivedAt !== 'string') {
+          throw AppError.badRequest('archivedAt must be an ISO string or null');
+        }
+        fields.archivedAt = body.archivedAt as string | null;
+      }
+      let cwdChanged = false;
+      if (body.cwd !== undefined) {
+        fields.cwd = normalizeCwd(body.cwd);
+        cwdChanged = fields.cwd !== existing.cwd;
+      }
+
+      repo.updateFields(existing.id, fields);
+      if (cwdChanged && fields.cwd) {
+        repo.updateVcs(existing.id, probeFields(fields.cwd));
+      }
+      res.json(repo.findById(existing.id)!);
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  remove(req: Request, res: Response, next: NextFunction): void {
+    try {
+      const project = repo.findById(req.params.id);
+      if (!project) throw AppError.notFound('Project');
+      repo.delete(project.id);
+      res.status(204).end();
+    } catch (err) {
+      next(err);
+    }
+  }
+
+  refreshVcs(req: Request, res: Response, next: NextFunction): void {
+    try {
+      const project = repo.findById(req.params.id);
+      if (!project) throw AppError.notFound('Project');
+      repo.updateVcs(project.id, probeFields(project.cwd));
+      res.json(repo.findById(project.id)!);
+    } catch (err) {
+      next(err);
+    }
+  }
+}

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -1068,4 +1068,12 @@ export function runMigrations(db: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS idx_projects_archived ON projects(archived_at);
   `);
+
+  // M1-2 (issue #587) — agent_sessions.project_id (nullable, logical FK to projects.id).
+  // PRAGMA foreign_keys is not enabled globally in this repo, so REFERENCES is informational.
+  const agentSessionColsM1 = (db.pragma('table_info(agent_sessions)') as { name: string }[]).map((c) => c.name);
+  if (!agentSessionColsM1.includes('project_id')) {
+    db.exec(`ALTER TABLE agent_sessions ADD COLUMN project_id TEXT REFERENCES projects(id)`);
+  }
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_agent_sessions_project ON agent_sessions(project_id)`);
 }

--- a/apps/api_server/src/database/migrations.ts
+++ b/apps/api_server/src/database/migrations.ts
@@ -1049,4 +1049,23 @@ export function runMigrations(db: Database.Database): void {
     // 5. Log affected row counts at INFO level for audit after deploy.
     console.log(`backfill_scheduled_date_v1: tasks updated=${tasksUpdated}, project_steps updated=${stepsUpdated}`);
   }
+
+  // M1-1 (issue #586) — Projects: parent entity for agent sessions.
+  // Local-only (SQLite); no Postgres path. VCS fields populated by services/vcs_probe.ts
+  // at create / on demand via POST /projects/:id/refresh-vcs.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS projects (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      cwd TEXT NOT NULL,
+      icon TEXT,
+      vcs_root TEXT,
+      vcs_branch TEXT,
+      vcs_dirty INTEGER NOT NULL DEFAULT 0,
+      vcs_checked_at TEXT,
+      created_at TEXT NOT NULL,
+      archived_at TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_projects_archived ON projects(archived_at);
+  `);
 }

--- a/apps/api_server/src/models/agent_session.ts
+++ b/apps/api_server/src/models/agent_session.ts
@@ -10,6 +10,7 @@ export interface AgentSession {
   sessionToken: string | null;
   cwd: string;
   name: string;
+  projectId: string | null;
   lastPreview: string | null;
   lastActivityAt: string | null;
   createdAt: string;
@@ -31,4 +32,5 @@ export interface CreateAgentSessionDto {
   taskTitle?: string | null;
   cwd: string;
   name: string;
+  projectId?: string | null;
 }

--- a/apps/api_server/src/models/project.ts
+++ b/apps/api_server/src/models/project.ts
@@ -1,0 +1,25 @@
+export interface Project {
+  id: string;
+  name: string;
+  cwd: string;
+  icon: string | null;
+  vcsRoot: string | null;
+  vcsBranch: string | null;
+  vcsDirty: boolean;
+  vcsCheckedAt: string | null;
+  createdAt: string;
+  archivedAt: string | null;
+}
+
+export interface CreateProjectDto {
+  name: string;
+  cwd: string;
+  icon?: string | null;
+}
+
+export interface UpdateProjectDto {
+  name?: string;
+  cwd?: string;
+  icon?: string | null;
+  archivedAt?: string | null;
+}

--- a/apps/api_server/src/repositories/agent_sessions_repository.ts
+++ b/apps/api_server/src/repositories/agent_sessions_repository.ts
@@ -14,6 +14,7 @@ interface AgentSessionRow {
   session_token: string | null;
   cwd: string;
   name: string;
+  project_id: string | null;
   last_preview: string | null;
   last_activity_at: string | null;
   created_at: string;
@@ -30,6 +31,7 @@ function rowToModel(row: AgentSessionRow): AgentSession {
     sessionToken: row.session_token,
     cwd: row.cwd,
     name: row.name,
+    projectId: row.project_id ?? null,
     lastPreview: row.last_preview,
     lastActivityAt: row.last_activity_at,
     createdAt: row.created_at,
@@ -43,11 +45,31 @@ export class AgentSessionsRepository {
     const now = new Date().toISOString();
     getDb()
       .prepare(
-        `INSERT INTO agent_sessions (id, task_id, task_title, agent_kind, status, cwd, name, created_at, updated_at)
-         VALUES (?, ?, ?, ?, 'starting', ?, ?, ?, ?)`,
+        `INSERT INTO agent_sessions (id, task_id, task_title, agent_kind, status, cwd, name, project_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'starting', ?, ?, ?, ?, ?)`,
       )
-      .run(id, dto.taskId ?? null, dto.taskTitle ?? null, dto.agentKind, dto.cwd, dto.name, now, now);
+      .run(
+        id,
+        dto.taskId ?? null,
+        dto.taskTitle ?? null,
+        dto.agentKind,
+        dto.cwd,
+        dto.name,
+        dto.projectId ?? null,
+        now,
+        now,
+      );
     return this.findById(id)!;
+  }
+
+  listByProject(projectId: string | null, limit = 100): AgentSession[] {
+    const sql = projectId === null
+      ? `SELECT * FROM agent_sessions WHERE project_id IS NULL ORDER BY created_at DESC LIMIT ?`
+      : `SELECT * FROM agent_sessions WHERE project_id = ? ORDER BY created_at DESC LIMIT ?`;
+    const rows = projectId === null
+      ? (getDb().prepare(sql).all(limit) as AgentSessionRow[])
+      : (getDb().prepare(sql).all(projectId, limit) as AgentSessionRow[]);
+    return rows.map(rowToModel);
   }
 
   findById(id: string): AgentSession | null {

--- a/apps/api_server/src/repositories/projects_repository.ts
+++ b/apps/api_server/src/repositories/projects_repository.ts
@@ -1,0 +1,130 @@
+import { getDb } from '../database/db';
+import type { Project } from '../models/project';
+
+interface ProjectRow {
+  id: string;
+  name: string;
+  cwd: string;
+  icon: string | null;
+  vcs_root: string | null;
+  vcs_branch: string | null;
+  vcs_dirty: number;
+  vcs_checked_at: string | null;
+  created_at: string;
+  archived_at: string | null;
+}
+
+function rowToModel(row: ProjectRow): Project {
+  return {
+    id: row.id,
+    name: row.name,
+    cwd: row.cwd,
+    icon: row.icon,
+    vcsRoot: row.vcs_root,
+    vcsBranch: row.vcs_branch,
+    vcsDirty: Boolean(row.vcs_dirty),
+    vcsCheckedAt: row.vcs_checked_at,
+    createdAt: row.created_at,
+    archivedAt: row.archived_at,
+  };
+}
+
+export interface ProjectVcsFields {
+  vcsRoot: string | null;
+  vcsBranch: string | null;
+  vcsDirty: boolean;
+  vcsCheckedAt: string | null;
+}
+
+export class ProjectsRepository {
+  insert(input: {
+    name: string;
+    cwd: string;
+    icon: string | null;
+    vcs: ProjectVcsFields;
+  }): Project {
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    getDb()
+      .prepare(
+        `INSERT INTO projects (id, name, cwd, icon, vcs_root, vcs_branch, vcs_dirty, vcs_checked_at, created_at, archived_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+      )
+      .run(
+        id,
+        input.name,
+        input.cwd,
+        input.icon,
+        input.vcs.vcsRoot,
+        input.vcs.vcsBranch,
+        input.vcs.vcsDirty ? 1 : 0,
+        input.vcs.vcsCheckedAt,
+        now,
+      );
+    return this.findById(id)!;
+  }
+
+  findById(id: string): Project | null {
+    const row = getDb()
+      .prepare(`SELECT * FROM projects WHERE id = ?`)
+      .get(id) as ProjectRow | undefined;
+    return row ? rowToModel(row) : null;
+  }
+
+  list(opts: { includeArchived?: boolean } = {}): Project[] {
+    const includeArchived = opts.includeArchived ?? false;
+    const sql = includeArchived
+      ? `SELECT * FROM projects ORDER BY created_at DESC`
+      : `SELECT * FROM projects WHERE archived_at IS NULL ORDER BY created_at DESC`;
+    const rows = getDb().prepare(sql).all() as ProjectRow[];
+    return rows.map(rowToModel);
+  }
+
+  updateFields(
+    id: string,
+    fields: {
+      name?: string;
+      cwd?: string;
+      icon?: string | null;
+      archivedAt?: string | null;
+    },
+  ): void {
+    const sets: string[] = [];
+    const values: unknown[] = [];
+    if (fields.name !== undefined) {
+      sets.push('name = ?');
+      values.push(fields.name);
+    }
+    if (fields.cwd !== undefined) {
+      sets.push('cwd = ?');
+      values.push(fields.cwd);
+    }
+    if (fields.icon !== undefined) {
+      sets.push('icon = ?');
+      values.push(fields.icon);
+    }
+    if (fields.archivedAt !== undefined) {
+      sets.push('archived_at = ?');
+      values.push(fields.archivedAt);
+    }
+    if (sets.length === 0) return;
+    values.push(id);
+    getDb()
+      .prepare(`UPDATE projects SET ${sets.join(', ')} WHERE id = ?`)
+      .run(...values);
+  }
+
+  updateVcs(id: string, vcs: ProjectVcsFields): void {
+    getDb()
+      .prepare(
+        `UPDATE projects
+         SET vcs_root = ?, vcs_branch = ?, vcs_dirty = ?, vcs_checked_at = ?
+         WHERE id = ?`,
+      )
+      .run(vcs.vcsRoot, vcs.vcsBranch, vcs.vcsDirty ? 1 : 0, vcs.vcsCheckedAt, id);
+  }
+
+  delete(id: string): void {
+    getDb().prepare(`DELETE FROM projects WHERE id = ?`).run(id);
+  }
+}

--- a/apps/api_server/src/repositories/projects_repository.ts
+++ b/apps/api_server/src/repositories/projects_repository.ts
@@ -127,4 +127,30 @@ export class ProjectsRepository {
   delete(id: string): void {
     getDb().prepare(`DELETE FROM projects WHERE id = ?`).run(id);
   }
+
+  /**
+   * Return the non-archived project whose `cwd` is an exact match or a
+   * path-prefix of `sessionCwd`. When multiple match, returns the longest
+   * (e.g. nested projects). Strings are compared after stripping trailing
+   * slashes; no symlink resolution.
+   */
+  findByCwdPrefix(sessionCwd: string): Project | null {
+    const normalized = sessionCwd.length > 1
+      ? sessionCwd.replace(/\/+$/, '')
+      : sessionCwd;
+    const rows = getDb()
+      .prepare(`SELECT * FROM projects WHERE archived_at IS NULL`)
+      .all() as ProjectRow[];
+
+    let best: ProjectRow | null = null;
+    for (const row of rows) {
+      const projectCwd = row.cwd.length > 1 ? row.cwd.replace(/\/+$/, '') : row.cwd;
+      if (normalized === projectCwd || normalized.startsWith(projectCwd + '/')) {
+        if (!best || projectCwd.length > best.cwd.length) {
+          best = row;
+        }
+      }
+    }
+    return best ? rowToModel(best) : null;
+  }
 }

--- a/apps/api_server/src/routes/projects_routes.ts
+++ b/apps/api_server/src/routes/projects_routes.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { env } from '../config/env';
+import { requireAuth } from '../middleware/auth_middleware';
+import { ProjectsController } from '../controllers/projects_controller';
+
+const controller = new ProjectsController();
+export const projectsRouter = Router();
+
+if (!env.agentLocal) projectsRouter.use(requireAuth);
+
+projectsRouter.get('/', controller.list.bind(controller));
+projectsRouter.get('/:id', controller.getOne.bind(controller));
+projectsRouter.post('/', controller.create.bind(controller));
+projectsRouter.patch('/:id', controller.update.bind(controller));
+projectsRouter.delete('/:id', controller.remove.bind(controller));
+projectsRouter.post('/:id/refresh-vcs', controller.refreshVcs.bind(controller));

--- a/apps/api_server/src/services/vcs_probe.ts
+++ b/apps/api_server/src/services/vcs_probe.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from 'child_process';
+
+export interface VcsInfo {
+  vcsRoot: string | null;
+  vcsBranch: string | null;
+  vcsDirty: boolean;
+}
+
+// Single-quote a string for safe embedding in a `/bin/zsh -lc` argument.
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function run(cmd: string): { ok: boolean; stdout: string } {
+  try {
+    const stdout = execFileSync('/bin/zsh', ['-lc', cmd], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    });
+    return { ok: true, stdout };
+  } catch {
+    return { ok: false, stdout: '' };
+  }
+}
+
+/**
+ * Best-effort git working-tree probe for a project cwd.
+ *
+ * Runs via `/bin/zsh -lc` so a GUI-stripped PATH (Flutter desktop launches
+ * the embedded Node server, which inherits a sparse PATH on macOS) still
+ * resolves `git`. Returns null when the directory is not a git repo or git
+ * is unavailable. Never throws to the caller.
+ */
+export function probeVcs(cwd: string): VcsInfo | null {
+  const q = shellQuote(cwd);
+
+  const rootRes = run(`git -C ${q} rev-parse --show-toplevel`);
+  if (!rootRes.ok) return null;
+  const vcsRoot = rootRes.stdout.trim();
+  if (vcsRoot === '') return null;
+
+  // Detached HEAD: symbolic-ref exits non-zero. Treat branch as null but
+  // still return a populated record (the working tree is a real git repo).
+  const branchRes = run(`git -C ${q} symbolic-ref --quiet --short HEAD`);
+  const branch = branchRes.ok ? branchRes.stdout.trim() : '';
+  const vcsBranch = branch === '' ? null : branch;
+
+  const statusRes = run(`git -C ${q} status --porcelain`);
+  const vcsDirty = statusRes.ok && statusRes.stdout.trim().length > 0;
+
+  return { vcsRoot, vcsBranch, vcsDirty };
+}

--- a/apps/api_server/src/services/vcs_probe.ts
+++ b/apps/api_server/src/services/vcs_probe.ts
@@ -6,16 +6,21 @@ export interface VcsInfo {
   vcsDirty: boolean;
 }
 
-// Single-quote a string for safe embedding in a `/bin/zsh -lc` argument.
-function shellQuote(s: string): string {
-  return `'${s.replace(/'/g, `'\\''`)}'`;
-}
-
-function run(cmd: string): { ok: boolean; stdout: string } {
+function runGit(args: string[], cwd: string): { ok: boolean; stdout: string } {
   try {
-    const stdout = execFileSync('/bin/zsh', ['-lc', cmd], {
+    const stdout = execFileSync('git', args, {
+      cwd,
       stdio: ['ignore', 'pipe', 'ignore'],
       encoding: 'utf8',
+      // Augment PATH so GUI-launched Node (Flutter desktop spawns the embedded
+      // server with a stripped PATH on macOS) can still find git in standard
+      // system locations.
+      env: {
+        ...process.env,
+        PATH: [process.env.PATH, '/usr/bin', '/usr/local/bin', '/opt/homebrew/bin']
+          .filter(Boolean)
+          .join(':'),
+      },
     });
     return { ok: true, stdout };
   } catch {
@@ -24,28 +29,20 @@ function run(cmd: string): { ok: boolean; stdout: string } {
 }
 
 /**
- * Best-effort git working-tree probe for a project cwd.
- *
- * Runs via `/bin/zsh -lc` so a GUI-stripped PATH (Flutter desktop launches
- * the embedded Node server, which inherits a sparse PATH on macOS) still
- * resolves `git`. Returns null when the directory is not a git repo or git
- * is unavailable. Never throws to the caller.
+ * Best-effort git working-tree probe for a project cwd. Returns null when the
+ * directory is not a git repo or git is unavailable. Never throws.
  */
 export function probeVcs(cwd: string): VcsInfo | null {
-  const q = shellQuote(cwd);
-
-  const rootRes = run(`git -C ${q} rev-parse --show-toplevel`);
+  const rootRes = runGit(['-C', cwd, 'rev-parse', '--show-toplevel'], cwd);
   if (!rootRes.ok) return null;
   const vcsRoot = rootRes.stdout.trim();
   if (vcsRoot === '') return null;
 
-  // Detached HEAD: symbolic-ref exits non-zero. Treat branch as null but
-  // still return a populated record (the working tree is a real git repo).
-  const branchRes = run(`git -C ${q} symbolic-ref --quiet --short HEAD`);
+  const branchRes = runGit(['-C', cwd, 'symbolic-ref', '--quiet', '--short', 'HEAD'], cwd);
   const branch = branchRes.ok ? branchRes.stdout.trim() : '';
   const vcsBranch = branch === '' ? null : branch;
 
-  const statusRes = run(`git -C ${q} status --porcelain`);
+  const statusRes = runGit(['-C', cwd, 'status', '--porcelain'], cwd);
   const vcsDirty = statusRes.ok && statusRes.stdout.trim().length > 0;
 
   return { vcsRoot, vcsBranch, vcsDirty };

--- a/apps/desktop_flutter/lib/features/agent_projects/controllers/agent_projects_controller.dart
+++ b/apps/desktop_flutter/lib/features/agent_projects/controllers/agent_projects_controller.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/agent_project.dart';
+import '../repositories/agent_projects_repository.dart';
+
+enum AgentProjectsLoadStatus { idle, loading, error }
+
+/// Owns the local list of agent projects and the currently-selected one.
+///
+/// `selectedProjectId == null` corresponds to the "All sessions" pseudo-project
+/// at the top of the sidebar rail (M1-5).
+class AgentProjectsController extends ChangeNotifier {
+  AgentProjectsController(this._repository);
+
+  final AgentProjectsRepository _repository;
+
+  List<AgentProject> _projects = const [];
+  List<AgentProject> get projects => List.unmodifiable(_projects);
+
+  String? _selectedProjectId;
+  String? get selectedProjectId => _selectedProjectId;
+
+  AgentProject? get selectedProject {
+    final id = _selectedProjectId;
+    if (id == null) return null;
+    for (final p in _projects) {
+      if (p.id == id) return p;
+    }
+    return null;
+  }
+
+  AgentProjectsLoadStatus _status = AgentProjectsLoadStatus.idle;
+  AgentProjectsLoadStatus get status => _status;
+
+  String? _error;
+  String? get error => _error;
+
+  Future<void> load({bool includeArchived = false}) async {
+    _status = AgentProjectsLoadStatus.loading;
+    _error = null;
+    notifyListeners();
+    try {
+      _projects = await _repository.list(includeArchived: includeArchived);
+      _status = AgentProjectsLoadStatus.idle;
+    } catch (e) {
+      _error = e.toString();
+      _status = AgentProjectsLoadStatus.error;
+    }
+    notifyListeners();
+  }
+
+  Future<AgentProject> create({
+    required String name,
+    required String cwd,
+    String? icon,
+  }) async {
+    final created = await _repository.create(name: name, cwd: cwd, icon: icon);
+    _projects = [created, ..._projects];
+    notifyListeners();
+    return created;
+  }
+
+  Future<AgentProject> update(
+    String id, {
+    String? name,
+    String? cwd,
+    String? icon,
+    DateTime? archivedAt,
+    bool clearArchivedAt = false,
+  }) async {
+    final updated = await _repository.update(
+      id,
+      name: name,
+      cwd: cwd,
+      icon: icon,
+      archivedAt: archivedAt,
+      clearArchivedAt: clearArchivedAt,
+    );
+    _replaceById(updated);
+    notifyListeners();
+    return updated;
+  }
+
+  Future<void> archive(String id) async {
+    final updated = await _repository.update(id, archivedAt: DateTime.now());
+    // archive removes from the visible list (load() filters archived by default).
+    _projects = _projects.where((p) => p.id != updated.id).toList();
+    if (_selectedProjectId == id) {
+      _selectedProjectId = null;
+    }
+    notifyListeners();
+  }
+
+  Future<void> delete(String id) async {
+    await _repository.delete(id);
+    _projects = _projects.where((p) => p.id != id).toList();
+    if (_selectedProjectId == id) {
+      _selectedProjectId = null;
+    }
+    notifyListeners();
+  }
+
+  Future<AgentProject> refreshVcs(String id) async {
+    final updated = await _repository.refreshVcs(id);
+    _replaceById(updated);
+    notifyListeners();
+    return updated;
+  }
+
+  void select(String? id) {
+    if (_selectedProjectId == id) return;
+    _selectedProjectId = id;
+    notifyListeners();
+  }
+
+  void _replaceById(AgentProject updated) {
+    final idx = _projects.indexWhere((p) => p.id == updated.id);
+    if (idx >= 0) {
+      final next = List<AgentProject>.from(_projects);
+      next[idx] = updated;
+      _projects = next;
+    }
+  }
+}

--- a/apps/desktop_flutter/lib/features/agent_projects/data/agent_projects_remote_data_source.dart
+++ b/apps/desktop_flutter/lib/features/agent_projects/data/agent_projects_remote_data_source.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../../../app/core/constants/app_constants.dart';
+import '../../../app/core/utils/http_utils.dart';
+import '../models/agent_project.dart';
+
+/// HTTP client for the embedded api_server's /projects endpoints.
+///
+/// Targets `AppConstants.agentLocalBaseUrl` (localhost:4001), never the
+/// user-configured production server. Projects are local-only data tied
+/// to the embedded api_server's SQLite store.
+class AgentProjectsRemoteDataSource {
+  AgentProjectsRemoteDataSource({http.Client? client})
+      : _client = client ?? http.Client(),
+        _baseUrl = AppConstants.agentLocalBaseUrl;
+
+  final http.Client _client;
+  final String _baseUrl;
+
+  Future<List<AgentProject>> list({bool includeArchived = false}) async {
+    final uri = Uri.parse('$_baseUrl/projects').replace(
+      queryParameters: includeArchived ? {'includeArchived': 'true'} : null,
+    );
+    final response = await _client.get(uri);
+    assertOk(response);
+    final list = jsonDecode(response.body) as List<dynamic>;
+    return list
+        .map((j) => AgentProject.fromJson(j as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<AgentProject> create({
+    required String name,
+    required String cwd,
+    String? icon,
+  }) async {
+    final response = await _client.post(
+      Uri.parse('$_baseUrl/projects'),
+      headers: const {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'name': name,
+        'cwd': cwd,
+        if (icon != null) 'icon': icon,
+      }),
+    );
+    assertOk(response);
+    return AgentProject.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+  }
+
+  Future<AgentProject> update(
+    String id, {
+    String? name,
+    String? cwd,
+    String? icon,
+    DateTime? archivedAt,
+    bool clearArchivedAt = false,
+  }) async {
+    final payload = <String, dynamic>{};
+    if (name != null) payload['name'] = name;
+    if (cwd != null) payload['cwd'] = cwd;
+    if (icon != null) payload['icon'] = icon;
+    if (clearArchivedAt) {
+      payload['archivedAt'] = null;
+    } else if (archivedAt != null) {
+      payload['archivedAt'] = archivedAt.toUtc().toIso8601String();
+    }
+    final response = await _client.patch(
+      Uri.parse('$_baseUrl/projects/$id'),
+      headers: const {'Content-Type': 'application/json'},
+      body: jsonEncode(payload),
+    );
+    assertOk(response);
+    return AgentProject.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+  }
+
+  Future<void> delete(String id) async {
+    final response = await _client.delete(Uri.parse('$_baseUrl/projects/$id'));
+    if (response.statusCode != 204) {
+      assertOk(response);
+    }
+  }
+
+  Future<AgentProject> refreshVcs(String id) async {
+    final response = await _client.post(
+      Uri.parse('$_baseUrl/projects/$id/refresh-vcs'),
+    );
+    assertOk(response);
+    return AgentProject.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+  }
+}

--- a/apps/desktop_flutter/lib/features/agent_projects/models/agent_project.dart
+++ b/apps/desktop_flutter/lib/features/agent_projects/models/agent_project.dart
@@ -1,0 +1,85 @@
+import '../../../app/core/utils/json_parsing.dart';
+
+/// Client-side model mirroring api_server's `Project` entity.
+///
+/// VCS fields are read-only — the server is the single source of truth.
+/// The controller never mutates them locally except via `fromJson`.
+class AgentProject {
+  const AgentProject({
+    required this.id,
+    required this.name,
+    required this.cwd,
+    this.icon,
+    this.vcsRoot,
+    this.vcsBranch,
+    this.vcsDirty = false,
+    this.vcsCheckedAt,
+    required this.createdAt,
+    this.archivedAt,
+  });
+
+  final String id;
+  final String name;
+  final String cwd;
+  final String? icon;
+  final String? vcsRoot;
+  final String? vcsBranch;
+  final bool vcsDirty;
+  final DateTime? vcsCheckedAt;
+  final DateTime createdAt;
+  final DateTime? archivedAt;
+
+  factory AgentProject.fromJson(Map<String, dynamic> json) {
+    return AgentProject(
+      id: asString(json['id']) ?? '',
+      name: asString(json['name']) ?? '',
+      cwd: asString(json['cwd']) ?? '',
+      icon: asString(json['icon']),
+      vcsRoot: asString(json['vcsRoot']),
+      vcsBranch: asString(json['vcsBranch']),
+      vcsDirty: asBool(json['vcsDirty']) ?? false,
+      vcsCheckedAt: _parse(asString(json['vcsCheckedAt'])),
+      createdAt: _parse(asString(json['createdAt'])) ?? DateTime.utc(1970),
+      archivedAt: _parse(asString(json['archivedAt'])),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'cwd': cwd,
+        if (icon != null) 'icon': icon,
+        if (vcsRoot != null) 'vcsRoot': vcsRoot,
+        if (vcsBranch != null) 'vcsBranch': vcsBranch,
+        'vcsDirty': vcsDirty,
+        if (vcsCheckedAt != null)
+          'vcsCheckedAt': vcsCheckedAt!.toUtc().toIso8601String(),
+        'createdAt': createdAt.toUtc().toIso8601String(),
+        if (archivedAt != null)
+          'archivedAt': archivedAt!.toUtc().toIso8601String(),
+      };
+
+  AgentProject copyWith({
+    String? name,
+    String? cwd,
+    String? icon,
+    DateTime? archivedAt,
+  }) =>
+      AgentProject(
+        id: id,
+        name: name ?? this.name,
+        cwd: cwd ?? this.cwd,
+        icon: icon ?? this.icon,
+        vcsRoot: vcsRoot,
+        vcsBranch: vcsBranch,
+        vcsDirty: vcsDirty,
+        vcsCheckedAt: vcsCheckedAt,
+        createdAt: createdAt,
+        archivedAt: archivedAt ?? this.archivedAt,
+      );
+
+  static DateTime? _parse(String? raw) {
+    if (raw == null) return null;
+    return DateTime.tryParse(raw);
+  }
+}

--- a/apps/desktop_flutter/lib/features/agent_projects/repositories/agent_projects_repository.dart
+++ b/apps/desktop_flutter/lib/features/agent_projects/repositories/agent_projects_repository.dart
@@ -1,0 +1,39 @@
+import '../data/agent_projects_remote_data_source.dart';
+import '../models/agent_project.dart';
+
+class AgentProjectsRepository {
+  AgentProjectsRepository(this._remote);
+
+  final AgentProjectsRemoteDataSource _remote;
+
+  Future<List<AgentProject>> list({bool includeArchived = false}) =>
+      _remote.list(includeArchived: includeArchived);
+
+  Future<AgentProject> create({
+    required String name,
+    required String cwd,
+    String? icon,
+  }) =>
+      _remote.create(name: name, cwd: cwd, icon: icon);
+
+  Future<AgentProject> update(
+    String id, {
+    String? name,
+    String? cwd,
+    String? icon,
+    DateTime? archivedAt,
+    bool clearArchivedAt = false,
+  }) =>
+      _remote.update(
+        id,
+        name: name,
+        cwd: cwd,
+        icon: icon,
+        archivedAt: archivedAt,
+        clearArchivedAt: clearArchivedAt,
+      );
+
+  Future<void> delete(String id) => _remote.delete(id);
+
+  Future<AgentProject> refreshVcs(String id) => _remote.refreshVcs(id);
+}

--- a/apps/desktop_flutter/lib/features/agent_projects/views/edit_project_dialog.dart
+++ b/apps/desktop_flutter/lib/features/agent_projects/views/edit_project_dialog.dart
@@ -1,0 +1,248 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../app/core/ui/tokens/rhythm_theme.dart';
+import '../controllers/agent_projects_controller.dart';
+import '../models/agent_project.dart';
+
+/// Shared create / edit project dialog. Called from the rail's `+` button
+/// (create) and from a long-press / context-menu on a rail icon (edit).
+///
+/// Folder picker UX is currently a plain text field — `file_picker` is not
+/// yet a dependency. The "Pick…" button is reserved for a follow-up; users
+/// paste/type the absolute path for now.
+///
+/// On save the dialog stays open for ~800ms to show the server's VCS probe
+/// result before dismissing.
+Future<void> showEditProjectDialog(
+  BuildContext context, {
+  AgentProject? existing,
+}) {
+  return showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (dialogCtx) => ChangeNotifierProvider.value(
+      value: context.read<AgentProjectsController>(),
+      child: _EditProjectDialog(existing: existing),
+    ),
+  );
+}
+
+class _EditProjectDialog extends StatefulWidget {
+  const _EditProjectDialog({this.existing});
+
+  final AgentProject? existing;
+
+  bool get isEdit => existing != null;
+
+  @override
+  State<_EditProjectDialog> createState() => _EditProjectDialogState();
+}
+
+class _EditProjectDialogState extends State<_EditProjectDialog> {
+  late final TextEditingController _name;
+  late final TextEditingController _cwd;
+  late final TextEditingController _icon;
+
+  AgentProject? _vcsResult;
+  String? _serverError;
+  bool _saving = false;
+  bool _showVcsConfirmation = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final e = widget.existing;
+    _name = TextEditingController(text: e?.name ?? '');
+    _cwd = TextEditingController(text: e?.cwd ?? '');
+    _icon = TextEditingController(text: e?.icon ?? '');
+    for (final c in [_name, _cwd, _icon]) {
+      c.addListener(_onChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _cwd.dispose();
+    _icon.dispose();
+    super.dispose();
+  }
+
+  void _onChanged() => setState(() {});
+
+  bool get _canSave =>
+      !_saving && _name.text.trim().isNotEmpty && _cwd.text.trim().isNotEmpty;
+
+  Future<void> _save() async {
+    final controller = context.read<AgentProjectsController>();
+    setState(() {
+      _saving = true;
+      _serverError = null;
+    });
+    try {
+      final iconValue = _icon.text.trim().isEmpty ? null : _icon.text.trim();
+      final result = widget.isEdit
+          ? await controller.update(
+              widget.existing!.id,
+              name: _name.text.trim(),
+              cwd: _cwd.text.trim(),
+              icon: iconValue,
+            )
+          : await controller.create(
+              name: _name.text.trim(),
+              cwd: _cwd.text.trim(),
+              icon: iconValue,
+            );
+      if (!mounted) return;
+      setState(() {
+        _vcsResult = result;
+        _showVcsConfirmation = true;
+        _saving = false;
+      });
+      // Hold the VCS confirmation line briefly before closing — per the spec
+      // this is intentional UX, not a server delay.
+      await Future<void>.delayed(const Duration(milliseconds: 800));
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _serverError = e.toString();
+        _saving = false;
+      });
+    }
+  }
+
+  Future<void> _archive() async {
+    final controller = context.read<AgentProjectsController>();
+    try {
+      await controller.archive(widget.existing!.id);
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _serverError = e.toString());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final title = widget.isEdit ? 'Edit project' : 'New project';
+    return AlertDialog(
+      title: Text(title),
+      content: SizedBox(
+        width: 420,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _name,
+              decoration: const InputDecoration(labelText: 'Name'),
+              autofocus: true,
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _cwd,
+                    decoration: const InputDecoration(
+                      labelText: 'Folder (absolute path)',
+                      hintText: '/Users/you/Documents/repo',
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                // Folder picker stub — needs file_picker dep (follow-up).
+                const Tooltip(
+                  message: 'Folder picker coming soon — paste path for now',
+                  child: OutlinedButton(
+                    onPressed: null,
+                    child: Text('Pick…'),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _icon,
+              decoration: const InputDecoration(
+                labelText: 'Icon (emoji or #RRGGBB)',
+                hintText: 'optional',
+              ),
+              maxLength: 7,
+            ),
+            if (_showVcsConfirmation && _vcsResult != null) ...[
+              const SizedBox(height: 8),
+              Divider(color: context.rhythm.borderSubtle),
+              const SizedBox(height: 6),
+              _VcsConfirmationLine(project: _vcsResult!),
+            ],
+            if (_serverError != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                _serverError!,
+                style: const TextStyle(color: Color(0xFFEF4444)),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        if (widget.isEdit)
+          TextButton(
+            onPressed: _saving ? null : _archive,
+            style:
+                TextButton.styleFrom(foregroundColor: const Color(0xFFEF4444)),
+            child: const Text('Archive'),
+          ),
+        TextButton(
+          onPressed: _saving ? null : () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _canSave ? _save : null,
+          child: Text(_saving ? 'Saving…' : 'Save'),
+        ),
+      ],
+    );
+  }
+}
+
+class _VcsConfirmationLine extends StatelessWidget {
+  const _VcsConfirmationLine({required this.project});
+  final AgentProject project;
+
+  @override
+  Widget build(BuildContext context) {
+    if (project.vcsRoot != null) {
+      return Row(
+        children: [
+          const Icon(Icons.check_circle_outline,
+              color: Color(0xFF10B981), size: 16),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              'Detected git branch: ${project.vcsBranch ?? '(detached)'}',
+              style: TextStyle(color: context.rhythm.textPrimary),
+            ),
+          ),
+        ],
+      );
+    }
+    return Row(
+      children: [
+        Icon(Icons.info_outline, color: context.rhythm.textMuted, size: 16),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            'No git repository at this path',
+            style: TextStyle(color: context.rhythm.textSecondary),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/desktop_flutter/lib/features/agents/models/agent_session.dart
+++ b/apps/desktop_flutter/lib/features/agents/models/agent_session.dart
@@ -26,6 +26,7 @@ class AgentSession {
     this.sessionToken,
     required this.cwd,
     required this.name,
+    this.projectId,
     this.lastPreview,
     this.lastActivityAt,
     required this.createdAt,
@@ -39,6 +40,7 @@ class AgentSession {
   final String? sessionToken;
   final String cwd;
   final String name;
+  final String? projectId;
   final String? lastPreview;
   final DateTime? lastActivityAt;
   final DateTime createdAt;
@@ -60,6 +62,7 @@ class AgentSession {
       sessionToken: asString(json['sessionToken']),
       cwd: asString(json['cwd']) ?? '',
       name: asString(json['name']) ?? '',
+      projectId: asString(json['projectId']),
       lastPreview: asString(json['lastPreview']),
       lastActivityAt: _parseDateTime(asString(json['lastActivityAt'])),
       createdAt: _parseDateTime(asString(json['createdAt'])) ?? _epoch,
@@ -76,6 +79,7 @@ class AgentSession {
       if (sessionToken != null) 'sessionToken': sessionToken,
       'cwd': cwd,
       'name': name,
+      if (projectId != null) 'projectId': projectId,
       if (lastPreview != null) 'lastPreview': lastPreview,
       if (lastActivityAt != null)
         'lastActivityAt': lastActivityAt!.toUtc().toIso8601String(),

--- a/apps/desktop_flutter/lib/features/agents/views/_project_vcs_chip.dart
+++ b/apps/desktop_flutter/lib/features/agents/views/_project_vcs_chip.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+
+import '../../../app/core/ui/tokens/rhythm_theme.dart';
+import '../../agent_projects/models/agent_project.dart';
+
+/// Rounded chip showing the selected project's git branch + a dirty-state
+/// dot. Hidden when the project is not a git repo.
+///
+/// Tap fires [onRefresh] (typically `controller.refreshVcs(project.id)`).
+class ProjectVcsChip extends StatelessWidget {
+  const ProjectVcsChip({
+    super.key,
+    required this.project,
+    this.onRefresh,
+  });
+
+  final AgentProject project;
+  final VoidCallback? onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    if (project.vcsRoot == null) return const SizedBox.shrink();
+
+    final branch = project.vcsBranch ?? '(detached)';
+    final tooltipLines = <String>[
+      'Branch: ${project.vcsBranch ?? '(detached)'}',
+      'Root: ${project.vcsRoot}',
+      if (project.vcsCheckedAt != null)
+        'Last checked: ${_relative(project.vcsCheckedAt!)}',
+    ];
+
+    return Tooltip(
+      message: tooltipLines.join('\n'),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(999),
+        onTap: onRefresh,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+          decoration: BoxDecoration(
+            color: context.rhythm.surfaceRaised,
+            border: Border.all(color: context.rhythm.border),
+            borderRadius: BorderRadius.circular(999),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.call_split_rounded,
+                size: 12,
+                color: context.rhythm.textMuted,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                branch,
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: context.rhythm.textPrimary,
+                ),
+              ),
+              const SizedBox(width: 6),
+              _DirtyDot(dirty: project.vcsDirty),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _relative(DateTime at) {
+    final diff = DateTime.now().difference(at);
+    if (diff.inMinutes < 1) return 'just now';
+    if (diff.inHours < 1) return '${diff.inMinutes}m ago';
+    if (diff.inDays < 1) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
+  }
+}
+
+class _DirtyDot extends StatelessWidget {
+  const _DirtyDot({required this.dirty});
+  final bool dirty;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: dirty ? const Color(0xFFEF4444) : Colors.transparent,
+        border: Border.all(
+          color: dirty ? const Color(0xFFEF4444) : context.rhythm.textMuted,
+          width: 1.5,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/desktop_flutter/lib/features/agents/views/_projects_rail.dart
+++ b/apps/desktop_flutter/lib/features/agents/views/_projects_rail.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../app/core/ui/tokens/rhythm_theme.dart';
+import '../../agent_projects/controllers/agent_projects_controller.dart';
+import '../../agent_projects/models/agent_project.dart';
+
+/// 64px sidebar rail listing agent projects.
+///
+/// Layout: ⭐ All-sessions pseudo-project, divider, one icon per project,
+/// `+` button at the bottom. Selected entry uses the primary-tint background
+/// from theme tokens.
+class ProjectsRail extends StatelessWidget {
+  const ProjectsRail({super.key, this.onAddProject});
+
+  /// Called when the user taps the `+` button. M1-6 wires this to the
+  /// create-project dialog; M1-5 ships a no-op placeholder until then.
+  final VoidCallback? onAddProject;
+
+  static const double railWidth = 64;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<AgentProjectsController>();
+    final selectedId = controller.selectedProjectId;
+
+    return Container(
+      width: railWidth,
+      decoration: BoxDecoration(
+        color: context.rhythm.surfaceRaised,
+        borderRadius: BorderRadius.circular(RhythmRadius.xl),
+        border: Border.all(color: context.rhythm.border),
+        boxShadow: RhythmElevation.panel,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Column(
+          children: [
+            _RailItem(
+              tooltip: 'All sessions',
+              selected: selectedId == null,
+              onTap: () => controller.select(null),
+              child: const Icon(Icons.star_rounded, size: 22),
+            ),
+            const SizedBox(height: 6),
+            Divider(
+              color: context.rhythm.borderSubtle,
+              indent: 12,
+              endIndent: 12,
+              height: 8,
+            ),
+            const SizedBox(height: 6),
+            Expanded(
+              child: ListView.separated(
+                padding: const EdgeInsets.symmetric(vertical: 2),
+                itemCount: controller.projects.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 12),
+                itemBuilder: (_, i) {
+                  final p = controller.projects[i];
+                  return _RailItem(
+                    tooltip: p.name,
+                    selected: p.id == selectedId,
+                    onTap: () => controller.select(p.id),
+                    child: _ProjectIcon(project: p),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 6),
+            Divider(
+              color: context.rhythm.borderSubtle,
+              indent: 12,
+              endIndent: 12,
+              height: 8,
+            ),
+            const SizedBox(height: 6),
+            _RailItem(
+              tooltip: 'New project',
+              selected: false,
+              onTap: onAddProject,
+              child: Icon(
+                Icons.add_rounded,
+                size: 22,
+                color: context.rhythm.textMuted,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _RailItem extends StatelessWidget {
+  const _RailItem({
+    required this.tooltip,
+    required this.selected,
+    required this.onTap,
+    required this.child,
+  });
+
+  final String tooltip;
+  final bool selected;
+  final VoidCallback? onTap;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedBg = const Color(0x144F6AF5);
+    final button = SizedBox(
+      width: 40,
+      height: 40,
+      child: Material(
+        color: selected ? selectedBg : Colors.transparent,
+        borderRadius: BorderRadius.circular(10),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(10),
+          onTap: onTap,
+          child: Center(child: child),
+        ),
+      ),
+    );
+    return Tooltip(message: tooltip, child: Center(child: button));
+  }
+}
+
+class _ProjectIcon extends StatelessWidget {
+  const _ProjectIcon({required this.project});
+
+  final AgentProject project;
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = project.icon;
+    if (icon != null && icon.startsWith('#') && icon.length == 7) {
+      final color = _tryParseHex(icon);
+      if (color != null) {
+        return CircleAvatar(radius: 12, backgroundColor: color);
+      }
+    }
+    if (icon != null && icon.trim().isNotEmpty) {
+      return Text(icon, style: const TextStyle(fontSize: 18));
+    }
+    // Default fallback — folder glyph.
+    return const Text('📁', style: TextStyle(fontSize: 18));
+  }
+
+  static Color? _tryParseHex(String hex) {
+    final v = int.tryParse(hex.substring(1), radix: 16);
+    if (v == null) return null;
+    return Color(0xFF000000 | v);
+  }
+}

--- a/apps/desktop_flutter/lib/features/agents/views/_projects_rail.dart
+++ b/apps/desktop_flutter/lib/features/agents/views/_projects_rail.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../../../app/core/ui/tokens/rhythm_theme.dart';
 import '../../agent_projects/controllers/agent_projects_controller.dart';
 import '../../agent_projects/models/agent_project.dart';
+import '../../agent_projects/views/edit_project_dialog.dart';
 
 /// 64px sidebar rail listing agent projects.
 ///
@@ -55,13 +56,18 @@ class ProjectsRail extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(vertical: 2),
                 itemCount: controller.projects.length,
                 separatorBuilder: (_, __) => const SizedBox(height: 12),
-                itemBuilder: (_, i) {
+                itemBuilder: (ctx, i) {
                   final p = controller.projects[i];
-                  return _RailItem(
-                    tooltip: p.name,
-                    selected: p.id == selectedId,
-                    onTap: () => controller.select(p.id),
-                    child: _ProjectIcon(project: p),
+                  return GestureDetector(
+                    onLongPress: () => showEditProjectDialog(ctx, existing: p),
+                    onSecondaryTap: () =>
+                        showEditProjectDialog(ctx, existing: p),
+                    child: _RailItem(
+                      tooltip: p.name,
+                      selected: p.id == selectedId,
+                      onTap: () => controller.select(p.id),
+                      child: _ProjectIcon(project: p),
+                    ),
                   );
                 },
               ),

--- a/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
+++ b/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
@@ -14,6 +14,7 @@ import '../../agent_configs/widgets/agent_icon.dart';
 import '../../tasks/controllers/tasks_controller.dart';
 import '../../tasks/models/task.dart';
 import '../../agent_projects/controllers/agent_projects_controller.dart';
+import '../../agent_projects/views/edit_project_dialog.dart';
 import '../controllers/agents_controller.dart';
 import '../models/agent_session.dart';
 import '../models/agent_session_message.dart';
@@ -86,23 +87,8 @@ class _AgentsViewState extends State<AgentsView> {
     );
   }
 
-  // Placeholder until M1-6's EditProjectDialog lands. Keeps the rail's `+`
-  // button visibly responsive; replace this method when M1-6 ships.
-  // TODO(M1-6): swap for showEditProjectDialog(create: true, ...).
   void _showNewProjectDialog(BuildContext context) {
-    showDialog<void>(
-      context: context,
-      builder: (_) => AlertDialog(
-        title: const Text('New project'),
-        content: const Text('Project creation lands in M1-6.'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('OK'),
-          ),
-        ],
-      ),
-    );
+    showEditProjectDialog(context);
   }
 }
 

--- a/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
+++ b/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
@@ -13,10 +13,13 @@ import '../../settings/views/settings_view.dart';
 import '../../agent_configs/widgets/agent_icon.dart';
 import '../../tasks/controllers/tasks_controller.dart';
 import '../../tasks/models/task.dart';
+import '../../agent_projects/controllers/agent_projects_controller.dart';
 import '../controllers/agents_controller.dart';
 import '../models/agent_session.dart';
 import '../models/agent_session_message.dart';
 import '../models/chat_models.dart';
+import '_project_vcs_chip.dart';
+import '_projects_rail.dart';
 
 class AgentsView extends StatefulWidget {
   const AgentsView({super.key});
@@ -64,6 +67,10 @@ class _AgentsViewState extends State<AgentsView> {
           padding: const EdgeInsets.all(12),
           child: Row(
             children: [
+              ProjectsRail(
+                onAddProject: () => _showNewProjectDialog(context),
+              ),
+              const SizedBox(width: 12),
               _SessionListPanel(
                 resumableSectionExpanded: _resumableSectionExpanded,
                 onToggleResumable: () => setState(
@@ -75,6 +82,25 @@ class _AgentsViewState extends State<AgentsView> {
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  // Placeholder until M1-6's EditProjectDialog lands. Keeps the rail's `+`
+  // button visibly responsive; replace this method when M1-6 ships.
+  // TODO(M1-6): swap for showEditProjectDialog(create: true, ...).
+  void _showNewProjectDialog(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('New project'),
+        content: const Text('Project creation lands in M1-6.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
       ),
     );
   }
@@ -260,8 +286,18 @@ class _SessionListPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     final controller = context.watch<AgentsController>();
     final agentServerController = context.watch<AgentServerController>();
+    final projectsController = context.watch<AgentProjectsController>();
     final canStartSession =
         agentServerController.isReady && agentServerController.hasAnyAgent;
+
+    final selectedProject = projectsController.selectedProject;
+    final selectedProjectId = projectsController.selectedProjectId;
+    // selectedProjectId == null → All sessions (no filter). Otherwise filter.
+    final filteredSessions = selectedProjectId == null
+        ? controller.sessions
+        : controller.sessions
+            .where((s) => s.projectId == selectedProjectId)
+            .toList();
 
     return Container(
       width: 320,
@@ -278,23 +314,35 @@ class _SessionListPanel extends StatelessWidget {
             onNewSession:
                 canStartSession ? () => _showNewSessionDialog(context) : null,
           ),
+          if (selectedProject != null && selectedProject.vcsRoot != null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: ProjectVcsChip(
+                  project: selectedProject,
+                  onRefresh: () =>
+                      projectsController.refreshVcs(selectedProject.id),
+                ),
+              ),
+            ),
           Divider(height: 1, color: context.rhythm.borderSubtle),
           const _DisconnectedBanner(),
           Expanded(
             child: controller.status == AgentsLoadStatus.loading &&
-                    controller.sessions.isEmpty
+                    filteredSessions.isEmpty
                 ? Center(
                     child: CircularProgressIndicator(
                       color: context.rhythm.accent,
                     ),
                   )
-                : controller.sessions.isEmpty && controller.resumable.isEmpty
+                : filteredSessions.isEmpty && controller.resumable.isEmpty
                     ? const _EmptySessionsState()
                     : ListView(
                         padding: const EdgeInsets.fromLTRB(12, 12, 12, 14),
                         children: [
-                          // Active sessions
-                          for (final session in controller.sessions) ...[
+                          // Active sessions (filtered by selected project).
+                          for (final session in filteredSessions) ...[
                             _SessionRow(
                               session: session,
                               isSelected:

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -53,6 +53,9 @@ import 'app/core/workspace/workspace_repository.dart';
 import 'features/notifications/controllers/notifications_controller.dart';
 import 'features/notifications/data/notifications_data_source.dart';
 import 'features/notifications/repositories/notifications_repository.dart';
+import 'features/agent_projects/controllers/agent_projects_controller.dart';
+import 'features/agent_projects/data/agent_projects_remote_data_source.dart';
+import 'features/agent_projects/repositories/agent_projects_repository.dart';
 import 'features/agents/controllers/agents_controller.dart';
 import 'features/agents/data/agents_data_source.dart';
 import 'features/agents/repositories/agents_repository.dart';
@@ -209,6 +212,11 @@ class RhythmApp extends StatelessWidget {
         ChangeNotifierProvider(
           create: (_) => NotificationsController(
             NotificationsRepository(NotificationsDataSource(baseUrl: baseUrl)),
+          ),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => AgentProjectsController(
+            AgentProjectsRepository(AgentProjectsRemoteDataSource()),
           ),
         ),
         ChangeNotifierProvider(

--- a/apps/desktop_flutter/test/features/agent_projects/agent_projects_controller_test.dart
+++ b/apps/desktop_flutter/test/features/agent_projects/agent_projects_controller_test.dart
@@ -1,0 +1,198 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rhythm_desktop/features/agent_projects/controllers/agent_projects_controller.dart';
+import 'package:rhythm_desktop/features/agent_projects/data/agent_projects_remote_data_source.dart';
+import 'package:rhythm_desktop/features/agent_projects/models/agent_project.dart';
+import 'package:rhythm_desktop/features/agent_projects/repositories/agent_projects_repository.dart';
+
+class _FakeRemote extends AgentProjectsRemoteDataSource {
+  _FakeRemote() : super();
+
+  final List<AgentProject> store = [];
+  bool failNextList = false;
+
+  AgentProject _build({
+    required String id,
+    required String name,
+    String cwd = '/tmp/x',
+    String? icon,
+    String? vcsRoot,
+    String? vcsBranch,
+    bool vcsDirty = false,
+    DateTime? archivedAt,
+  }) =>
+      AgentProject(
+        id: id,
+        name: name,
+        cwd: cwd,
+        icon: icon,
+        vcsRoot: vcsRoot,
+        vcsBranch: vcsBranch,
+        vcsDirty: vcsDirty,
+        vcsCheckedAt: DateTime.utc(2026),
+        createdAt: DateTime.utc(2026),
+        archivedAt: archivedAt,
+      );
+
+  @override
+  Future<List<AgentProject>> list({bool includeArchived = false}) async {
+    if (failNextList) {
+      failNextList = false;
+      throw Exception('boom');
+    }
+    if (includeArchived) return List.of(store);
+    return store.where((p) => p.archivedAt == null).toList();
+  }
+
+  @override
+  Future<AgentProject> create({
+    required String name,
+    required String cwd,
+    String? icon,
+  }) async {
+    final p =
+        _build(id: 'id-${store.length}', name: name, cwd: cwd, icon: icon);
+    store.add(p);
+    return p;
+  }
+
+  @override
+  Future<AgentProject> update(
+    String id, {
+    String? name,
+    String? cwd,
+    String? icon,
+    DateTime? archivedAt,
+    bool clearArchivedAt = false,
+  }) async {
+    final idx = store.indexWhere((p) => p.id == id);
+    final cur = store[idx];
+    final next = _build(
+      id: id,
+      name: name ?? cur.name,
+      cwd: cwd ?? cur.cwd,
+      icon: icon ?? cur.icon,
+      vcsRoot: cur.vcsRoot,
+      vcsBranch: cur.vcsBranch,
+      vcsDirty: cur.vcsDirty,
+      archivedAt: clearArchivedAt ? null : (archivedAt ?? cur.archivedAt),
+    );
+    store[idx] = next;
+    return next;
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    store.removeWhere((p) => p.id == id);
+  }
+
+  @override
+  Future<AgentProject> refreshVcs(String id) async {
+    final idx = store.indexWhere((p) => p.id == id);
+    final cur = store[idx];
+    final next = _build(
+      id: id,
+      name: cur.name,
+      cwd: cur.cwd,
+      vcsRoot: '/refreshed',
+      vcsBranch: 'main',
+      vcsDirty: true,
+    );
+    store[idx] = next;
+    return next;
+  }
+}
+
+void main() {
+  late _FakeRemote remote;
+  late AgentProjectsController controller;
+
+  setUp(() {
+    remote = _FakeRemote();
+    controller = AgentProjectsController(AgentProjectsRepository(remote));
+  });
+
+  test('load() populates projects on success', () async {
+    remote.store.add(AgentProject(
+      id: 'a',
+      name: 'A',
+      cwd: '/x',
+      createdAt: DateTime.utc(2026),
+    ));
+    await controller.load();
+    expect(controller.status, AgentProjectsLoadStatus.idle);
+    expect(controller.projects.single.id, 'a');
+  });
+
+  test('load() sets error on failure', () async {
+    remote.failNextList = true;
+    await controller.load();
+    expect(controller.status, AgentProjectsLoadStatus.error);
+    expect(controller.error, isNotNull);
+  });
+
+  test('create() appends to in-memory list and notifies', () async {
+    var notified = 0;
+    controller.addListener(() => notified++);
+    final p = await controller.create(name: 'New', cwd: '/tmp/n');
+    expect(controller.projects, contains(p));
+    expect(notified, greaterThan(0));
+  });
+
+  test('update() replaces matching project by id', () async {
+    final p = await controller.create(name: 'Old', cwd: '/tmp/u');
+    final updated = await controller.update(p.id, name: 'New');
+    expect(updated.name, 'New');
+    expect(controller.projects.single.name, 'New');
+  });
+
+  test('archive() removes from visible list and notifies', () async {
+    final p = await controller.create(name: 'Bye', cwd: '/tmp/a');
+    controller.select(p.id);
+    await controller.archive(p.id);
+    expect(controller.projects.where((q) => q.id == p.id), isEmpty);
+    expect(controller.selectedProjectId, isNull);
+  });
+
+  test('delete() removes from list and notifies', () async {
+    final p = await controller.create(name: 'Doomed', cwd: '/tmp/d');
+    await controller.delete(p.id);
+    expect(controller.projects.where((q) => q.id == p.id), isEmpty);
+  });
+
+  test('refreshVcs() updates VCS fields in place', () async {
+    final p = await controller.create(name: 'V', cwd: '/tmp/v');
+    final refreshed = await controller.refreshVcs(p.id);
+    expect(refreshed.vcsRoot, '/refreshed');
+    expect(controller.projects.single.vcsBranch, 'main');
+  });
+
+  test('select() updates selectedProjectId and notifies; null switches to All',
+      () {
+    var notified = 0;
+    controller.addListener(() => notified++);
+    controller.select('abc');
+    expect(controller.selectedProjectId, 'abc');
+    expect(notified, 1);
+    controller.select(null);
+    expect(controller.selectedProjectId, isNull);
+    expect(notified, 2);
+  });
+
+  test('AgentProject.fromJson round-trips nullable VCS fields', () {
+    final p = AgentProject.fromJson({
+      'id': 'x',
+      'name': 'n',
+      'cwd': '/a',
+      'icon': null,
+      'vcsRoot': null,
+      'vcsBranch': null,
+      'vcsDirty': false,
+      'vcsCheckedAt': null,
+      'createdAt': '2026-05-14T00:00:00.000Z',
+      'archivedAt': null,
+    });
+    expect(p.vcsRoot, isNull);
+    expect(p.vcsBranch, isNull);
+    expect(p.vcsDirty, isFalse);
+  });
+}

--- a/apps/desktop_flutter/test/features/agent_projects/edit_project_dialog_test.dart
+++ b/apps/desktop_flutter/test/features/agent_projects/edit_project_dialog_test.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:rhythm_desktop/features/agent_projects/controllers/agent_projects_controller.dart';
+import 'package:rhythm_desktop/features/agent_projects/data/agent_projects_remote_data_source.dart';
+import 'package:rhythm_desktop/features/agent_projects/models/agent_project.dart';
+import 'package:rhythm_desktop/features/agent_projects/repositories/agent_projects_repository.dart';
+import 'package:rhythm_desktop/features/agent_projects/views/edit_project_dialog.dart';
+
+class _Remote extends AgentProjectsRemoteDataSource {
+  _Remote() : super();
+
+  bool failNextWrite = false;
+  String? createdWith;
+  String? updatedId;
+  String? archivedId;
+  bool returnGit = true;
+
+  AgentProject _make({
+    String id = 'new-id',
+    String name = 'P',
+    String cwd = '/tmp/p',
+    String? icon,
+    bool git = true,
+    DateTime? archivedAt,
+  }) =>
+      AgentProject(
+        id: id,
+        name: name,
+        cwd: cwd,
+        icon: icon,
+        vcsRoot: git ? '/tmp/p' : null,
+        vcsBranch: git ? 'main' : null,
+        vcsDirty: false,
+        vcsCheckedAt: DateTime.utc(2026),
+        createdAt: DateTime.utc(2026),
+        archivedAt: archivedAt,
+      );
+
+  @override
+  Future<List<AgentProject>> list({bool includeArchived = false}) async =>
+      const [];
+
+  @override
+  Future<AgentProject> create({
+    required String name,
+    required String cwd,
+    String? icon,
+  }) async {
+    if (failNextWrite) {
+      failNextWrite = false;
+      throw Exception('server boom');
+    }
+    createdWith = '$name|$cwd|$icon';
+    return _make(name: name, cwd: cwd, icon: icon, git: returnGit);
+  }
+
+  @override
+  Future<AgentProject> update(
+    String id, {
+    String? name,
+    String? cwd,
+    String? icon,
+    DateTime? archivedAt,
+    bool clearArchivedAt = false,
+  }) async {
+    if (archivedAt != null) {
+      archivedId = id;
+      return _make(id: id, archivedAt: archivedAt);
+    }
+    updatedId = id;
+    return _make(id: id, name: name ?? 'X', cwd: cwd ?? '/x', icon: icon);
+  }
+
+  @override
+  Future<void> delete(String id) async {}
+
+  @override
+  Future<AgentProject> refreshVcs(String id) async => _make(id: id);
+}
+
+AgentProject _existing() => AgentProject(
+      id: 'existing-1',
+      name: 'Existing',
+      cwd: '/tmp/existing',
+      icon: '🛠',
+      createdAt: DateTime.utc(2026),
+    );
+
+Widget _harness(AgentProjectsController controller) {
+  return ChangeNotifierProvider<AgentProjectsController>.value(
+    value: controller,
+    child: MaterialApp(
+      home: Builder(
+        builder: (ctx) => Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              onPressed: () => showEditProjectDialog(ctx),
+              child: const Text('open-create'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Widget _harnessEdit(AgentProjectsController controller, AgentProject existing) {
+  return ChangeNotifierProvider<AgentProjectsController>.value(
+    value: controller,
+    child: MaterialApp(
+      home: Builder(
+        builder: (ctx) => Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              onPressed: () => showEditProjectDialog(ctx, existing: existing),
+              child: const Text('open-edit'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('create mode renders with empty fields + Save disabled',
+      (tester) async {
+    final remote = _Remote();
+    final controller = AgentProjectsController(AgentProjectsRepository(remote));
+
+    await tester.pumpWidget(_harness(controller));
+    await tester.tap(find.text('open-create'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('New project'), findsOneWidget);
+    final saveBtn =
+        tester.widget<FilledButton>(find.widgetWithText(FilledButton, 'Save'));
+    expect(saveBtn.onPressed, isNull);
+  });
+
+  testWidgets('edit mode pre-fills + Archive button present', (tester) async {
+    final remote = _Remote();
+    final controller = AgentProjectsController(AgentProjectsRepository(remote));
+
+    await tester.pumpWidget(_harnessEdit(controller, _existing()));
+    await tester.tap(find.text('open-edit'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit project'), findsOneWidget);
+    expect(find.text('Existing'), findsOneWidget);
+    expect(find.text('/tmp/existing'), findsOneWidget);
+    expect(find.text('Archive'), findsOneWidget);
+  });
+
+  testWidgets('Save in create mode calls controller.create and shows git line',
+      (tester) async {
+    final remote = _Remote()..returnGit = true;
+    final controller = AgentProjectsController(AgentProjectsRepository(remote));
+
+    await tester.pumpWidget(_harness(controller));
+    await tester.tap(find.text('open-create'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.widgetWithText(TextField, 'Name'), 'Hello');
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Folder (absolute path)'),
+      '/tmp/hello',
+    );
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    for (var i = 0; i < 5; i++) {
+      await tester.pump();
+    }
+
+    expect(remote.createdWith, startsWith('Hello|/tmp/hello|'));
+    expect(find.textContaining('Detected git branch'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 900));
+    await tester.pumpAndSettle();
+    // Dialog auto-dismisses after the 800ms hold.
+    expect(find.text('New project'), findsNothing);
+  });
+
+  testWidgets('non-git folder shows fallback line', (tester) async {
+    final remote = _Remote()..returnGit = false;
+    final controller = AgentProjectsController(AgentProjectsRepository(remote));
+
+    await tester.pumpWidget(_harness(controller));
+    await tester.tap(find.text('open-create'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.widgetWithText(TextField, 'Name'), 'NG');
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Folder (absolute path)'),
+      '/tmp/ng',
+    );
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    for (var i = 0; i < 5; i++) {
+      await tester.pump();
+    }
+    expect(find.text('No git repository at this path'), findsOneWidget);
+    // Drain the 800ms hold timer so the dialog auto-dismisses cleanly.
+    await tester.pump(const Duration(milliseconds: 900));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('server error keeps dialog open and shows the message',
+      (tester) async {
+    final remote = _Remote()..failNextWrite = true;
+    final controller = AgentProjectsController(AgentProjectsRepository(remote));
+
+    await tester.pumpWidget(_harness(controller));
+    await tester.tap(find.text('open-create'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.widgetWithText(TextField, 'Name'), 'X');
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Folder (absolute path)'),
+      '/tmp/x',
+    );
+    await tester.pump();
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    for (var i = 0; i < 5; i++) {
+      await tester.pump();
+    }
+    expect(find.text('New project'), findsOneWidget);
+    expect(find.textContaining('server boom'), findsOneWidget);
+  });
+
+  testWidgets('Archive button in edit mode calls controller.archive',
+      (tester) async {
+    final remote = _Remote();
+    final controller = AgentProjectsController(AgentProjectsRepository(remote));
+
+    await tester.pumpWidget(_harnessEdit(controller, _existing()));
+    await tester.tap(find.text('open-edit'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Archive'));
+    await tester.pumpAndSettle();
+    expect(remote.archivedId, 'existing-1');
+  });
+}

--- a/apps/desktop_flutter/test/features/agents/new_session_dialog_error_test.dart
+++ b/apps/desktop_flutter/test/features/agents/new_session_dialog_error_test.dart
@@ -20,6 +20,10 @@ import 'package:rhythm_desktop/features/agents/views/agents_view.dart';
 import 'package:rhythm_desktop/features/notifications/controllers/notifications_controller.dart';
 import 'package:rhythm_desktop/features/notifications/data/notifications_data_source.dart';
 import 'package:rhythm_desktop/features/notifications/repositories/notifications_repository.dart';
+import 'package:rhythm_desktop/features/agent_projects/controllers/agent_projects_controller.dart';
+import 'package:rhythm_desktop/features/agent_projects/data/agent_projects_remote_data_source.dart';
+import 'package:rhythm_desktop/features/agent_projects/models/agent_project.dart';
+import 'package:rhythm_desktop/features/agent_projects/repositories/agent_projects_repository.dart';
 import 'package:rhythm_desktop/features/tasks/controllers/tasks_controller.dart';
 import 'package:rhythm_desktop/features/tasks/data/tasks_local_data_source.dart';
 import 'package:rhythm_desktop/features/tasks/models/task.dart';
@@ -191,6 +195,10 @@ Future<Widget> _buildTestApp({
     TasksRepository(_EmptyTasksLocalDataSource()),
   );
 
+  final agentProjectsController = AgentProjectsController(
+    AgentProjectsRepository(_EmptyAgentProjectsRemote()),
+  );
+
   return MultiProvider(
     providers: [
       ChangeNotifierProvider<AgentServerController>.value(
@@ -201,9 +209,19 @@ Future<Widget> _buildTestApp({
       ),
       ChangeNotifierProvider<AgentsController>.value(value: agentsController),
       ChangeNotifierProvider<TasksController>.value(value: tasksController),
+      ChangeNotifierProvider<AgentProjectsController>.value(
+        value: agentProjectsController,
+      ),
     ],
     child: const MaterialApp(home: Scaffold(body: AgentsView())),
   );
+}
+
+class _EmptyAgentProjectsRemote extends AgentProjectsRemoteDataSource {
+  _EmptyAgentProjectsRemote() : super();
+  @override
+  Future<List<AgentProject>> list({bool includeArchived = false}) async =>
+      const [];
 }
 
 class _EmptyTasksLocalDataSource extends TasksLocalDataSource {

--- a/apps/desktop_flutter/test/features/agents/project_vcs_chip_test.dart
+++ b/apps/desktop_flutter/test/features/agents/project_vcs_chip_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rhythm_desktop/features/agent_projects/models/agent_project.dart';
+import 'package:rhythm_desktop/features/agents/views/_project_vcs_chip.dart';
+
+AgentProject _proj({
+  String? vcsRoot,
+  String? vcsBranch,
+  bool vcsDirty = false,
+}) =>
+    AgentProject(
+      id: 'p',
+      name: 'P',
+      cwd: '/tmp',
+      vcsRoot: vcsRoot,
+      vcsBranch: vcsBranch,
+      vcsDirty: vcsDirty,
+      vcsCheckedAt: DateTime.utc(2026),
+      createdAt: DateTime.utc(2026),
+    );
+
+Widget _wrap(Widget w) => MaterialApp(home: Scaffold(body: Center(child: w)));
+
+void main() {
+  testWidgets('hidden when vcsRoot is null', (tester) async {
+    await tester.pumpWidget(_wrap(ProjectVcsChip(project: _proj())));
+    expect(find.byType(InkWell), findsNothing);
+  });
+
+  testWidgets('shows branch text when vcsRoot != null', (tester) async {
+    await tester.pumpWidget(_wrap(ProjectVcsChip(
+      project: _proj(vcsRoot: '/r', vcsBranch: 'main'),
+    )));
+    expect(find.text('main'), findsOneWidget);
+  });
+
+  testWidgets('shows detached label when branch null but vcsRoot set',
+      (tester) async {
+    await tester.pumpWidget(_wrap(ProjectVcsChip(
+      project: _proj(vcsRoot: '/r'),
+    )));
+    expect(find.text('(detached)'), findsOneWidget);
+  });
+
+  testWidgets('onRefresh callback invoked on tap', (tester) async {
+    var taps = 0;
+    await tester.pumpWidget(_wrap(ProjectVcsChip(
+      project: _proj(vcsRoot: '/r', vcsBranch: 'main'),
+      onRefresh: () => taps++,
+    )));
+    await tester.tap(find.byType(InkWell));
+    expect(taps, 1);
+  });
+}

--- a/apps/desktop_flutter/test/features/agents/projects_rail_test.dart
+++ b/apps/desktop_flutter/test/features/agents/projects_rail_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:rhythm_desktop/features/agent_projects/controllers/agent_projects_controller.dart';
+import 'package:rhythm_desktop/features/agent_projects/data/agent_projects_remote_data_source.dart';
+import 'package:rhythm_desktop/features/agent_projects/models/agent_project.dart';
+import 'package:rhythm_desktop/features/agent_projects/repositories/agent_projects_repository.dart';
+import 'package:rhythm_desktop/features/agents/views/_projects_rail.dart';
+
+class _StubRemote extends AgentProjectsRemoteDataSource {
+  _StubRemote(this.initial) : super();
+  final List<AgentProject> initial;
+  @override
+  Future<List<AgentProject>> list({bool includeArchived = false}) async =>
+      initial;
+}
+
+AgentProject _proj(String id, String name) => AgentProject(
+      id: id,
+      name: name,
+      cwd: '/tmp/$id',
+      createdAt: DateTime.utc(2026),
+    );
+
+Widget _wrap(Widget child, AgentProjectsController controller) {
+  return ChangeNotifierProvider<AgentProjectsController>.value(
+    value: controller,
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  testWidgets('renders one icon per project plus All-sessions + add button',
+      (tester) async {
+    final controller = AgentProjectsController(
+      AgentProjectsRepository(_StubRemote([_proj('a', 'A'), _proj('b', 'B')])),
+    );
+    await controller.load();
+
+    await tester.pumpWidget(_wrap(const ProjectsRail(), controller));
+    await tester.pump();
+
+    // Tooltips: All sessions + each project name + New project.
+    expect(find.byTooltip('All sessions'), findsOneWidget);
+    expect(find.byTooltip('A'), findsOneWidget);
+    expect(find.byTooltip('B'), findsOneWidget);
+    expect(find.byTooltip('New project'), findsOneWidget);
+  });
+
+  testWidgets('tapping a project icon selects it', (tester) async {
+    final controller = AgentProjectsController(
+      AgentProjectsRepository(_StubRemote([_proj('a', 'A')])),
+    );
+    await controller.load();
+    await tester.pumpWidget(_wrap(const ProjectsRail(), controller));
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('A'));
+    await tester.pump();
+
+    expect(controller.selectedProjectId, 'a');
+  });
+
+  testWidgets('tapping All-sessions calls select(null)', (tester) async {
+    final controller = AgentProjectsController(
+      AgentProjectsRepository(_StubRemote([_proj('a', 'A')])),
+    );
+    await controller.load();
+    controller.select('a');
+    await tester.pumpWidget(_wrap(const ProjectsRail(), controller));
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('All sessions'));
+    await tester.pump();
+
+    expect(controller.selectedProjectId, isNull);
+  });
+
+  testWidgets('add button invokes onAddProject callback', (tester) async {
+    final controller = AgentProjectsController(
+      AgentProjectsRepository(_StubRemote(const [])),
+    );
+    var clicked = 0;
+    await tester.pumpWidget(_wrap(
+      ProjectsRail(onAddProject: () => clicked++),
+      controller,
+    ));
+    await tester.tap(find.byTooltip('New project'));
+    await tester.pump();
+    expect(clicked, 1);
+  });
+}

--- a/docs/ai/generated-issues/m1-1-projects-table-crud.md
+++ b/docs/ai/generated-issues/m1-1-projects-table-crud.md
@@ -1,0 +1,111 @@
+# M1-1 — Backend: `projects` table + CRUD with VCS detection
+
+**Milestone:** M1 — Sessions ↔ Projects
+**Branch:** `m1-projects`
+**Depends on:** —
+
+## Summary
+
+Add a `projects` table to the embedded API server with full CRUD and inline VCS detection (git working-tree probe) at project create / on-demand refresh. Projects are the parent entity that future agent sessions belong to (M1-2). VCS fields (`vcs_root`, `vcs_branch`, `vcs_dirty`, `vcs_checked_at`) are populated up front per the resolved Q1 decision — non-git folders are still valid projects with NULL VCS fields.
+
+## Motivation
+
+Every later milestone (model picker per project, file tree scoped to project, diff review against a project repo, settings overrides) assumes a session belongs to a project. We need the schema right before any UI work depends on it. VCS detection is baked in now so the sidebar can surface branch/dirty from day one (no later migration).
+
+## Likely files
+
+- `apps/api_server/src/database/migrations.ts` — new `CREATE TABLE IF NOT EXISTS projects`
+- `apps/api_server/src/models/project.ts` — TypeScript interface
+- `apps/api_server/src/repositories/projects_repository.ts` — SQLite query layer
+- `apps/api_server/src/services/vcs_probe.ts` — `probeVcs(cwd): { vcsRoot, vcsBranch, vcsDirty } | null`
+- `apps/api_server/src/controllers/projects_controller.ts` — request handlers
+- `apps/api_server/src/routes/projects_routes.ts` — Express router
+- `apps/api_server/src/app.ts` — register router
+- `apps/api_server/src/__tests__/projects_routes.test.ts` — vitest suite
+- `apps/api_server/src/__tests__/vcs_probe.test.ts` — vitest for the probe in isolation
+
+## Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS projects (
+  id            TEXT PRIMARY KEY,
+  name          TEXT NOT NULL,
+  cwd           TEXT NOT NULL,
+  icon          TEXT,           -- emoji or "#hex" color string
+  vcs_root      TEXT,           -- NULL for non-git
+  vcs_branch    TEXT,           -- NULL for non-git or detached HEAD
+  vcs_dirty     INTEGER NOT NULL DEFAULT 0,
+  vcs_checked_at TEXT,          -- ISO timestamp
+  created_at    TEXT NOT NULL,
+  archived_at   TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_projects_archived ON projects(archived_at);
+```
+
+Migration is additive and idempotent.
+
+## VCS probe contract
+
+`probeVcs(cwd)` shells out via `/bin/zsh -lc` (same login-shell pattern used by `_findNode` in `ApiServerService`, so GUI-stripped PATH still finds `git`):
+
+1. `git -C <cwd> rev-parse --show-toplevel` → `vcsRoot` (if non-zero exit → return `null`)
+2. `git -C <cwd> symbolic-ref --quiet --short HEAD` → `vcsBranch` (empty / non-zero → `null`, e.g. detached HEAD)
+3. `git -C <cwd> status --porcelain` → `vcsDirty = output.trim().length > 0`
+
+Probe is best-effort: any exception returns `null`. No git binary on PATH → `null`. Never throws to the caller.
+
+## Endpoints
+
+| Method | Path | Body / Query | Response |
+|---|---|---|---|
+| `GET` | `/projects` | `?includeArchived=true` (default false) | `Project[]` |
+| `GET` | `/projects/:id` | — | `Project` |
+| `POST` | `/projects` | `{ name, cwd, icon? }` | `Project` (201, with VCS fields probed at create) |
+| `PATCH` | `/projects/:id` | `{ name?, cwd?, icon?, archivedAt? }` | `Project` (re-probes VCS if `cwd` changed) |
+| `DELETE` | `/projects/:id` | — | 204 (hard delete; soft archive is via PATCH archivedAt) |
+| `POST` | `/projects/:id/refresh-vcs` | — | `Project` (re-runs probe, updates `vcs_*` + `vcs_checked_at`) |
+
+`cwd` is stored as the absolute, expanded path (`expandHome` if it starts with `~`). The controller rejects relative paths with 400.
+
+## Acceptance criteria
+
+1. Migration runs cleanly against a fresh DB and against the existing dev DB (no data loss, idempotent).
+2. `POST /projects` with a cwd that is a git repo returns the project with `vcs_root`, `vcs_branch`, `vcs_dirty` populated.
+3. `POST /projects` with a cwd that is NOT a git repo returns the project with `vcs_root`, `vcs_branch` NULL and `vcs_dirty` `false`.
+4. `POST /projects/:id/refresh-vcs` updates VCS fields and `vcs_checked_at`.
+5. `GET /projects` returns the list in `created_at DESC` order, excluding archived rows unless `?includeArchived=true`.
+6. Relative-path cwd is rejected with 400.
+7. `ai-workflow checks --level pr` exits 0.
+
+## Required tests (vitest)
+
+`projects_routes.test.ts`:
+- POST creates a project, returns 201 + VCS fields when cwd is a git repo (use the repo root itself as fixture).
+- POST creates a project with NULL VCS fields when cwd is a non-git folder (use `os.tmpdir()` subdir).
+- POST rejects relative path with 400.
+- GET lists; GET excludes archived; GET `?includeArchived=true` includes archived.
+- PATCH archivedAt soft-archives.
+- PATCH cwd re-probes VCS.
+- DELETE removes the row.
+- POST /:id/refresh-vcs updates `vcs_checked_at` even when nothing else changed.
+
+`vcs_probe.test.ts`:
+- Returns populated fields for a git repo (probe `process.cwd()` since CI runs inside the repo).
+- Returns `null` for a non-git tmp directory.
+- `vcs_dirty` flips true when an untracked file is created and false after cleanup.
+- Detached HEAD returns `vcs_branch === null` but `vcs_root` set.
+- Missing `git` binary on PATH (mock spawn failure) returns `null` without throwing.
+
+## Data safety / out of scope
+
+- This issue does NOT add the `agent_sessions.project_id` FK — that's M1-2.
+- No Flutter changes here; all backend.
+- No production-API coupling — projects are local-only on `localhost:4001`.
+- Do not auto-create projects from existing sessions; backfill is a manual decision deferred to M1-2's NULL-tolerant FK.
+- Do not commit DB files, fixtures with absolute home paths, or any tester's local repo state.
+
+## Notes
+
+- `Project` model maps `vcs_dirty INTEGER` to `boolean` in TypeScript via `Boolean(row.vcs_dirty)`.
+- Pattern matches existing `tasks_repository.ts` / `tasks_controller.ts` — copy that structure.
+- Keep the controller thin; VCS logic stays in `services/vcs_probe.ts` so M1-2 (auto-assign-on-session-create) can reuse it.

--- a/docs/ai/generated-issues/m1-2-agent-sessions-project-fk.md
+++ b/docs/ai/generated-issues/m1-2-agent-sessions-project-fk.md
@@ -1,0 +1,70 @@
+# M1-2 — Backend: `agent_sessions.project_id` FK + per-project listing
+
+**Milestone:** M1 — Sessions ↔ Projects
+**Branch:** `m1-projects`
+**Depends on:** M1-1
+
+## Summary
+
+Add a nullable `project_id` column to `agent_sessions` and extend `GET /agent-sessions` with a `?projectId=X` filter. Existing sessions keep `NULL project_id` and remain visible under an "All sessions" pseudo-project on the client.
+
+## Motivation
+
+M1-1 created the `projects` table. To filter the sidebar session list by project (M1-5), every session needs a project pointer. NULL is intentional and supported — pre-existing sessions can't be retroactively assigned without guessing, so the UI shows them under "All sessions" until the user re-creates them inside a project.
+
+## Likely files
+
+- `apps/api_server/src/database/migrations.ts` — `ALTER TABLE agent_sessions ADD COLUMN project_id TEXT` (idempotent guard)
+- `apps/api_server/src/models/agent_session.ts` — add `projectId: string | null`
+- `apps/api_server/src/repositories/agent_sessions_repository.ts` — accept `projectId` filter in `listActive` / `list`; persist `project_id` on insert
+- `apps/api_server/src/controllers/agent_sessions_controller.ts` — read `req.query.projectId`, pass through
+- `apps/api_server/src/__tests__/agent_sessions.test.ts` — extend existing suite
+
+## Schema
+
+```sql
+-- Idempotent: skip if column already exists (check via PRAGMA table_info)
+ALTER TABLE agent_sessions ADD COLUMN project_id TEXT REFERENCES projects(id);
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_project ON agent_sessions(project_id);
+```
+
+`REFERENCES` is informational in SQLite without `PRAGMA foreign_keys=ON` (we currently leave it off). Hard FK enforcement is deferred — the index gives the perf benefit, and ON DELETE cascade is left to a future cleanup pass.
+
+## Endpoints
+
+- `GET /agent-sessions` — accepts optional `?projectId=<id>` query.
+  - When present: returns only sessions where `project_id = ?`.
+  - When absent: existing behavior unchanged (returns all sessions, including NULL).
+  - `?projectId=null` (literal string `null`) returns only sessions with `project_id IS NULL` (i.e. the "All sessions / unassigned" pseudo-project bucket).
+- `POST /agent-sessions` — accepts optional `projectId` in body; persists to the new column. M1-3 will add cwd-based auto-assignment when omitted.
+
+## Acceptance criteria
+
+1. Migration runs cleanly on a fresh DB and on an existing dev DB where `agent_sessions` already has rows; pre-existing rows keep `project_id = NULL`.
+2. `GET /agent-sessions` without query returns all sessions (unchanged from today).
+3. `GET /agent-sessions?projectId=<existing-id>` returns only that project's sessions.
+4. `GET /agent-sessions?projectId=null` returns only sessions with `project_id IS NULL`.
+5. `POST /agent-sessions` with `projectId` in body persists it; without it, persists NULL (M1-3 will refine this).
+6. `ai-workflow checks --level pr` exits 0.
+
+## Required tests (vitest)
+
+Extend `agent_sessions.test.ts`:
+- Existing tests continue to pass with `project_id = NULL`.
+- New: POST with `projectId` persists and is returned by GET.
+- New: GET `?projectId=<id>` filters correctly.
+- New: GET `?projectId=null` returns only NULL-project sessions.
+- New: POST without `projectId` persists NULL (assertion explicitly checks for `projectId === null` in response).
+- New: migration is idempotent — calling it twice on the same DB is a no-op.
+
+## Data safety / out of scope
+
+- Do NOT add auto-assignment-by-cwd in this issue; that's M1-3.
+- Do NOT add hard FK enforcement (`PRAGMA foreign_keys=ON`) — risk of breaking existing rows during dev.
+- Do NOT cascade-delete sessions on project archive; archive is a UI-only filter for now.
+- No Flutter changes here.
+
+## Notes
+
+- `agent_sessions` already has `cwd` stored — M1-3 reads that to pick a project; no schema change needed for that step.
+- Repository pattern: add `projectId?: string | null` to the list filter type alongside the existing filters.

--- a/docs/ai/generated-issues/m1-3-auto-assign-project-on-session-create.md
+++ b/docs/ai/generated-issues/m1-3-auto-assign-project-on-session-create.md
@@ -1,0 +1,72 @@
+# M1-3 — Backend: auto-assign project on session create (cwd prefix match)
+
+**Milestone:** M1 — Sessions ↔ Projects
+**Branch:** `m1-projects`
+**Depends on:** M1-2
+
+## Summary
+
+When `POST /agent-sessions` is called without an explicit `projectId`, look up the project whose `cwd` matches (or is a prefix of) the session's `cwd` and auto-assign it. Falls back to `NULL` if no project matches. Removes the need for the client to know the project id in M1-5's "new session" button.
+
+## Motivation
+
+The sidebar's new-session shortcut (M1-5) creates a session with the currently selected project's cwd. The cleanest contract is "post a session with a cwd, get a `projectId` back if one fits." This keeps the backend the single source of truth for the cwd→project mapping and avoids client-side guessing.
+
+## Likely files
+
+- `apps/api_server/src/repositories/projects_repository.ts` — new `findByCwdPrefix(cwd): Project | null`
+- `apps/api_server/src/controllers/agent_sessions_controller.ts` — auto-assign branch in `create`
+- `apps/api_server/src/__tests__/agent_sessions.test.ts` — extend
+
+## Behavior
+
+In `agent_sessions_controller.create`:
+
+```
+if (!body.projectId) {
+  const match = projectsRepository.findByCwdPrefix(expandedCwd);
+  body.projectId = match?.id ?? null;
+}
+```
+
+`findByCwdPrefix(cwd)` rules:
+1. Normalize: expand `~`, resolve trailing slashes.
+2. Find all non-archived projects.
+3. Return the project whose `cwd` is an **exact match or a path-prefix** of the session cwd (i.e. `session.cwd === project.cwd` OR `session.cwd.startsWith(project.cwd + '/')`).
+4. If multiple match (nested projects), prefer the **longest** project cwd.
+5. If none match, return `null`.
+
+Auto-assignment is **only** invoked when the client omits `projectId`. Explicit `projectId: null` is honored (means "intentionally unassigned").
+
+## Acceptance criteria
+
+1. POST `/agent-sessions` with `cwd: "/Users/x/Documents/Rhythm/apps/api_server"` and no `projectId` auto-assigns the project whose cwd is `/Users/x/Documents/Rhythm`.
+2. POST with `cwd: "/Users/x/elsewhere"` and no matching project → `projectId === null` in response.
+3. POST with explicit `projectId: null` keeps NULL even when a prefix match exists.
+4. POST with explicit `projectId: "<id>"` honors that id without re-checking.
+5. Nested projects: when two projects exist (`/Users/x/A` and `/Users/x/A/sub`), a session at `/Users/x/A/sub/inner` matches `/Users/x/A/sub` (longest prefix).
+6. Archived projects are NOT considered.
+7. `ai-workflow checks --level pr` exits 0.
+
+## Required tests (vitest)
+
+Extend `agent_sessions.test.ts`:
+- Exact-cwd-match auto-assigns.
+- Prefix-match auto-assigns.
+- No-match returns `projectId: null`.
+- Explicit `projectId: null` not overridden.
+- Explicit `projectId: "<id>"` not overridden.
+- Longest-prefix wins with two candidates.
+- Archived project is skipped.
+
+## Data safety / out of scope
+
+- Do NOT mutate existing session rows retroactively — auto-assign only fires on `POST`, never on session list / get.
+- Do NOT consult `agent_sessions` from `projectsRepository` (no reverse dependency).
+- Path comparison is string-based with trailing-slash normalization; do NOT resolve symlinks (would surprise the user and could match across mount boundaries).
+- No Flutter changes.
+
+## Notes
+
+- The longest-prefix tie-breaker matters even for non-nested projects if someone creates `~/Documents/Rhythm` and later `~/Documents/Rhythm-fork`. Without it, both would match a `/Users/x/Documents/Rhythm/...` session.
+- This logic lives in the controller, not the repository, so the auto-assignment is observable in one place during smoke debugging.

--- a/docs/ai/generated-issues/m1-4-flutter-project-model-repo-controller.md
+++ b/docs/ai/generated-issues/m1-4-flutter-project-model-repo-controller.md
@@ -1,0 +1,114 @@
+# M1-4 — Flutter: Project model + repository + controller (with VCS fields)
+
+**Milestone:** M1 — Sessions ↔ Projects
+**Branch:** `m1-projects`
+**Depends on:** M1-1
+
+## Summary
+
+Add the standard Flutter feature layer for projects (model / data source / repository / controller) following the existing pattern used by `tasks`, `rhythms`, `projects` (the legacy template feature — rename if collision), etc. The model carries the new VCS fields (`vcsRoot`, `vcsBranch`, `vcsDirty`). The controller exposes `refreshVcs(id)` that hits `POST /projects/:id/refresh-vcs`. No UI in this issue — that's M1-5 / M1-6.
+
+## Motivation
+
+M1-5 and M1-6 need a `ProjectController` ready to consume. Building the data layer first matches the existing pattern (every feature follows: view ↔ controller ↔ repository ↔ data source ↔ model) and lets the UI work be a thin wrapper.
+
+## Likely files
+
+- `apps/desktop_flutter/lib/features/projects/models/project.dart` — **NEW** (current `lib/features/projects/` is the project-templates feature; place this under a sibling folder if needed to avoid collision — see Notes)
+- `apps/desktop_flutter/lib/features/projects/data/projects_remote_data_source.dart`
+- `apps/desktop_flutter/lib/features/projects/repositories/projects_repository.dart`
+- `apps/desktop_flutter/lib/features/projects/controllers/projects_controller.dart`
+- `apps/desktop_flutter/lib/main.dart` — register `ChangeNotifierProvider<ProjectsController>`
+- `apps/desktop_flutter/test/features/projects/projects_controller_test.dart`
+
+## Naming collision
+
+The existing `lib/features/projects/` is the **project templates** feature (template/instance/step). To avoid breaking it, this issue introduces the new Agent-projects layer under:
+
+```
+lib/features/agent_projects/
+  models/agent_project.dart
+  data/agent_projects_remote_data_source.dart
+  repositories/agent_projects_repository.dart
+  controllers/agent_projects_controller.dart
+```
+
+Class names: `AgentProject`, `AgentProjectsController`, etc. UI files (M1-5/M1-6) live under `lib/features/agents/views/` since they're surfaced in the Agents screen.
+
+## Model
+
+```dart
+class AgentProject {
+  final String id;
+  final String name;
+  final String cwd;
+  final String? icon;          // emoji or "#hex"
+  final String? vcsRoot;       // null for non-git
+  final String? vcsBranch;     // null for non-git or detached HEAD
+  final bool vcsDirty;
+  final DateTime? vcsCheckedAt;
+  final DateTime createdAt;
+  final DateTime? archivedAt;
+
+  factory AgentProject.fromJson(Map<String, dynamic> json);
+  Map<String, dynamic> toJson();
+}
+```
+
+## Controller surface
+
+`AgentProjectsController extends ChangeNotifier`:
+
+| Field / method | Behavior |
+|---|---|
+| `List<AgentProject> projects` | Loaded list (sorted createdAt DESC, archived excluded) |
+| `String? selectedProjectId` | null = "All sessions" pseudo-project |
+| `LoadStatus status` | `idle` / `loading` / `error` (existing enum pattern) |
+| `String? error` | Human-readable last error |
+| `Future<void> load({bool includeArchived = false})` | GET /projects |
+| `Future<AgentProject> create({name, cwd, icon})` | POST /projects; refreshes list |
+| `Future<AgentProject> update(id, {name?, cwd?, icon?, archivedAt?})` | PATCH /projects/:id |
+| `Future<void> archive(id)` | PATCH archivedAt = now |
+| `Future<void> delete(id)` | DELETE /projects/:id |
+| `Future<AgentProject> refreshVcs(id)` | POST /projects/:id/refresh-vcs; updates in-place |
+| `void select(String? id)` | Sets `selectedProjectId`, notifies |
+
+Data source constructor takes `baseUrl` from `ServerConfigService.url` (NOT the agent localhost URL — projects are stored in the production-config DB on whatever server the user pointed at, matching how tasks/rhythms work).
+
+**Decision point:** projects are local-only data and belong to the **embedded api_server on `localhost:4001`**, not the user-configured production API. Per CLAUDE.md's Dual-Endpoint rule, agent-related data uses `AppConstants.agentLocalBaseUrl`. Use that, not `serverConfigService.url`.
+
+## Acceptance criteria
+
+1. `AgentProject.fromJson` round-trips every field including null VCS fields.
+2. Controller `load()` fetches and populates `projects`; status transitions `idle → loading → idle`.
+3. `create` adds the new project to the in-memory list (no re-fetch needed) and notifies listeners.
+4. `archive` removes the project from the visible list (unless `includeArchived: true` is later supported).
+5. `refreshVcs` replaces the in-memory project with the updated VCS fields and notifies.
+6. `select(id)` updates `selectedProjectId` and notifies; `select(null)` switches to the "All sessions" pseudo-project.
+7. `flutter analyze --no-fatal-infos` clean.
+8. `dart format --set-exit-if-changed` clean.
+9. `flutter test` passes (existing 180 + new tests).
+10. `ai-workflow checks --level pr` exits 0.
+
+## Required tests (`projects_controller_test.dart`)
+
+Mock the data source (or use a fake `HttpClient`):
+- `load()` populates projects on success and sets `error` on HTTP failure.
+- `create()` posts and appends to the in-memory list.
+- `update()` patches and replaces the matching id.
+- `archive()` removes the row from `projects`.
+- `delete()` removes the row.
+- `refreshVcs()` updates VCS fields without touching other fields.
+- `select(id)` / `select(null)` updates `selectedProjectId` and emits `notifyListeners`.
+
+## Data safety / out of scope
+
+- No UI in this issue — sidebar rail + dialogs land in M1-5 / M1-6.
+- Use `AppConstants.agentLocalBaseUrl` (`http://localhost:4001`), NOT `serverConfigService.url`. Agent traffic must never couple to the production API per CLAUDE.md.
+- Do NOT add session-listing changes here; M1-5 wires `AgentSessionsController.listByProject(id)` separately.
+- Do NOT introduce a `package:dio` or other new HTTP library — match the existing `package:http` pattern.
+
+## Notes
+
+- The folder name `agent_projects` is verbose but unambiguous. If the legacy `lib/features/projects/` ever gets renamed (it's `project_template_*` internally), we can rename this back to `projects/`. Don't rename the legacy feature in this issue — out of scope.
+- VCS fields are read-only from the client perspective; the server is the source of truth. The controller never sets them locally except via `fromJson`.

--- a/docs/ai/generated-issues/m1-5-flutter-sidebar-rail-vcs-chip.md
+++ b/docs/ai/generated-issues/m1-5-flutter-sidebar-rail-vcs-chip.md
@@ -1,0 +1,98 @@
+# M1-5 — Flutter: sidebar rail + project panel with VCS chip
+
+**Milestone:** M1 — Sessions ↔ Projects
+**Branch:** `m1-projects`
+**Depends on:** M1-2, M1-4
+
+## Summary
+
+Replace the existing flat session list in the Agents view with a two-pane layout: a 64px **project rail** (icons stacked top-to-bottom, click to switch) and a **session panel** scoped to the selected project. Above the panel, a header chip shows the selected project's git branch and a dirty indicator (hidden for non-git projects). An "All sessions" pseudo-project at the top of the rail shows the unassigned bucket.
+
+## Motivation
+
+The data layer (M1-1..M1-4) is invisible until the rail exists. This is the first visible change of M1 — switching projects must filter sessions, and the VCS chip must reflect M1-1's probe so the Q1 decision (cwd + VCS in M1) is observable.
+
+## Likely files
+
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` — replace `_SessionListPanel` (or its equivalent) with the new two-pane layout
+- `apps/desktop_flutter/lib/features/agents/views/_projects_rail.dart` — **NEW**
+- `apps/desktop_flutter/lib/features/agents/views/_project_vcs_chip.dart` — **NEW**
+- `apps/desktop_flutter/lib/features/agents/controllers/agent_sessions_controller.dart` — extend to filter `_sessions` by `projectId` (mirror server filter; query string already supported)
+- `apps/desktop_flutter/lib/features/agents/data/agent_sessions_remote_data_source.dart` — accept optional `projectId` in `list(...)`
+- `apps/desktop_flutter/test/features/agents/projects_rail_test.dart` — **NEW** (widget test)
+- `apps/desktop_flutter/test/features/agents/project_vcs_chip_test.dart` — **NEW**
+
+## Layout
+
+```
+┌───────┬─────────────────────────┬──────────────────────┐
+│ rail  │  session panel          │  chat thread (main)  │
+│ 64px  │  (≈280px, existing)     │  (existing)          │
+│       │                         │                      │
+│ [⭐]  │  [branch · dirty?] chip │                      │
+│ ─     │  ─────                  │                      │
+│ [🛠]  │  session-1              │                      │
+│ [📦]  │  session-2              │                      │
+│ [+]   │  session-3              │                      │
+└───────┴─────────────────────────┴──────────────────────┘
+```
+
+- Rail width: 64px. Icons rendered 40×40 with 12px vertical gap. Selected item gets the `primary tint` background per the theme tokens (`Color(0x144F6AF5)`).
+- First rail item is the "All sessions" pseudo-project (icon: ⭐ or similar). `selectedProjectId == null` selects it.
+- Last rail item is a `+` button → opens M1-6's new-project dialog.
+- Session panel only renders sessions where `session.projectId == selectedProjectId` (or all when null is selected).
+- New-session button (already present) pre-fills cwd from the selected project's cwd. When "All sessions" is selected, cwd defaults to the existing fallback (current behavior, e.g. user home).
+
+## VCS chip
+
+`_ProjectVcsChip`:
+- Hidden entirely when `project.vcsRoot == null`.
+- Otherwise: rounded chip showing `<branch> · ●` where the ● is a small dirty-indicator dot (filled if `vcsDirty`, outline if clean).
+- Tooltip on hover: `Branch: <branch>\nRoot: <vcsRoot>\nLast checked: <relative time from vcsCheckedAt>`.
+- Tap calls `controller.refreshVcs(project.id)`; brief loading state until the response lands.
+
+## Acceptance criteria
+
+1. Rail renders projects from `AgentProjectsController.projects` plus the "All sessions" pseudo-entry at top and the `+` button at bottom.
+2. Tapping a rail item switches `selectedProjectId` and the session panel re-filters within one frame.
+3. Tapping the `+` opens the M1-6 dialog (no-op stub if M1-6 hasn't landed yet — guard with a `// TODO(M1-6)` placeholder dialog).
+4. For a project pointing at a git repo, the VCS chip is visible and shows the correct branch + dirty state.
+5. For a project pointing at a non-git folder, the VCS chip is NOT rendered.
+6. Tapping the VCS chip calls `refreshVcs` and the chip updates without a full reload.
+7. Sessions created from inside a project default to that project's cwd (visible in the create-session form).
+8. Existing sessions (NULL `project_id`) appear under "All sessions" and only there.
+9. `flutter analyze --no-fatal-infos` clean.
+10. `dart format --set-exit-if-changed` clean.
+11. `flutter test` passes; new widget tests included.
+12. `ai-workflow checks --level pr` exits 0.
+
+## Required tests
+
+`projects_rail_test.dart`:
+- Renders one icon per project plus All-sessions + `+` button.
+- Tapping a project icon notifies `AgentProjectsController.select(id)` with the right id.
+- Tapping the All-sessions icon calls `select(null)`.
+- Selected item has the primary-tint background.
+
+`project_vcs_chip_test.dart`:
+- Hidden when `vcsRoot == null`.
+- Shows branch text when `vcsRoot != null`.
+- Dirty dot filled when `vcsDirty == true`.
+- Tapping calls the supplied `onRefresh` callback.
+
+Optional smoke addition to `manual-smoke.md` (extend in this PR):
+- Create two projects, one git one non-git; verify chip behavior.
+- Create a session in each, switch rails, verify session panel filters.
+
+## Data safety / out of scope
+
+- Edit / new-project dialog UI is M1-6; this issue only wires the `+` button as a no-op or placeholder.
+- Do NOT migrate existing sessions to a project as part of rail-switching — they stay NULL under All-sessions.
+- Do NOT add VCS-aware UI to the chat thread or session-create form beyond cwd pre-fill (that's M3 territory).
+- No theme token violations — all colors via the existing theme tokens from CLAUDE.md (`primary`, `primary tint`, `card border`, etc.).
+
+## Notes
+
+- Reference layout from Opencode Desktop: `/tmp/opencode-ref/packages/app/src/pages/layout.tsx` — the sidebar rail + panel pattern.
+- The rail uses `LayoutBuilder` for tight width; the panel is the existing list with one extra `where(p => p.projectId == selectedProjectId)` clause.
+- If a session is open in the main thread when the user switches projects, do NOT close it — selecting a different project just filters the list panel. The currently-streaming session stays open until the user manually switches.

--- a/docs/ai/generated-issues/m1-6-flutter-edit-project-dialog.md
+++ b/docs/ai/generated-issues/m1-6-flutter-edit-project-dialog.md
@@ -1,0 +1,89 @@
+# M1-6 — Flutter: edit-project dialog + new-project flow
+
+**Milestone:** M1 — Sessions ↔ Projects
+**Branch:** `m1-projects`
+**Depends on:** M1-4
+
+## Summary
+
+Add a dialog used for both creating a new project (triggered by the `+` button on the rail in M1-5) and editing an existing one (triggered by long-press / context-menu on a project icon). The dialog has fields for name, cwd (folder picker), and icon (emoji or color). On save, the server auto-probes VCS; the dialog displays the detected branch (or "no git") as a confirmation line before closing.
+
+## Motivation
+
+Without this dialog, the rail's `+` button in M1-5 is a no-op and users can't create projects from the UI. This issue also handles edit (name / cwd / icon) and archive, completing the project-management surface for M1.
+
+## Likely files
+
+- `apps/desktop_flutter/lib/features/agent_projects/views/edit_project_dialog.dart` — **NEW** (same package as M1-4's controller)
+- `apps/desktop_flutter/lib/features/agents/views/_projects_rail.dart` — wire `+` button to open the dialog in create mode; wire context-menu on rail items to open in edit mode
+- `apps/desktop_flutter/pubspec.yaml` — add `file_picker: ^X.Y` if not already present (folder selection); `emoji_picker_flutter` is optional, fall back to a `TextField` for emoji
+- `apps/desktop_flutter/test/features/agent_projects/edit_project_dialog_test.dart` — **NEW** (widget test)
+
+## Dialog
+
+```
+┌──────────────────────────────────────────┐
+│ New project                          [×] │
+├──────────────────────────────────────────┤
+│ Name        [_______________________]    │
+│ Folder      [/Users/.../Rhythm] [Pick…]  │
+│ Icon        [🛠] [Pick…]                 │
+│                                          │
+│ ── (after save attempt) ─────────────    │
+│ ✓ Detected git branch: main              │
+│   (or: ⓘ No git repository at this path) │
+│                                          │
+│            [Cancel]  [Save]              │
+└──────────────────────────────────────────┘
+```
+
+- **Name** required (`> 0` chars after trim).
+- **Folder** required. "Pick…" launches the native folder picker via `file_picker`'s `getDirectoryPath()`. Path is shown as absolute; manual edit allowed.
+- **Icon** optional. Default is a generic 📁. Stored as either an emoji codepoint or `#RRGGBB`. Minimal UI: a text field accepting one grapheme cluster, with a color-swatch fallback button if no emoji entered.
+- **Save** disabled until name + folder both non-empty.
+- After Save, the dialog stays open for 800ms displaying the server's VCS detection result (read from the response's `vcsBranch` / `vcsRoot`), then closes. If the server returns an error, the dialog stays open with an inline red error and re-enables Save.
+- **Edit mode** pre-fills all fields and shows an extra **Archive** button bottom-left.
+- **Cancel** closes without committing.
+
+## Acceptance criteria
+
+1. New-project flow: `+` button on the rail opens the dialog blank; Save creates the project, shows the VCS confirmation line, closes, and the new project appears in the rail.
+2. Edit-project flow: long-press (or right-click) on a rail icon opens the dialog pre-filled; Save updates and the rail re-renders.
+3. Archive button in edit mode calls `AgentProjectsController.archive(id)` and closes the dialog; the project disappears from the rail.
+4. Folder picker writes the selected absolute path into the Folder field.
+5. Save is disabled while either name or folder is empty.
+6. Server error (e.g. relative path 400) renders inline; dialog stays open; user can correct and retry.
+7. After successful save of a git folder, the VCS confirmation line reads `Detected git branch: <branch>`.
+8. After successful save of a non-git folder, the VCS confirmation line reads `No git repository at this path`.
+9. `flutter analyze --no-fatal-infos` clean.
+10. `dart format --set-exit-if-changed` clean.
+11. `flutter test` passes; new widget tests included.
+12. `ai-workflow checks --level pr` exits 0.
+
+## Required tests (`edit_project_dialog_test.dart`)
+
+Mock `AgentProjectsController`:
+- Renders with empty fields in create mode.
+- Renders pre-filled in edit mode.
+- Save button disabled when name empty.
+- Save button disabled when folder empty.
+- Tapping Save in create mode calls `controller.create(...)` with the entered values.
+- Tapping Save in edit mode calls `controller.update(id, ...)`.
+- Server-returned VCS confirmation line renders for both git and non-git responses.
+- Inline server error renders when controller throws.
+- Archive button (edit mode only) calls `controller.archive(id)`.
+
+## Data safety / out of scope
+
+- Folder picker MUST NOT remember the previously-picked path inside the app — let the OS handle that. No new shared_preferences keys for it.
+- Do NOT auto-create a session inside the new project on save — that's a user action, not a side effect of project creation.
+- Do NOT validate that the chosen folder exists on disk in the dialog — server returns 400 if needed; client trusts the picker.
+- Emoji picker is optional and out of scope. If `emoji_picker_flutter` is not already in `pubspec.yaml`, ship with a plain text field for icon entry and a small color-swatch fallback. Adding a full emoji picker is a follow-up.
+- Do NOT add multi-project bulk operations.
+- Theme tokens only — no hex literals.
+
+## Notes
+
+- `file_picker` is widely used in the Flutter desktop ecosystem; check if it's already a transitive dep before adding. If not present, this is a small new dep — minimal blast radius.
+- The 800ms confirmation pause is intentional UX, not a server delay. Done with a `Future.delayed` after `notifyListeners` returns.
+- Reference: Opencode Desktop `packages/app/src/components/dialog-edit-project.tsx`.

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -1,20 +1,28 @@
 # Project State
 
-## Current Status (2026-05-14, session-end snapshot)
+## Current Status (2026-05-14 v2 — M1-1 verified)
 
-🟢 **Agents chat is fully working end-to-end.** User confirmed in a live smoke: user bubble right-aligned, assistant bubble streams in place, Enter sends, Shift+Enter inserts newlines, auto-resume rebinds orphan sessions from previous launches transparently.
+🟢 **PR #574 merged.** `main` is at `84eef44`; the Opencode auth/chat rework is now upstream.
+
+🟢 **M1-1 (#586) implementation verified.** Backend `projects` table + CRUD + VCS probe landed on `m1-projects`. PR-level checks green (flutter analyze, dart format, tsc --noEmit, vitest 430/430 incl. 13 new). Smoke probes against `localhost:4099`: `/health` ok, `POST /projects` with the Rhythm repo cwd returns `vcsRoot=/Users/.../Rhythm, vcsBranch=m1-projects, vcsDirty=true`; relative-path → 400; `refresh-vcs` → 200; `DELETE` → 204.
+
+**Branch state.** `m1-projects`, branched from `84eef44` (clean main). Local commits:
+- `7ccadbf` — docs(ai): generated M1 issue bodies #586–#591
+- (uncommitted) M1-1 source: migrations, model, vcs_probe service, repo, controller, route, tests, app.ts wire-up
+
+Pending action by user: commit M1-1 + push branch + open PR for #586 (or stack #587–#591 first per the milestone-per-PR decision in `docs/ai/current-plan.md`).
+
+**Active plan.** `docs/ai/current-plan.md` holds the 5-milestone parity roadmap with all 6 open questions resolved (2026-05-14). One-branch-per-milestone confirmed. Milestone #86 (`M1 — Sessions ↔ Projects`) tracks issues [#586](https://github.com/ajhochy/Rhythm/issues/586)–[#591](https://github.com/ajhochy/Rhythm/issues/591).
+
+## Prior Status (2026-05-14, session-end snapshot — PRE-merge)
+
+🟢 **Agents chat was fully working end-to-end** at PR #574 merge: user bubble right-aligned, assistant streams in place, Enter sends, auto-resume rebinds orphan sessions.
 
 **Routing verification (live, `/opencode/auth/`):** authed providers = `["openrouter","anthropic","openai","github-copilot"]`. Local cred sources = `{"claudeCode":true,"codex":true}`. So:
-- `claude-code` agent → `anthropic / claude-sonnet-4-6` (direct Anthropic account via `opencode-claude-auth` Keychain bridge — NOT OpenRouter)
-- `codex` agent → `openai / gpt-5.3-codex` (direct OpenAI account via `opencode-openai-codex-auth` — NOT OpenRouter)
-- `gemini-cli` agent → `openrouter / google/gemini-3.1-pro-preview-customtools` (Google not signed in)
-- `opencode` (bare) agent → `openrouter / anthropic/claude-sonnet-4.6` (fallback added this session)
-
-**Branch state.** `opencode-engine-issue-564`, local HEAD `9b26aa1`, 42 commits ahead of last push at `70b87d7`. **NOT pushed.** Awaiting user `git push origin opencode-engine-issue-564` then PR #574 merge.
-
-**Issue backlog.** All Opencode-implementation issues (#564–#585) closed today. Open issues remaining are non-Opencode: #48 (PCO UX), #71 (mobile MVP), #418 (mobile smoke), #476 (AgentTriggerWatcher dev-gating).
-
-**Active plan.** `docs/ai/current-plan.md` replaced — now holds the full Opencode Desktop UI parity roadmap (5 milestones M1–M5, ~25 atomic issues, ~15–17 sessions). Next session branches off a clean `main` after PR #574 merges and starts at M1 issue #1 (`projects` table + CRUD).
+- `claude-code` → `anthropic / claude-sonnet-4-6` (direct, via `opencode-claude-auth` Keychain bridge)
+- `codex` → `openai / gpt-5.3-codex` (direct, via `opencode-openai-codex-auth`)
+- `gemini-cli` → `openrouter / google/gemini-3.1-pro-preview-customtools` (Google not signed in)
+- `opencode` (bare) → `openrouter / anthropic/claude-sonnet-4.6` (fallback)
 
 Automated checks (last run, post 9b26aa1):
 - **417/417 tests** (vitest, api_server) — `agents_ws_e2e.test.ts` has 4 cases (chat→server, server→chat, full round-trip, auto-resume regression)
@@ -213,7 +221,9 @@ Flutter → DELETE /agent-sessions/:id → controller stops bridge + clears map 
 ```
 
 ## Branch / PR
-`opencode-engine-issue-564` — Draft PR #574 — **local HEAD `ef5ea12`, 38 commits ahead of last push at `70b87d7`**. NOT YET PUSHED. Auth rework (Issues A–G), follow-up smoke fixes, plugin auto-installer, plus today's chat round-trip fix all stacked here. See "Outstanding Issues" at top and "Chat round-trip fix" section for verification status.
+`m1-projects` — branched off clean `main` at `84eef44` (post PR #574 merge). Local-only commit `7ccadbf` adds the M1 issue bodies under `docs/ai/generated-issues/`. M1-1 implementation is on disk, not yet committed.
+
+Historic: `opencode-engine-issue-564` → PR #574 — **MERGED** 2026-05-14.
 
 ## Active plan
 `docs/ai/current-plan.md` is no longer a placeholder. It contains the full 8-issue UI port plan (Opencode Desktop reference at `github.com/anomalyco/opencode/tree/dev/packages/desktop`). Status of the plan's issues:
@@ -235,13 +245,35 @@ All Opencode-implementation issues (#564–#585) are closed. Final disposition:
 
 Open issues remaining (none Opencode-related): #48 (PCO automation rules UX), #71 (mobile MVP scope), #418 (mobile smoke fail), #476 (AgentTriggerWatcher dev-gating).
 
+## M1 — Sessions ↔ Projects (milestone #86)
+
+| # | Issue | Status |
+|---|---|---|
+| #586 | M1-1 Backend: projects table + CRUD with VCS detection | **Implemented + verified** on `m1-projects`, uncommitted |
+| #587 | M1-2 Backend: agent_sessions.project_id FK + per-project listing | Not started |
+| #588 | M1-3 Backend: auto-assign project on session create | Not started |
+| #589 | M1-4 Flutter: Project model + repository + controller | Not started |
+| #590 | M1-5 Flutter: sidebar rail + project panel with VCS chip | Not started |
+| #591 | M1-6 Flutter: edit-project dialog | Not started |
+
+### M1-1 (#586) summary
+
+Files added/changed on `m1-projects`:
+- `apps/api_server/src/database/migrations.ts` — `CREATE TABLE IF NOT EXISTS projects` + `idx_projects_archived` (additive, idempotent)
+- `apps/api_server/src/models/project.ts` (NEW) — `Project`, `CreateProjectDto`, `UpdateProjectDto`
+- `apps/api_server/src/services/vcs_probe.ts` (NEW) — `probeVcs(cwd)` via `/bin/zsh -lc` (rev-parse → symbolic-ref → status --porcelain); best-effort, never throws
+- `apps/api_server/src/repositories/projects_repository.ts` (NEW)
+- `apps/api_server/src/controllers/projects_controller.ts` (NEW) — expandHome, absolute-path rejection (400), trailing-slash normalization, VCS re-probe on cwd change
+- `apps/api_server/src/routes/projects_routes.ts` (NEW) — mirrors `agent_sessions_routes` AGENT_LOCAL bypass
+- `apps/api_server/src/app.ts` — register `projectsRouter` at `/projects`
+- `apps/api_server/src/__tests__/vcs_probe.test.ts` (NEW) — 5 tests (git, non-git, dirty toggle, detached HEAD, mocked spawn failure)
+- `apps/api_server/src/__tests__/projects_routes.test.ts` (NEW) — 8 tests (CRUD + archive filter + cwd re-probe + refresh-vcs)
+
+Endpoints: `GET/POST /projects`, `GET/PATCH/DELETE /projects/:id`, `POST /projects/:id/refresh-vcs`.
+
 ## What to do next (resume notes)
 
-1. **Push the branch** (`git push origin opencode-engine-issue-564`) — manual smoke already passed; user confirmed chat round-trip works (user bubble + streaming assistant bubble visible, Enter sends, auto-resume works for orphan sessions).
-2. **Merge PR #574** after CI passes; the M1–M5 parity work in `docs/ai/current-plan.md` should branch off a clean `main` after this lands.
-3. **Sign in with Google AI** via the Settings tile so `gemini-cli` routes to the direct google provider (still outstanding).
-4. **Resolve OpenRouter rate-limit** on the test account if free-model fallback is needed (Outstanding #3).
-5. **Continue the UI port** by picking up issues #593–#597 from `docs/ai/current-plan.md`.
-6. **Document plugin requirements in CLAUDE.md** — the auto-installer adds `opencode-claude-auth`, `opencode-openai-codex-auth`, `opencode-gemini-auth`. Hard requirement for direct routing.
-
-Working-tree note: 3 unrelated dirty files (`.gitignore`, `apps/mcp_server/package.json`, `apps/mcp_server/tsconfig.json`) are pre-existing churn, deliberately not committed.
+1. **Commit M1-1** on `m1-projects` (single commit covering migrations, model, service, repo, controller, route, app.ts, tests).
+2. **Push `m1-projects` + open draft PR for #586** — or, per the milestone-per-PR decision in `current-plan.md`, stack #587/#588 onto the same branch before opening one PR for the whole backend half of M1.
+3. **Dispatch coding-agent for #587** (M1-2: `agent_sessions.project_id` FK + per-project listing).
+4. Outstanding non-M1 items still apply: Google AI sign-in for direct gemini routing; OpenRouter rate-limit on test account; plugin requirements doc in CLAUDE.md.


### PR DESCRIPTION
## Summary

M1-1 of the Opencode Desktop UI parity plan (milestone [#86](https://github.com/ajhochy/Rhythm/milestone/86)). Adds a local-only `projects` table to the embedded api_server with full CRUD and a best-effort git working-tree probe at create / on-demand refresh. Non-git folders are valid projects with NULL VCS fields.

- **Schema:** `projects(id, name, cwd, icon, vcs_root, vcs_branch, vcs_dirty, vcs_checked_at, created_at, archived_at)` + `idx_projects_archived` (additive, idempotent migration).
- **Endpoints:** `GET/POST /projects`, `GET/PATCH/DELETE /projects/:id`, `POST /projects/:id/refresh-vcs`.
- **VCS probe** (`services/vcs_probe.ts`): shells out via `/bin/zsh -lc` to match the login-shell pattern Flutter uses for `_findNode`, ensuring `git` is on PATH when the api_server is launched from the GUI. Never throws; returns `null` for non-git cwds.
- **Auth:** `AGENT_LOCAL` bypass mirrors `agent_sessions_routes`.

This is the backend foundation for M1-2..M1-6. No Flutter changes here.

## Verification

- `ai-workflow checks --level pr` ✓ (flutter analyze, dart format, tsc --noEmit, vitest 430/430 incl. 13 new)
- Live smoke against `localhost:4099`:
  - `POST /projects` with the Rhythm repo cwd → 201 with `vcsRoot=/Users/.../Rhythm`, `vcsBranch=m1-projects`, `vcsDirty=true`, `vcsCheckedAt=ISO`
  - `POST /projects` with a non-git tmpdir → NULL VCS fields, `vcsDirty=false`
  - `POST /projects` with relative path → 400
  - `POST /projects/:id/refresh-vcs` → 200, `vcsCheckedAt` updated
  - `DELETE /projects/:id` → 204

## Test plan

- [x] `vitest src/__tests__/vcs_probe.test.ts` (5 cases: git repo, non-git tmp, dirty toggle, detached HEAD, mocked spawn failure)
- [x] `vitest src/__tests__/projects_routes.test.ts` (8 cases: CRUD, includeArchived filter, cwd re-probe, refresh-vcs)
- [x] Full PR-level checks
- [ ] Manual smoke after merge: confirm migration runs cleanly on the dev DB at `~/Library/Application Support/Rhythm/rhythm.db`

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)
