### PR TITLE
fix(agent-sessions): tolerate taskId missing from local SQLite

### DIFF
--- a/apps/api_server/package.json
+++ b/apps/api_server/package.json
@@ -9,6 +9,7 @@
     "start": "node dist/server.js",
     "lint": "echo 'TODO: add eslint'",
     "test": "vitest run",
+    "smoke:launch": "bash scripts/smoke-launch.sh",
     "migrate:sqlite-to-postgres": "tsx src/database/migrate_sqlite_to_postgres.ts",
     "postinstall": "node scripts/postinstall.js"
   },

--- a/apps/api_server/scripts/smoke-launch.sh
+++ b/apps/api_server/scripts/smoke-launch.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Smoke test: prove the api_server build + spawn pipeline actually works.
+#
+# What this asserts (NOT "fix is implemented"):
+#   1. Node sentinel exists and points to an executable.
+#   2. better-sqlite3 .node binary loads under that sentinel Node (ABI match).
+#   3. dist/server.js exists (build artifact present).
+#   4. Spawning the server with the sentinel Node + AGENT_LOCAL=true binds
+#      :4001 and answers /health within 25s — same path Rhythm.app uses.
+#   5. /agents/capabilities returns 200.
+#   6. POST /agent-sessions with a taskId not in local DB does NOT 500
+#      (PR #619 regression). 201 or 400-engine-not-ready both pass.
+#
+# Exit codes:
+#   0  PASS
+#   1  build/sentinel/ABI prerequisite failure
+#   2  server failed to bind :4001
+#   3  capabilities or session POST failed acceptance
+#
+# Usage: bash apps/api_server/scripts/smoke-launch.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+API_SERVER_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$API_SERVER_DIR/../.." && pwd)"
+SENTINEL="$API_SERVER_DIR/.node-runtime.json"
+DIST="$API_SERVER_DIR/dist/server.js"
+LOG_DIR="/tmp/rhythm-smoke"
+LOG="$LOG_DIR/api-server.log"
+mkdir -p "$LOG_DIR"
+
+fail() { echo "❌ FAIL: $*"; exit "${2:-1}"; }
+ok()   { echo "✅ $*"; }
+info() { echo "ℹ️  $*"; }
+
+cleanup() {
+  if [ -n "${SPAWN_PID:-}" ]; then
+    kill "$SPAWN_PID" 2>/dev/null || true
+    sleep 1
+    kill -9 "$SPAWN_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# 0. Free :4001 (kill any orphan)
+ORPHAN=$(lsof -iTCP:4001 -sTCP:LISTEN -t 2>/dev/null || true)
+if [ -n "$ORPHAN" ]; then
+  info "killing existing :4001 listener(s): $ORPHAN"
+  kill $ORPHAN 2>/dev/null || true
+  sleep 2
+fi
+
+# 1. Sentinel present
+[ -f "$SENTINEL" ] || fail "$SENTINEL missing — run apps/api_server postinstall"
+NODE_PATH=$(/usr/bin/env node -e "console.log(require('$SENTINEL').nodePath)" 2>/dev/null)
+NODE_ABI=$(/usr/bin/env node -e "console.log(require('$SENTINEL').abi)" 2>/dev/null)
+[ -x "$NODE_PATH" ] || fail "sentinel nodePath not executable: $NODE_PATH"
+ok "sentinel: $NODE_PATH (ABI $NODE_ABI)"
+
+# 2. better-sqlite3 ABI match under sentinel Node
+"$NODE_PATH" -e "
+  const p='$REPO_ROOT/node_modules/better-sqlite3/build/Release/better_sqlite3.node';
+  try { process.dlopen({exports:{}}, p); }
+  catch(e){ console.error(e.message.split('\\n')[0]); process.exit(2); }
+" 2>/tmp/rhythm-smoke/abi-err || fail "better-sqlite3 ABI mismatch under sentinel Node: $(cat /tmp/rhythm-smoke/abi-err)"
+ok "better-sqlite3 loads under sentinel Node"
+
+# 3. dist build artifact
+[ -f "$DIST" ] || fail "$DIST missing — run 'cd apps/api_server && npm run build'"
+ok "dist/server.js present"
+
+# 4. Spawn the server exactly like Rhythm.app does
+info "spawning: $NODE_PATH $DIST (PORT=4001 AGENT_LOCAL=true) — same env Flutter ApiServerService uses"
+( cd "$API_SERVER_DIR" && AGENT_LOCAL=true PORT=4001 "$NODE_PATH" "$DIST" >"$LOG" 2>&1 ) &
+SPAWN_PID=$!
+info "pid=$SPAWN_PID waiting for :4001 (25s budget)"
+
+deadline=$(( $(date +%s) + 25 ))
+while true; do
+  if curl -fsS -o /dev/null --max-time 1 http://localhost:4001/health; then
+    break
+  fi
+  if ! kill -0 "$SPAWN_PID" 2>/dev/null; then
+    echo "--- api_server log tail ---"
+    tail -50 "$LOG"
+    fail "server crashed before /health responded" 2
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "--- api_server log tail ---"
+    tail -50 "$LOG"
+    fail "server did not bind :4001 within 25s" 2
+  fi
+  sleep 0.5
+done
+ok "server bound :4001 and answered /health"
+
+# 5. /agents/capabilities
+CAPS=$(curl -sS -w "\n%{http_code}" http://localhost:4001/agents/capabilities)
+CAPS_CODE=$(echo "$CAPS" | tail -1)
+[ "$CAPS_CODE" = "200" ] || fail "/agents/capabilities returned $CAPS_CODE" 3
+ok "/agents/capabilities → 200"
+
+# 6. PR #619 regression: POST with bogus taskId must NOT 500
+BODY=$(cat <<EOF
+{"agentId":"claude-code","name":"smoke-619","cwd":"$HOME","taskId":"definitely-not-in-local-db","taskTitle":"Synthetic"}
+EOF
+)
+RESP=$(curl -sS -w "\n%{http_code}" -X POST http://localhost:4001/agent-sessions \
+  -H "Content-Type: application/json" -d "$BODY")
+SESS_CODE=$(echo "$RESP" | tail -1)
+SESS_BODY=$(echo "$RESP" | sed '$d')
+case "$SESS_CODE" in
+  500)
+    echo "$SESS_BODY"
+    fail "POST /agent-sessions with bogus taskId returned 500 — FK regression" 3
+    ;;
+  201)
+    ok "POST /agent-sessions → 201 (session created end-to-end)"
+    ;;
+  400)
+    ok "POST /agent-sessions → 400 (expected when Opencode not authed — FK path is past)"
+    ;;
+  *)
+    echo "$SESS_BODY"
+    fail "POST /agent-sessions returned unexpected HTTP $SESS_CODE" 3
+    ;;
+esac
+
+echo
+ok "ALL CHECKS PASSED — build + spawn + bind + agent-session FK path verified"
+echo "log: $LOG"
+exit 0

--- a/apps/api_server/scripts/smoke-launch.sh
+++ b/apps/api_server/scripts/smoke-launch.sh
@@ -19,6 +19,12 @@
 #
 # Usage: bash apps/api_server/scripts/smoke-launch.sh
 set -uo pipefail
+# Enable job control so the background spawn lives in its own process group;
+# this lets us kill the whole tree (including the Opencode SDK's child node
+# server) on cleanup. Without this the Opencode child reparents to launchd
+# and keeps :4001 bound — causing the next Rhythm.app launch to "reuse" a
+# stale server pointing at the wrong DB.
+set -m
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 API_SERVER_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -27,7 +33,11 @@ SENTINEL="$API_SERVER_DIR/.node-runtime.json"
 DIST="$API_SERVER_DIR/dist/server.js"
 LOG_DIR="/tmp/rhythm-smoke"
 LOG="$LOG_DIR/api-server.log"
+# Isolated DB so smoke can never overwrite the user's real data at
+# ~/Library/Application Support/Rhythm/rhythm.db.
+SMOKE_DB="$LOG_DIR/smoke.db"
 mkdir -p "$LOG_DIR"
+rm -f "$SMOKE_DB" "$SMOKE_DB-shm" "$SMOKE_DB-wal"
 
 fail() { echo "❌ FAIL: $*"; exit "${2:-1}"; }
 ok()   { echo "✅ $*"; }
@@ -35,12 +45,19 @@ info() { echo "ℹ️  $*"; }
 
 cleanup() {
   if [ -n "${SPAWN_PID:-}" ]; then
-    kill "$SPAWN_PID" 2>/dev/null || true
+    # Kill the whole process group so the Opencode SDK child node dies too.
+    kill -- "-$SPAWN_PID" 2>/dev/null || kill "$SPAWN_PID" 2>/dev/null || true
     sleep 1
-    kill -9 "$SPAWN_PID" 2>/dev/null || true
+    kill -9 -- "-$SPAWN_PID" 2>/dev/null || kill -9 "$SPAWN_PID" 2>/dev/null || true
+  fi
+  # Belt-and-suspenders: nuke anything still bound to :4001 that we spawned.
+  STRAY=$(lsof -iTCP:4001 -sTCP:LISTEN -t 2>/dev/null || true)
+  if [ -n "$STRAY" ]; then
+    info "cleanup: killing stray :4001 listener(s) $STRAY"
+    kill -9 $STRAY 2>/dev/null || true
   fi
 }
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
 
 # 0. Free :4001 (kill any orphan)
 ORPHAN=$(lsof -iTCP:4001 -sTCP:LISTEN -t 2>/dev/null || true)
@@ -70,8 +87,8 @@ ok "better-sqlite3 loads under sentinel Node"
 ok "dist/server.js present"
 
 # 4. Spawn the server exactly like Rhythm.app does
-info "spawning: $NODE_PATH $DIST (PORT=4001 AGENT_LOCAL=true) — same env Flutter ApiServerService uses"
-( cd "$API_SERVER_DIR" && AGENT_LOCAL=true PORT=4001 "$NODE_PATH" "$DIST" >"$LOG" 2>&1 ) &
+info "spawning: $NODE_PATH $DIST (PORT=4001 AGENT_LOCAL=true DB_PATH=$SMOKE_DB)"
+( cd "$API_SERVER_DIR" && AGENT_LOCAL=true PORT=4001 DB_PATH="$SMOKE_DB" "$NODE_PATH" "$DIST" >"$LOG" 2>&1 ) &
 SPAWN_PID=$!
 info "pid=$SPAWN_PID waiting for :4001 (25s budget)"
 

--- a/apps/api_server/src/__tests__/agent_sessions.test.ts
+++ b/apps/api_server/src/__tests__/agent_sessions.test.ts
@@ -748,4 +748,58 @@ describe('Agent Sessions API', () => {
     });
     expect(res.status).toBe(400);
   });
+
+  // ── FK tolerance: taskId not in local tasks table ─────────────────────────
+
+  it('creates a session with taskId=null when taskId is not present in the local tasks table', async () => {
+    // foreign_keys = ON is set in makeDb(); this taskId does not exist in tasks.
+    const bogusTaskId = 'definitely-not-in-local-db';
+    const taskTitle = 'Synthetic task from production';
+
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        agentId: 'claude-code',
+        cwd: os.homedir(),
+        name: 'FK tolerance test',
+        taskId: bogusTaskId,
+        taskTitle,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const session = (await res.json()) as { taskId: string | null; taskTitle: string | null };
+    // taskId should be nulled out (not in local DB); taskTitle preserved for UI
+    expect(session.taskId).toBeNull();
+    expect(session.taskTitle).toBe(taskTitle);
+  });
+
+  it('creates a session with taskId set when taskId exists in the local tasks table', async () => {
+    // Insert a real task into the local DB so the FK check passes.
+    const { getDb } = await import('../database/db');
+    const db = getDb();
+    const taskId = 'local-task-abc123';
+    db.prepare(
+      `INSERT INTO tasks (id, title, status, created_at, updated_at)
+       VALUES (?, 'Local Task', 'pending', datetime('now'), datetime('now'))`,
+    ).run(taskId);
+
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        agentId: 'claude-code',
+        cwd: os.homedir(),
+        name: 'Real task FK test',
+        taskId,
+        taskTitle: 'Local Task',
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const session = (await res.json()) as { taskId: string | null; taskTitle: string | null };
+    expect(session.taskId).toBe(taskId);
+    expect(session.taskTitle).toBe('Local Task');
+  });
 });

--- a/apps/api_server/src/__tests__/agent_sessions.test.ts
+++ b/apps/api_server/src/__tests__/agent_sessions.test.ts
@@ -749,34 +749,67 @@ describe('Agent Sessions API', () => {
     expect(res.status).toBe(400);
   });
 
-  // ── FK tolerance: taskId not in local tasks table ─────────────────────────
+  // ── PR #619 acceptance: SESSIONS ACTUALLY LAUNCH when taskId is missing locally
+  // Contract: docs/ai/contracts/pr-619.json
+  // These tests assert the full launch path, not just "row inserted":
+  //   - 201 with the expected taskId/taskTitle reconciliation
+  //   - opencodeClient.createSession invoked (SDK session created)
+  //   - opencodeSessionMap populated (stream-bridge can route prompts → SDK)
+  //   - opencodeClient.promptAsync invoked (initial prompt actually dispatched)
 
-  it('creates a session with taskId=null when taskId is not present in the local tasks table', async () => {
+  it('launches a session end-to-end when taskId is not present in the local tasks table (PR #619 acceptance)', async () => {
     // foreign_keys = ON is set in makeDb(); this taskId does not exist in tasks.
     const bogusTaskId = 'definitely-not-in-local-db';
     const taskTitle = 'Synthetic task from production';
+    const sessionName = 'FK launch test';
+    const cwd = os.homedir();
+
+    const { opencodeClient, opencodeSessionMap } = await import('../services/opencode_engine');
+    const mock = opencodeClient as unknown as {
+      createSession: ReturnType<typeof vi.fn>;
+      promptAsync: ReturnType<typeof vi.fn>;
+    };
+    mock.createSession.mockResolvedValueOnce({ id: 'sdk-launch-no-fk' });
 
     const res = await fetch(`${baseUrl}/agent-sessions`, {
       method: 'POST',
       headers: authHeaders,
       body: JSON.stringify({
         agentId: 'claude-code',
-        cwd: os.homedir(),
-        name: 'FK tolerance test',
+        cwd,
+        name: sessionName,
         taskId: bogusTaskId,
         taskTitle,
       }),
     });
 
     expect(res.status).toBe(201);
-    const session = (await res.json()) as { taskId: string | null; taskTitle: string | null };
-    // taskId should be nulled out (not in local DB); taskTitle preserved for UI
+    const session = (await res.json()) as {
+      id: string;
+      taskId: string | null;
+      taskTitle: string | null;
+      status: string;
+    };
+    // FK reconciliation: id is dropped, title is kept for UI display.
     expect(session.taskId).toBeNull();
     expect(session.taskTitle).toBe(taskTitle);
+    expect(session.status).toBe('starting');
+
+    // The session ACTUALLY LAUNCHED — assert the three SDK-side invariants:
+    //   1. SDK session was created with our cwd + name
+    expect(mock.createSession).toHaveBeenCalledWith(sessionName, cwd);
+    //   2. local id ↔ SDK id mapping is registered (otherwise WS prompts can't route)
+    expect(opencodeSessionMap.get(session.id)).toBe('sdk-launch-no-fk');
+    //   3. initial prompt was dispatched (session is doing work, not parked)
+    expect(mock.promptAsync).toHaveBeenCalled();
+    const [sdkId, promptText] = mock.promptAsync.mock.calls.at(-1)!;
+    expect(sdkId).toBe('sdk-launch-no-fk');
+    expect(promptText).toContain(sessionName);
+    // taskTitle should be folded into the initial prompt when present
+    expect(promptText).toContain(taskTitle);
   });
 
-  it('creates a session with taskId set when taskId exists in the local tasks table', async () => {
-    // Insert a real task into the local DB so the FK check passes.
+  it('launches a session end-to-end when taskId IS present in the local tasks table (happy path)', async () => {
     const { getDb } = await import('../database/db');
     const db = getDb();
     const taskId = 'local-task-abc123';
@@ -785,21 +818,39 @@ describe('Agent Sessions API', () => {
        VALUES (?, 'Local Task', 'pending', datetime('now'), datetime('now'))`,
     ).run(taskId);
 
+    const sessionName = 'Real task launch';
+    const cwd = os.homedir();
+    const { opencodeClient, opencodeSessionMap } = await import('../services/opencode_engine');
+    const mock = opencodeClient as unknown as {
+      createSession: ReturnType<typeof vi.fn>;
+      promptAsync: ReturnType<typeof vi.fn>;
+    };
+    mock.createSession.mockResolvedValueOnce({ id: 'sdk-launch-with-fk' });
+
     const res = await fetch(`${baseUrl}/agent-sessions`, {
       method: 'POST',
       headers: authHeaders,
       body: JSON.stringify({
         agentId: 'claude-code',
-        cwd: os.homedir(),
-        name: 'Real task FK test',
+        cwd,
+        name: sessionName,
         taskId,
         taskTitle: 'Local Task',
       }),
     });
 
     expect(res.status).toBe(201);
-    const session = (await res.json()) as { taskId: string | null; taskTitle: string | null };
+    const session = (await res.json()) as {
+      id: string;
+      taskId: string | null;
+      taskTitle: string | null;
+      status: string;
+    };
     expect(session.taskId).toBe(taskId);
     expect(session.taskTitle).toBe('Local Task');
+    expect(session.status).toBe('starting');
+    expect(mock.createSession).toHaveBeenCalledWith(sessionName, cwd);
+    expect(opencodeSessionMap.get(session.id)).toBe('sdk-launch-with-fk');
+    expect(mock.promptAsync).toHaveBeenCalled();
   });
 });

--- a/apps/api_server/src/controllers/agent_sessions_controller.ts
+++ b/apps/api_server/src/controllers/agent_sessions_controller.ts
@@ -5,9 +5,11 @@ import { AgentSessionsRepository } from '../repositories/agent_sessions_reposito
 import { AgentSessionMessagesRepository } from '../repositories/agent_session_messages_repository';
 import { AgentConfigsRepository } from '../repositories/agent_configs_repository';
 import { ProjectsRepository } from '../repositories/projects_repository';
+import { TasksRepository } from '../repositories/tasks_repository';
 import type { AgentKind, CreateAgentSessionDto } from '../models/agent_session';
 import { opencodeClient, opencodeSessionMap } from '../services/opencode_engine';
 import { streamBridge } from '../services/opencode_stream_bridge';
+import { logger } from '../utils/logger';
 
 // Legacy agentId aliases. Older Rhythm clients (and a handful of historical
 // scripts) used short names. /agents/capabilities and the seed both use
@@ -100,9 +102,25 @@ export class AgentSessionsController {
         throw AppError.badRequest('name is required and must be a non-empty string');
       }
 
+      let resolvedTaskId: string | null = null;
       if (taskId !== undefined && taskId !== null) {
         if (typeof taskId !== 'string') {
           throw AppError.badRequest('taskId must be a string');
+        }
+        // Defensive FK check: the local SQLite tasks table may not contain
+        // production task IDs (sync gap). Rather than let SQLite raise
+        // SQLITE_CONSTRAINT_FOREIGNKEY (which becomes a 500), we probe the
+        // local table and silently null out the foreign key when not found.
+        // task_title is preserved so the UI still shows context.
+        try {
+          new TasksRepository().findByIdIncludingLegacy(taskId);
+          resolvedTaskId = taskId;
+        } catch {
+          logger.warn(
+            `[AgentSessionsController] taskId "${taskId}" not found in local tasks table — ` +
+              'creating agent session with task_id=null; task_title will be preserved.',
+          );
+          resolvedTaskId = null;
         }
       }
 
@@ -129,7 +147,7 @@ export class AgentSessionsController {
 
       const dto: CreateAgentSessionDto = {
         agentKind: normalizedAgentId as AgentKind,
-        taskId: taskId != null ? (taskId as string) : null,
+        taskId: resolvedTaskId,
         taskTitle: taskTitle != null ? (taskTitle as string) : null,
         cwd: expandedCwd,
         name: name.trim(),

--- a/apps/api_server/src/utils/logger.ts
+++ b/apps/api_server/src/utils/logger.ts
@@ -3,6 +3,10 @@ export const logger = {
     // eslint-disable-next-line no-console
     console.log(`[INFO] ${message}`, ...args);
   },
+  warn(message: string, ...args: unknown[]) {
+    // eslint-disable-next-line no-console
+    console.warn(`[WARN] ${message}`, ...args);
+  },
   error(message: string, ...args: unknown[]) {
     // eslint-disable-next-line no-console
     console.error(`[ERROR] ${message}`, ...args);

--- a/docs/ai/contracts/pr-619.json
+++ b/docs/ai/contracts/pr-619.json
@@ -1,0 +1,26 @@
+{
+  "pr": 619,
+  "title": "fix(agent-sessions): tolerate taskId missing from local SQLite",
+  "user_acceptance_criterion": "SESSIONS ACTUALLY LAUNCH — POST /agent-sessions with a taskId picked from production data (not present in the local SQLite tasks table) must successfully start a backing Opencode SDK session, not merely return 201 with a DB row.",
+  "failure_evidence_before_fix": [
+    "Curl repro on the running local agent server (PID 91607, :4001): POST /agent-sessions with {\"taskId\":\"<id-not-in-local-tasks>\"} returns HTTP 500 INTERNAL_ERROR with a correlationId.",
+    "Flutter desktop New-agent-session dialog: 'Something went wrong on the server.' under Details.",
+    "Flutter Task-ready bubble: 'Internal server error.'"
+  ],
+  "root_cause": "PRAGMA foreign_keys = ON (apps/api_server/src/database/db.ts:61) plus agent_sessions.task_id REFERENCES tasks(id). Flutter task picker reads from production (api.vcrcapps.com per ServerConfigService), but POSTs go to localhost:4001 whose local tasks table doesn't always have the picked row. SQLite raises SQLITE_CONSTRAINT_FOREIGNKEY, a plain Error (not AppError), so error_handler.ts returns 500.",
+  "required_assertions": [
+    "POST /agent-sessions with bogus taskId returns 201",
+    "Response.taskId === null (FK softly resolved to null)",
+    "Response.taskTitle === sent value (preserved for UI)",
+    "Response.status === 'starting'",
+    "opencodeClient.createSession was called with the session name and cwd (proves SDK session creation reached)",
+    "opencodeSessionMap contains an entry mapping local id → SDK id (proves stream-bridge mapping registered — without this, ws_gateway cannot route prompts to the SDK)",
+    "opencodeClient.promptAsync was called with the initial prompt (proves the session has actually started doing work, not just been created)"
+  ],
+  "test_file": "apps/api_server/src/__tests__/agent_sessions.test.ts",
+  "test_names": [
+    "launches a session end-to-end when taskId is not present in the local tasks table (PR #619 acceptance)",
+    "launches a session end-to-end when taskId IS present in the local tasks table (happy path)"
+  ],
+  "mandate": "PASS = the two contract tests above are green AND the full agent_sessions test suite is green. PASS is not 'tsc clean' alone, and not 'fix is implemented'."
+}


### PR DESCRIPTION
## Summary
- Fix HTTP 500 when starting an agent session linked to a task. "New agent session" dialog showed "Something went wrong on the server"; "Task ready" bubble showed "Internal server error."
- Root cause: the Flutter task picker is populated from production (`api.vcrcapps.com`), but the POST goes to the local agent server (`localhost:4001`). The local SQLite `tasks` table doesn't always have the picked task yet (sync gap — tracked in #620). With `PRAGMA foreign_keys = ON` (`apps/api_server/src/database/db.ts:61`) and `agent_sessions.task_id REFERENCES tasks(id)`, SQLite raised `SQLITE_CONSTRAINT_FOREIGNKEY` — a plain `Error`, not an `AppError` — so `error_handler.ts` returned 500.
- The schema already stores `task_title` independently of `task_id` (migration comment at `migrations.ts:793` explicitly notes this is for the local-server display case), so the minimal fix is in the controller: probe local tasks; if the id is missing, log a `warn` and null out `task_id` while preserving `task_title`.

## Changes
- `apps/api_server/src/controllers/agent_sessions_controller.ts` — defensive lookup in `create()` before DTO construction.
- `apps/api_server/src/utils/logger.ts` — add `warn()`.
- `apps/api_server/src/__tests__/agent_sessions.test.ts` — two acceptance-contract tests (see below).
- `docs/ai/contracts/pr-619.json` — acceptance contract: what "session actually launches" means.

## Acceptance contract — sessions actually launch

Contract: [`docs/ai/contracts/pr-619.json`](docs/ai/contracts/pr-619.json).

The two new tests do not just assert "HTTP 201 / row inserted." They assert the full launch path that proves a session is actually doing work:

| Assertion | Why it matters |
|---|---|
| HTTP 201 + `taskId: null` + `taskTitle` preserved + `status: 'starting'` | Response shape contract |
| `opencodeClient.createSession` called with `(name, cwd)` | SDK session actually created |
| `opencodeSessionMap.get(localId) === sdkId` | Stream-bridge mapping is registered — without this, `ws_gateway.session.input` can't route prompts to the SDK and the session would be silently dead |
| `opencodeClient.promptAsync` called with the initial prompt containing `taskTitle` | Initial prompt actually dispatched — the session is doing work, not parked |

### Red/green proof

Reverting the controller fix while keeping the test file:

```
FAIL  src/__tests__/agent_sessions.test.ts > launches a session end-to-end when taskId is not present in the local tasks table (PR #619 acceptance)
AssertionError: expected 500 to be 201
```

With the fix restored: **48/48 tests pass** in the `agent_sessions` suite, **467/467 across the full api_server suite**.

## Verification
- `npx tsc --noEmit` — clean.
- `npm test` (api_server) — 467/467 pass.
- `flutter analyze --no-fatal-infos` — exit 0 (only pre-existing infos).
- `dart format . --set-exit-if-changed` — clean.
- Pre-handoff smoke against `dist/server.js` on `:4101`:
  - `GET /health` → 200
  - `GET /agents/capabilities` → 200
  - `POST /agent-sessions` with bogus `taskId` → **HTTP 400 "Opencode engine is not ready"** (expected in dev with no AI creds), confirming the FK constraint no longer fires; in the installed app where Opencode IS ready, this path proceeds to actual launch.

## Manual smoke (must pass before merge)
The bundled api_server runs as a child of the installed `.app`. Quit Rhythm.app (Cmd+Q) **and** kill any orphan `lsof -iTCP:4001` listener before relaunching — Flutter run from source then picks up `apps/api_server/dist/server.js` with the fix.

- [ ] Open "New agent session", pick a task that's known to live only on production, click Start → session created (not "Something went wrong on the server"). The session row shows the task title even though `task_id` stored is `null`.
- [ ] When a `claude-trigger` "Task ready" bubble appears, click "Start with Claude Code" → session starts (not "Internal server error").
- [ ] Open the created session and send a prompt → confirm streaming response (full launch path).

## Follow-up
- #620 — the underlying sync gap that lets production tasks be absent from local SQLite. PR #619 is the defensive boundary fix; #620 closes the actual mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
