### PR TITLE
fix(release): bundle apps/api_server/scripts into the macOS .app

### DIFF
--- a/.github/workflows/desktop_release.yml
+++ b/.github/workflows/desktop_release.yml
@@ -99,6 +99,7 @@ jobs:
           DEST="$APP/Contents/Resources/api_server"
           mkdir -p "$DEST"
           cp -r ../api_server/dist "$DEST/"
+          cp -r ../api_server/scripts "$DEST/"
           cp ../api_server/package.json "$DEST/"
           cp ../api_server/package-lock.json "$DEST/"
           (
@@ -116,6 +117,7 @@ jobs:
         run: |
           DEST="build/macos/Build/Products/Release/Rhythm.app/Contents/Resources/api_server"
           test -f "$DEST/dist/server.js"
+          test -f "$DEST/scripts/postinstall.js"
           test -f "$DEST/package.json"
           test -f "$DEST/package-lock.json"
           test -f "$DEST/.env"


### PR DESCRIPTION
## Summary
Desktop release `vbeta.18.31` failed in the **Bundle CLI server into app** step. `npm install` ran inside the bundled `Rhythm.app/Contents/Resources/api_server/` and tried to execute `node scripts/postinstall.js`, but the workflow only copied `dist/`, `package.json`, and `package-lock.json` — not `scripts/`.

The postinstall is intentional (chmod node-pty spawn-helper, rebuild better-sqlite3 against the runtime Node) so we want it to run during bundling — the fix is to copy `scripts/` alongside `dist/`. Also added `scripts/postinstall.js` to the bundle verification step so future regressions fail at the verify gate, not at install time.

Failure log: https://github.com/ajhochhalter/Rhythm/actions/runs/25968794136/job/<failed-job>

## Test plan
- [ ] Merge to main.
- [ ] Re-trigger the release via `gh workflow run desktop_release.yml -f version=beta.18.31 --ref main`.
- [ ] Watch the "Bundle CLI server into app" step — should now succeed.
- [ ] Watch "Verify bundled CLI server payload" — should include the new scripts/ assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
