### PR TITLE
fix: M5-3 dark-mode partial-render bugs

### DIFF
--- a/apps/desktop_flutter/lib/app/core/widgets/error_banner.dart
+++ b/apps/desktop_flutter/lib/app/core/widgets/error_banner.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../ui/tokens/rhythm_theme.dart';
+
 /// A consistent error banner used across all views.
 /// Shows a red-tinted message strip with an optional retry button.
 class ErrorBanner extends StatelessWidget {
@@ -10,22 +12,23 @@ class ErrorBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final danger = context.rhythm.danger;
     return Container(
       margin: const EdgeInsets.all(16),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       decoration: BoxDecoration(
-        color: const Color(0xFFFEF2F2),
-        border: Border.all(color: const Color(0xFFFCA5A5)),
+        color: danger.withValues(alpha: 0.10),
+        border: Border.all(color: danger.withValues(alpha: 0.28)),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(
         children: [
-          const Icon(Icons.error_outline, color: Color(0xFFDC2626), size: 18),
+          Icon(Icons.error_outline, color: danger, size: 18),
           const SizedBox(width: 10),
           Expanded(
             child: Text(
               message,
-              style: const TextStyle(color: Color(0xFF991B1B), fontSize: 13),
+              style: TextStyle(color: danger, fontSize: 13),
             ),
           ),
           if (onRetry != null) ...[
@@ -33,7 +36,7 @@ class ErrorBanner extends StatelessWidget {
             TextButton(
               onPressed: onRetry,
               style: TextButton.styleFrom(
-                foregroundColor: const Color(0xFFDC2626),
+                foregroundColor: danger,
                 padding: const EdgeInsets.symmetric(
                   horizontal: 12,
                   vertical: 6,

--- a/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
+++ b/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
@@ -58,7 +58,7 @@ class _AgentsViewState extends State<AgentsView> {
             end: Alignment.bottomRight,
             colors: [
               context.rhythm.canvas,
-              const Color(0xFFF7F4EF),
+              context.rhythm.surfaceRaised,
               context.rhythm.canvas,
             ],
             stops: const [0.0, 0.45, 1.0],

--- a/apps/desktop_flutter/lib/features/messages/views/messages_view.dart
+++ b/apps/desktop_flutter/lib/features/messages/views/messages_view.dart
@@ -49,7 +49,7 @@ class _MessagesViewState extends State<MessagesView> {
             end: Alignment.bottomRight,
             colors: [
               context.rhythm.canvas,
-              const Color(0xFFF7F4EF),
+              context.rhythm.surfaceRaised,
               context.rhythm.canvas
             ],
             stops: const [0.0, 0.45, 1.0],

--- a/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
+++ b/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
@@ -43,12 +43,16 @@ class _ProjectsViewState extends State<ProjectsView> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         gradient: LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
-          colors: [Color(0xFFF7F4EF), Color(0xFFFDFBF7), Color(0xFFF6F1EA)],
-          stops: [0.0, 0.5, 1.0],
+          colors: [
+            context.rhythm.canvas,
+            context.rhythm.surfaceRaised,
+            context.rhythm.canvas,
+          ],
+          stops: const [0.0, 0.5, 1.0],
         ),
       ),
       child: Consumer<ProjectTemplateController>(


### PR DESCRIPTION
## Summary
- Replaced hard-coded light gradients in Projects, Messages, and Agents with rhythm theme surface tokens.
- Replaced the shared error banner hard-coded red-on-light palette with theme-aware danger colors.

## Punch list fixed
- `apps/desktop_flutter/lib/features/projects/views/projects_view.dart`: Projects view used a hard-coded cream gradient, leaving the main work area light in dark mode.
- `apps/desktop_flutter/lib/features/messages/views/messages_view.dart`: Messages view mixed a hard-coded cream gradient into the dark screen, leaving the thread/detail side light.
- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart`: Agents view mixed a hard-coded cream gradient into the dark screen, leaving the transcript/detail side light.
- `apps/desktop_flutter/lib/app/core/widgets/error_banner.dart`: Integrations error banner used a fixed light red surface in dark mode.

## Screenshots
Local screenshots captured during discovery are in `.codex/dark-mode-screenshots/`:
- Before: `dark2_projects.png`, `dark2_messages.png`, `dark2_agents.png`, `dark2_integrations.png`
- After: code-level fixes verified by rebuild/analyze/checks; direct after navigation screenshots were blocked by local macOS accessibility permissions for synthetic clicks.

## Files touched
- `apps/desktop_flutter/lib/features/projects/views/projects_view.dart`
- `apps/desktop_flutter/lib/features/messages/views/messages_view.dart`
- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart`
- `apps/desktop_flutter/lib/app/core/widgets/error_banner.dart`

## Bugs left open
- None intentionally left in code. Visual after-screenshot capture could not be completed for each fixed widget because local desktop-control events were blocked by macOS accessibility permissions.

## Verification
- `dart format . && flutter analyze --no-fatal-infos` after each commit.
- `PATH=/opt/homebrew/Cellar/node/24.5.0/bin:$PATH ai-workflow checks --level pr` passed. The plain command used Node 22 and failed because `better-sqlite3` was compiled for Node ABI 137 (Node 24).
