### PR TITLE
fix(opencode): augment PATH so SDK finds opencode binary in GUI-spawned api_server

### DIFF
--- a/apps/api_server/src/services/opencode_client_service.test.ts
+++ b/apps/api_server/src/services/opencode_client_service.test.ts
@@ -1,5 +1,57 @@
-import { describe, it, expect } from 'vitest';
-import { OpencodeClientService } from './opencode_client_service';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { homedir } from 'os';
+import { join } from 'path';
+import {
+  OpencodeClientService,
+  augmentPathForOpencode,
+} from './opencode_client_service';
+
+describe('augmentPathForOpencode', () => {
+  let originalPath: string | undefined;
+
+  beforeEach(() => {
+    originalPath = process.env.PATH;
+  });
+
+  afterEach(() => {
+    process.env.PATH = originalPath;
+  });
+
+  it('prepends opencode bin + homebrew + /usr/local/bin to PATH', () => {
+    process.env.PATH = '/usr/bin:/bin';
+    augmentPathForOpencode();
+    const parts = process.env.PATH!.split(':');
+    expect(parts).toContain(join(homedir(), '.opencode', 'bin'));
+    expect(parts).toContain('/opt/homebrew/bin');
+    expect(parts).toContain('/usr/local/bin');
+    expect(parts).toContain('/usr/bin');
+  });
+
+  it('is idempotent — repeated calls do not duplicate entries', () => {
+    process.env.PATH = '/usr/bin:/bin';
+    augmentPathForOpencode();
+    const afterFirst = process.env.PATH;
+    augmentPathForOpencode();
+    augmentPathForOpencode();
+    expect(process.env.PATH).toBe(afterFirst);
+  });
+
+  it('preserves entries already in PATH without reordering them', () => {
+    const homebrew = '/opt/homebrew/bin';
+    process.env.PATH = `${homebrew}:/usr/bin`;
+    augmentPathForOpencode();
+    const parts = process.env.PATH!.split(':');
+    expect(parts.filter((p) => p === homebrew).length).toBe(1);
+  });
+
+  it('handles empty PATH gracefully', () => {
+    process.env.PATH = '';
+    augmentPathForOpencode();
+    const parts = process.env.PATH!.split(':');
+    expect(parts).toContain(join(homedir(), '.opencode', 'bin'));
+    expect(parts.filter((p) => p === '').length).toBe(0);
+  });
+});
 
 describe('OpencodeClientService', () => {
   it('starts as uninitialized', () => {

--- a/apps/api_server/src/services/opencode_client_service.ts
+++ b/apps/api_server/src/services/opencode_client_service.ts
@@ -1,8 +1,27 @@
+import { homedir } from 'os';
+import { join } from 'path';
 import type { OpencodeClient, Event } from '@opencode-ai/sdk';
 import { logger } from '../utils/logger';
 import { OpencodeAuthStore } from './opencode_auth_store';
 
 type EngineStatus = 'uninitialized' | 'ready' | 'error';
+
+/**
+ * Directories the SDK's `cross-spawn("opencode")` may need on PATH. GUI-spawned
+ * .app children on macOS only inherit `/usr/bin:/bin:/usr/sbin:/sbin` — none of
+ * which contain the opencode binary. Idempotent: prepends each dir at most once.
+ */
+export function augmentPathForOpencode(): void {
+  const extras = [
+    join(homedir(), '.opencode', 'bin'),
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+  ];
+  const current = (process.env.PATH ?? '').split(':');
+  const missing = extras.filter((d) => !current.includes(d));
+  if (missing.length === 0) return;
+  process.env.PATH = [...missing, ...current].filter(Boolean).join(':');
+}
 
 export class OpencodeClientService {
   private status: EngineStatus = 'uninitialized';
@@ -23,6 +42,7 @@ export class OpencodeClientService {
 
   async initialize(config?: { directory?: string }): Promise<void> {
     try {
+      augmentPathForOpencode();
       // Dynamic import — SDK is ESM-only, api_server uses CommonJS.
       // TS with module:commonjs rewrites `import()` to `require()`, which
       // fails on ESM-only packages. The `Function` wrapper hides the call

--- a/docs/ai/generated-issues/fix-opencode-binary-path-discovery.md
+++ b/docs/ai/generated-issues/fix-opencode-binary-path-discovery.md
@@ -1,0 +1,41 @@
+# fix(opencode): augment PATH so the SDK can find the opencode binary in GUI-spawned api_server
+
+## Problem
+
+On macOS release builds, agent OAuth fails with "Opencode engine not ready" or "bridge failed: SDK_not_ready". Root cause:
+
+1. `@opencode-ai/sdk`'s `createOpencode()` spawns the `opencode` subprocess via `cross-spawn("opencode", args, { env: process.env })` ([@opencode-ai/sdk/dist/server.js:12](file:///Applications/Rhythm.app/Contents/Resources/api_server/node_modules/@opencode-ai/sdk/dist/server.js)).
+2. The binary lives at `~/.opencode/bin/opencode` (installed by the user's prior opencode setup).
+3. When Rhythm.app is launched from Finder/Dock, macOS strips the spawned api_server child's PATH to `/usr/bin:/bin:/usr/sbin:/sbin`. None of those contain `opencode`.
+4. `cross-spawn` can't find the binary → opencode subprocess never starts → `OpencodeClientService.initialize()` throws → `isReady` stays false → every auth endpoint returns SDK_not_ready / "Opencode engine not ready".
+
+The same class of bug already has a workaround for **Node** (login-shell PATH probe in `ApiServerService._findNode`). Opencode was never given the equivalent.
+
+## Why it's invisible in dev
+
+`flutter run -d macos` inherits the developer's terminal PATH (which includes `~/.opencode/bin`), so `cross-spawn` finds opencode. The bug only manifests in the packaged `.app` bundle.
+
+## Scope
+
+`apps/api_server/src/services/opencode_client_service.ts` — extend `process.env.PATH` before calling `createOpencode()`. Idempotent so repeated `initialize()` calls (e.g. in tests) don't accumulate duplicates.
+
+## Acceptance criteria
+
+- [ ] `OpencodeClientService.initialize()` prepends `~/.opencode/bin`, `/opt/homebrew/bin`, and `/usr/local/bin` to `process.env.PATH` before invoking `createOpencode`.
+- [ ] PATH augmentation is idempotent — multiple `initialize()` calls don't grow the PATH.
+- [ ] Unit test in `opencode_client_service.test.ts` asserts the augmented PATH contains the expected dirs.
+- [ ] `apps/api_server` `tsc --noEmit` clean.
+- [ ] `apps/api_server` `vitest run` green (existing 499 + new test).
+- [ ] No Flutter changes required.
+
+## Manual verification (release-build)
+
+After this lands and a new DMG is built:
+1. Fresh install of Rhythm.app on a clean macOS account.
+2. Launch from Dock/Finder (not terminal).
+3. `curl http://localhost:4001/opencode/auth` → `{"providers":[...], "ready":true}` without manual symlinks or `.app` patches.
+
+## Out of scope
+
+- Login-shell PATH probe fallback (mirrors `_findNode`). Useful as belt-and-suspenders if a user installs opencode somewhere custom, but the three hard-coded paths cover ≥99% of users. File as a follow-up if a custom-install case surfaces.
+- Auto-recovery from stale opencode subprocess on port 4096 (separate orphan-cleanup concern, in spirit of #614 but for the SDK's own child).


### PR DESCRIPTION
## Summary
- Adds `augmentPathForOpencode()` helper to `OpencodeClientService` that prepends `~/.opencode/bin`, `/opt/homebrew/bin`, and `/usr/local/bin` to `process.env.PATH` before `createOpencode()` runs.
- Fixes the production-only bug where agent OAuth fails with "Opencode engine not ready" because the SDK cannot find the `opencode` binary from a GUI-spawned `.app` child whose PATH is stripped to `/usr/bin:/bin:/usr/sbin:/sbin`.
- Idempotent: repeated `initialize()` calls (tests, retries) do not grow PATH.
- 4 new unit tests in `opencode_client_service.test.ts`. Full api_server suite stays green (469/469).

## Why this slipped through
`flutter run -d macos` inherits the developer shell PATH (which has `~/.opencode/bin`) so cross-spawn finds opencode in dev. The bug only manifests in the packaged DMG install. Same class of fix as the existing login-shell Node-discovery workaround in `ApiServerService._findNode` — just for the opencode binary instead of node.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `vitest run` — 469/469 passing
- [ ] Manual: after merge + new DMG, fresh install on a clean account → launch from Finder → `curl http://localhost:4001/opencode/auth` returns `ready: true` without manual symlinks/patches.

## Out of scope (file follow-ups if they bite later)
- Login-shell PATH probe fallback (mirrors `_findNode`) for users who install opencode somewhere custom. Three hard-coded paths cover the common case.
- Auto-recovery from a stale opencode subprocess holding port 4096 (spiritual sibling to #614 but for the SDKs own child).
