### PR TITLE
fix(agent-sessions): tolerate taskId missing from local SQLite (rebased onto #617/follow-up)

### DIFF
--- a/.agent-stack/postmortems/2026-05-19-pr-621-agent-fk-tolerance.json
+++ b/.agent-stack/postmortems/2026-05-19-pr-621-agent-fk-tolerance.json
@@ -1,0 +1,58 @@
+{
+  "date": "2026-05-19",
+  "pr": 621,
+  "title": "fix(agent-sessions): tolerate taskId missing from local SQLite",
+  "branch": "fix/agent-session-fk-task-id-tolerance-followup",
+  "base": "follow-up (PR #617)",
+  "verification_gate": {
+    "tsc": "clean",
+    "tests": "508/508 (apps/api_server)",
+    "flutter_analyze": "0 errors (info-only)",
+    "smoke_pipeline": "PASS via npm run smoke:launch",
+    "live_acceptance": "POST against running Rhythm.app api_server with bogus taskId returned HTTP 201, WARN logged, taskTitle preserved",
+    "red_green_proof": "reverting controller fix while keeping tests fails 2 acceptance tests with HTTP 500 expected 201; restoring fix returns to 508/508"
+  },
+  "manual_smoke_result": "PASS for the PR's scope (FK tolerance); 4 unrelated defects caught during smoke and filed as follow-ups",
+  "followups_filed_during_smoke": [
+    { "id": 620, "title": "sync: local SQLite tasks table missing tasks that exist on production", "relation": "the underlying gap the FK tolerance defends against; #621 is the boundary fix, #620 fixes the mirror" },
+    { "id": 622, "title": "agent chat: 'question' tool call renders as raw args instead of an answer selector" },
+    { "id": 623, "title": "agent chat: Task-ready bubble forces agent pre-selection instead of using the composer picker" },
+    { "id": 624, "title": "agent chat: follow-up user message accepted by SDK but no LLM call fires; UI stuck on 'working'" },
+    { "id": 625, "title": "agent chat: mini-bubble transcript blanks when a different session is selected in the Agents tab" }
+  ],
+  "what_went_well": [
+    "Acceptance contract caught a real claim that the original test only covered 'row inserted' — strengthened to assert opencodeClient.createSession + opencodeSessionMap + promptAsync, the actual 'session launches' invariants.",
+    "Red/green proof (revert fix → 2 fail with HTTP 500; restore fix → 508/508) demonstrated the tests gate on the fix, not on incidental setup.",
+    "smoke-launch.sh + npm run smoke:launch caught two distinct orphan classes that had been costing the user repeated 'click Retry' cycles."
+  ],
+  "what_went_wrong": [
+    {
+      "issue": "PR opened against stale main",
+      "cost": "Forced a re-base to the follow-up branch (PR #617) after the user pointed out the agent picker dialog UI was obsolete. PR #619 had to be closed and superseded by #621.",
+      "root_cause": "Default branch verification step skipped — orchestrator didn't run 'ai-workflow status' or audit open draft PRs before branching off main.",
+      "prevention": "Workflow-orchestrator must check `gh pr list --state open` for active draft PRs that may be the true trunk before branching. Update planning skill to make this explicit."
+    },
+    {
+      "issue": "Smoke script v1 leaked process-group children, orphaning opencode-serve on :4096",
+      "cost": "User saw 'Opencode Engine not ready' on retry; Rhythm.app silently 'reused' the stale dev-DB api_server, surfacing as 'old code reverted' confusion.",
+      "root_cause": "Spawn without `set -m`; cleanup only killed the main PID, not the SDK's child opencode-serve. Combined with cwd-defaulted DB_PATH writing apps/api_server/rhythm.db.",
+      "prevention": "Smoke now uses set -m, kills the process group, additionally pkills 'opencode serve', and points DB_PATH at /tmp/rhythm-smoke/smoke.db. Hardened in commit 0cdd255."
+    },
+    {
+      "issue": "User had to click Retry repeatedly while ABI was diagnosed",
+      "cost": "Friction; user explicitly asked for an automated test to replace manual clicks.",
+      "root_cause": "Initial better-sqlite3 rebuild used PATH-shadowed Node (v24 ABI 137 instead of v22 ABI 127). The rebuild ran nominally through /usr/local/bin/npm but its node-gyp child picked up /opt/homebrew/bin/node from PATH.",
+      "prevention": "When rebuilding native modules in a session where 'which node' differs from the sentinel Node, prefix the rebuild with explicit PATH=/usr/local/bin:$PATH. The smoke script now ABI-checks the binary against the sentinel Node before spawn so this fails fast next time."
+    }
+  ],
+  "decisions": [
+    "Closed PR #619 and opened PR #621 against follow-up rather than rebasing main forward. Cleaner: #617/#621 ship together; main carries no half-baked staging.",
+    "Hardened smoke covers :4001, :4096, and any 'opencode serve' process — not just :4001 — because the SDK's child server matters as much as the api_server itself for end-to-end behavior.",
+    "Used an isolated DB_PATH for smoke so stray orphan processes can never corrupt user data."
+  ],
+  "lessons_for_workflow_orchestrator": [
+    "Branch-detection: before creating a new branch off main, check `gh pr list --state open` for draft/long-lived trunk PRs.",
+    "Smoke definition: 'session actually launches' means SDK session created + map registered + initial prompt fired, not just 'HTTP 201'. Acceptance contract should encode the full chain.",
+    "Spawn cleanup: any subprocess that creates further subprocesses needs process-group lifecycle. Cleanup must enumerate ports the child binds, not just the parent's port."
+  ]
+}

--- a/apps/api_server/package.json
+++ b/apps/api_server/package.json
@@ -9,6 +9,7 @@
     "start": "node dist/server.js",
     "lint": "echo 'TODO: add eslint'",
     "test": "vitest run",
+    "smoke:launch": "bash scripts/smoke-launch.sh",
     "migrate:sqlite-to-postgres": "tsx src/database/migrate_sqlite_to_postgres.ts",
     "postinstall": "node scripts/postinstall.js"
   },

--- a/apps/api_server/scripts/smoke-launch.sh
+++ b/apps/api_server/scripts/smoke-launch.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Smoke test: prove the api_server build + spawn pipeline actually works.
+#
+# What this asserts (NOT "fix is implemented"):
+#   1. Node sentinel exists and points to an executable.
+#   2. better-sqlite3 .node binary loads under that sentinel Node (ABI match).
+#   3. dist/server.js exists (build artifact present).
+#   4. Spawning the server with the sentinel Node + AGENT_LOCAL=true binds
+#      :4001 and answers /health within 25s — same path Rhythm.app uses.
+#   5. /agents/capabilities returns 200.
+#   6. POST /agent-sessions with a taskId not in local DB does NOT 500
+#      (PR #619 regression). 201 or 400-engine-not-ready both pass.
+#
+# Exit codes:
+#   0  PASS
+#   1  build/sentinel/ABI prerequisite failure
+#   2  server failed to bind :4001
+#   3  capabilities or session POST failed acceptance
+#
+# Usage: bash apps/api_server/scripts/smoke-launch.sh
+set -uo pipefail
+# Enable job control so the background spawn lives in its own process group;
+# this lets us kill the whole tree (including the Opencode SDK's child node
+# server) on cleanup. Without this the Opencode child reparents to launchd
+# and keeps :4001 bound — causing the next Rhythm.app launch to "reuse" a
+# stale server pointing at the wrong DB.
+set -m
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+API_SERVER_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$API_SERVER_DIR/../.." && pwd)"
+SENTINEL="$API_SERVER_DIR/.node-runtime.json"
+DIST="$API_SERVER_DIR/dist/server.js"
+LOG_DIR="/tmp/rhythm-smoke"
+LOG="$LOG_DIR/api-server.log"
+# Isolated DB so smoke can never overwrite the user's real data at
+# ~/Library/Application Support/Rhythm/rhythm.db.
+SMOKE_DB="$LOG_DIR/smoke.db"
+mkdir -p "$LOG_DIR"
+rm -f "$SMOKE_DB" "$SMOKE_DB-shm" "$SMOKE_DB-wal"
+
+fail() { echo "❌ FAIL: $*"; exit "${2:-1}"; }
+ok()   { echo "✅ $*"; }
+info() { echo "ℹ️  $*"; }
+
+cleanup() {
+  if [ -n "${SPAWN_PID:-}" ]; then
+    # Kill the whole process group so the Opencode SDK child node dies too.
+    kill -- "-$SPAWN_PID" 2>/dev/null || kill "$SPAWN_PID" 2>/dev/null || true
+    sleep 1
+    kill -9 -- "-$SPAWN_PID" 2>/dev/null || kill -9 "$SPAWN_PID" 2>/dev/null || true
+  fi
+  # Belt-and-suspenders: nuke anything still bound to :4001 that we spawned.
+  STRAY=$(lsof -iTCP:4001 -sTCP:LISTEN -t 2>/dev/null || true)
+  if [ -n "$STRAY" ]; then
+    info "cleanup: killing stray :4001 listener(s) $STRAY"
+    kill -9 $STRAY 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# 0. Free :4001 (kill any orphan)
+ORPHAN=$(lsof -iTCP:4001 -sTCP:LISTEN -t 2>/dev/null || true)
+if [ -n "$ORPHAN" ]; then
+  info "killing existing :4001 listener(s): $ORPHAN"
+  kill $ORPHAN 2>/dev/null || true
+  sleep 2
+fi
+
+# 1. Sentinel present
+[ -f "$SENTINEL" ] || fail "$SENTINEL missing — run apps/api_server postinstall"
+NODE_PATH=$(/usr/bin/env node -e "console.log(require('$SENTINEL').nodePath)" 2>/dev/null)
+NODE_ABI=$(/usr/bin/env node -e "console.log(require('$SENTINEL').abi)" 2>/dev/null)
+[ -x "$NODE_PATH" ] || fail "sentinel nodePath not executable: $NODE_PATH"
+ok "sentinel: $NODE_PATH (ABI $NODE_ABI)"
+
+# 2. better-sqlite3 ABI match under sentinel Node
+"$NODE_PATH" -e "
+  const p='$REPO_ROOT/node_modules/better-sqlite3/build/Release/better_sqlite3.node';
+  try { process.dlopen({exports:{}}, p); }
+  catch(e){ console.error(e.message.split('\\n')[0]); process.exit(2); }
+" 2>/tmp/rhythm-smoke/abi-err || fail "better-sqlite3 ABI mismatch under sentinel Node: $(cat /tmp/rhythm-smoke/abi-err)"
+ok "better-sqlite3 loads under sentinel Node"
+
+# 3. dist build artifact
+[ -f "$DIST" ] || fail "$DIST missing — run 'cd apps/api_server && npm run build'"
+ok "dist/server.js present"
+
+# 4. Spawn the server exactly like Rhythm.app does
+info "spawning: $NODE_PATH $DIST (PORT=4001 AGENT_LOCAL=true DB_PATH=$SMOKE_DB)"
+( cd "$API_SERVER_DIR" && AGENT_LOCAL=true PORT=4001 DB_PATH="$SMOKE_DB" "$NODE_PATH" "$DIST" >"$LOG" 2>&1 ) &
+SPAWN_PID=$!
+info "pid=$SPAWN_PID waiting for :4001 (25s budget)"
+
+deadline=$(( $(date +%s) + 25 ))
+while true; do
+  if curl -fsS -o /dev/null --max-time 1 http://localhost:4001/health; then
+    break
+  fi
+  if ! kill -0 "$SPAWN_PID" 2>/dev/null; then
+    echo "--- api_server log tail ---"
+    tail -50 "$LOG"
+    fail "server crashed before /health responded" 2
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "--- api_server log tail ---"
+    tail -50 "$LOG"
+    fail "server did not bind :4001 within 25s" 2
+  fi
+  sleep 0.5
+done
+ok "server bound :4001 and answered /health"
+
+# 5. /agents/capabilities
+CAPS=$(curl -sS -w "\n%{http_code}" http://localhost:4001/agents/capabilities)
+CAPS_CODE=$(echo "$CAPS" | tail -1)
+[ "$CAPS_CODE" = "200" ] || fail "/agents/capabilities returned $CAPS_CODE" 3
+ok "/agents/capabilities → 200"
+
+# 6. PR #619 regression: POST with bogus taskId must NOT 500
+BODY=$(cat <<EOF
+{"agentId":"claude-code","name":"smoke-619","cwd":"$HOME","taskId":"definitely-not-in-local-db","taskTitle":"Synthetic"}
+EOF
+)
+RESP=$(curl -sS -w "\n%{http_code}" -X POST http://localhost:4001/agent-sessions \
+  -H "Content-Type: application/json" -d "$BODY")
+SESS_CODE=$(echo "$RESP" | tail -1)
+SESS_BODY=$(echo "$RESP" | sed '$d')
+case "$SESS_CODE" in
+  500)
+    echo "$SESS_BODY"
+    fail "POST /agent-sessions with bogus taskId returned 500 — FK regression" 3
+    ;;
+  201)
+    ok "POST /agent-sessions → 201 (session created end-to-end)"
+    ;;
+  400)
+    ok "POST /agent-sessions → 400 (expected when Opencode not authed — FK path is past)"
+    ;;
+  *)
+    echo "$SESS_BODY"
+    fail "POST /agent-sessions returned unexpected HTTP $SESS_CODE" 3
+    ;;
+esac
+
+echo
+ok "ALL CHECKS PASSED — build + spawn + bind + agent-session FK path verified"
+echo "log: $LOG"
+exit 0

--- a/apps/api_server/scripts/smoke-launch.sh
+++ b/apps/api_server/scripts/smoke-launch.sh
@@ -50,22 +50,33 @@ cleanup() {
     sleep 1
     kill -9 -- "-$SPAWN_PID" 2>/dev/null || kill -9 "$SPAWN_PID" 2>/dev/null || true
   fi
-  # Belt-and-suspenders: nuke anything still bound to :4001 that we spawned.
-  STRAY=$(lsof -iTCP:4001 -sTCP:LISTEN -t 2>/dev/null || true)
-  if [ -n "$STRAY" ]; then
-    info "cleanup: killing stray :4001 listener(s) $STRAY"
-    kill -9 $STRAY 2>/dev/null || true
-  fi
+  # Belt-and-suspenders: nuke anything still bound to :4001 or :4096 that
+  # we spawned. The Opencode SDK starts a child 'opencode serve' on :4096
+  # which can survive even with set -m if it was double-forked.
+  for port in 4001 4096; do
+    STRAY=$(lsof -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null || true)
+    if [ -n "$STRAY" ]; then
+      info "cleanup: killing stray :$port listener(s) $STRAY"
+      kill -9 $STRAY 2>/dev/null || true
+    fi
+  done
+  pkill -9 -f "opencode serve" 2>/dev/null || true
 }
 trap cleanup EXIT INT TERM
 
-# 0. Free :4001 (kill any orphan)
-ORPHAN=$(lsof -iTCP:4001 -sTCP:LISTEN -t 2>/dev/null || true)
-if [ -n "$ORPHAN" ]; then
-  info "killing existing :4001 listener(s): $ORPHAN"
-  kill $ORPHAN 2>/dev/null || true
-  sleep 2
-fi
+# 0. Free :4001 AND :4096 (the Opencode SDK's internal server port).
+# Both can be held by orphans from earlier runs that double-forked past
+# the process group. An orphan on :4096 makes the SDK fail to start with
+# "Failed to start server on port 4096" even though :4001 is free.
+for port in 4001 4096; do
+  ORPHAN=$(lsof -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null || true)
+  if [ -n "$ORPHAN" ]; then
+    info "killing existing :$port listener(s): $ORPHAN"
+    kill -9 $ORPHAN 2>/dev/null || true
+  fi
+done
+pkill -9 -f "opencode serve" 2>/dev/null || true
+sleep 1
 
 # 1. Sentinel present
 [ -f "$SENTINEL" ] || fail "$SENTINEL missing — run apps/api_server postinstall"

--- a/apps/api_server/src/__tests__/agent_sessions.test.ts
+++ b/apps/api_server/src/__tests__/agent_sessions.test.ts
@@ -864,4 +864,103 @@ describe('Agent Sessions API', () => {
     const { getDb } = await import('../database/db');
     expect(() => run(getDb())).not.toThrow();
   });
+
+  // ── PR #619 acceptance: SESSIONS ACTUALLY LAUNCH when taskId is missing locally
+  // Contract: docs/ai/contracts/pr-619.json
+  // These tests assert the full launch path, not just "row inserted":
+  //   - 201 with the expected taskId/taskTitle reconciliation
+  //   - opencodeClient.createSession invoked (SDK session created)
+  //   - opencodeSessionMap populated (stream-bridge can route prompts → SDK)
+  //   - opencodeClient.promptAsync invoked (initial prompt actually dispatched)
+
+  it('launches a session end-to-end when taskId is not present in the local tasks table (PR #619 acceptance)', async () => {
+    // foreign_keys = ON is set in makeDb(); this taskId does not exist in tasks.
+    const bogusTaskId = 'definitely-not-in-local-db';
+    const taskTitle = 'Synthetic task from production';
+    const sessionName = 'FK launch test';
+    const cwd = os.homedir();
+
+    const { opencodeClient, opencodeSessionMap } = await import('../services/opencode_engine');
+    const mock = opencodeClient as unknown as {
+      createSession: ReturnType<typeof vi.fn>;
+      promptAsync: ReturnType<typeof vi.fn>;
+    };
+    mock.createSession.mockResolvedValueOnce({ id: 'sdk-launch-no-fk' });
+
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        agentId: 'claude-code',
+        cwd,
+        name: sessionName,
+        taskId: bogusTaskId,
+        taskTitle,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const session = (await res.json()) as {
+      id: string;
+      taskId: string | null;
+      taskTitle: string | null;
+      status: string;
+    };
+    expect(session.taskId).toBeNull();
+    expect(session.taskTitle).toBe(taskTitle);
+    expect(session.status).toBe('starting');
+
+    expect(mock.createSession).toHaveBeenCalledWith(sessionName, cwd);
+    expect(opencodeSessionMap.get(session.id)).toBe('sdk-launch-no-fk');
+    expect(mock.promptAsync).toHaveBeenCalled();
+    const [sdkId, promptText] = mock.promptAsync.mock.calls.at(-1)!;
+    expect(sdkId).toBe('sdk-launch-no-fk');
+    expect(promptText).toContain(sessionName);
+    expect(promptText).toContain(taskTitle);
+  });
+
+  it('launches a session end-to-end when taskId IS present in the local tasks table (happy path)', async () => {
+    const { getDb } = await import('../database/db');
+    const db = getDb();
+    const taskId = 'local-task-abc123';
+    db.prepare(
+      `INSERT INTO tasks (id, title, status, created_at, updated_at)
+       VALUES (?, 'Local Task', 'pending', datetime('now'), datetime('now'))`,
+    ).run(taskId);
+
+    const sessionName = 'Real task launch';
+    const cwd = os.homedir();
+    const { opencodeClient, opencodeSessionMap } = await import('../services/opencode_engine');
+    const mock = opencodeClient as unknown as {
+      createSession: ReturnType<typeof vi.fn>;
+      promptAsync: ReturnType<typeof vi.fn>;
+    };
+    mock.createSession.mockResolvedValueOnce({ id: 'sdk-launch-with-fk' });
+
+    const res = await fetch(`${baseUrl}/agent-sessions`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({
+        agentId: 'claude-code',
+        cwd,
+        name: sessionName,
+        taskId,
+        taskTitle: 'Local Task',
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const session = (await res.json()) as {
+      id: string;
+      taskId: string | null;
+      taskTitle: string | null;
+      status: string;
+    };
+    expect(session.taskId).toBe(taskId);
+    expect(session.taskTitle).toBe('Local Task');
+    expect(session.status).toBe('starting');
+    expect(mock.createSession).toHaveBeenCalledWith(sessionName, cwd);
+    expect(opencodeSessionMap.get(session.id)).toBe('sdk-launch-with-fk');
+    expect(mock.promptAsync).toHaveBeenCalled();
+  });
 });

--- a/apps/api_server/src/controllers/agent_sessions_controller.ts
+++ b/apps/api_server/src/controllers/agent_sessions_controller.ts
@@ -5,11 +5,13 @@ import { AgentSessionsRepository } from '../repositories/agent_sessions_reposito
 import { AgentSessionMessagesRepository } from '../repositories/agent_session_messages_repository';
 import { AgentConfigsRepository } from '../repositories/agent_configs_repository';
 import { ProjectsRepository } from '../repositories/projects_repository';
+import { TasksRepository } from '../repositories/tasks_repository';
 import type { AgentKind, CreateAgentSessionDto, PermissionMode } from '../models/agent_session';
 import { PERMISSION_MODES } from '../models/agent_session';
 import { opencodeClient, opencodeSessionMap } from '../services/opencode_engine';
 import { streamBridge } from '../services/opencode_stream_bridge';
 import { broadcastSessionUpdated, broadcastSessionRemoved } from '../services/ws_gateway';
+import { logger } from '../utils/logger';
 
 // Legacy agentId aliases. Older Rhythm clients (and a handful of historical
 // scripts) used short names. /agents/capabilities and the seed both use
@@ -121,9 +123,25 @@ export class AgentSessionsController {
         throw AppError.badRequest('name is required and must be a non-empty string');
       }
 
+      let resolvedTaskId: string | null = null;
       if (taskId !== undefined && taskId !== null) {
         if (typeof taskId !== 'string') {
           throw AppError.badRequest('taskId must be a string');
+        }
+        // Defensive FK check: the local SQLite tasks table may not contain
+        // production task IDs (sync gap). Rather than let SQLite raise
+        // SQLITE_CONSTRAINT_FOREIGNKEY (which becomes a 500), we probe the
+        // local table and silently null out the foreign key when not found.
+        // task_title is preserved so the UI still shows context.
+        try {
+          new TasksRepository().findByIdIncludingLegacy(taskId);
+          resolvedTaskId = taskId;
+        } catch {
+          logger.warn(
+            `[AgentSessionsController] taskId "${taskId}" not found in local tasks table — ` +
+              'creating agent session with task_id=null; task_title will be preserved.',
+          );
+          resolvedTaskId = null;
         }
       }
 
@@ -183,7 +201,7 @@ export class AgentSessionsController {
 
       const dto: CreateAgentSessionDto = {
         agentKind: normalizedAgentId as AgentKind,
-        taskId: taskId != null ? (taskId as string) : null,
+        taskId: resolvedTaskId,
         taskTitle: taskTitle != null ? (taskTitle as string) : null,
         cwd: expandedCwd,
         name: name.trim(),

--- a/apps/api_server/src/utils/logger.ts
+++ b/apps/api_server/src/utils/logger.ts
@@ -3,6 +3,10 @@ export const logger = {
     // eslint-disable-next-line no-console
     console.log(`[INFO] ${message}`, ...args);
   },
+  warn(message: string, ...args: unknown[]) {
+    // eslint-disable-next-line no-console
+    console.warn(`[WARN] ${message}`, ...args);
+  },
   error(message: string, ...args: unknown[]) {
     // eslint-disable-next-line no-console
     console.error(`[ERROR] ${message}`, ...args);

--- a/docs/ai/contracts/pr-619.json
+++ b/docs/ai/contracts/pr-619.json
@@ -1,0 +1,26 @@
+{
+  "pr": 619,
+  "title": "fix(agent-sessions): tolerate taskId missing from local SQLite",
+  "user_acceptance_criterion": "SESSIONS ACTUALLY LAUNCH — POST /agent-sessions with a taskId picked from production data (not present in the local SQLite tasks table) must successfully start a backing Opencode SDK session, not merely return 201 with a DB row.",
+  "failure_evidence_before_fix": [
+    "Curl repro on the running local agent server (PID 91607, :4001): POST /agent-sessions with {\"taskId\":\"<id-not-in-local-tasks>\"} returns HTTP 500 INTERNAL_ERROR with a correlationId.",
+    "Flutter desktop New-agent-session dialog: 'Something went wrong on the server.' under Details.",
+    "Flutter Task-ready bubble: 'Internal server error.'"
+  ],
+  "root_cause": "PRAGMA foreign_keys = ON (apps/api_server/src/database/db.ts:61) plus agent_sessions.task_id REFERENCES tasks(id). Flutter task picker reads from production (api.vcrcapps.com per ServerConfigService), but POSTs go to localhost:4001 whose local tasks table doesn't always have the picked row. SQLite raises SQLITE_CONSTRAINT_FOREIGNKEY, a plain Error (not AppError), so error_handler.ts returns 500.",
+  "required_assertions": [
+    "POST /agent-sessions with bogus taskId returns 201",
+    "Response.taskId === null (FK softly resolved to null)",
+    "Response.taskTitle === sent value (preserved for UI)",
+    "Response.status === 'starting'",
+    "opencodeClient.createSession was called with the session name and cwd (proves SDK session creation reached)",
+    "opencodeSessionMap contains an entry mapping local id → SDK id (proves stream-bridge mapping registered — without this, ws_gateway cannot route prompts to the SDK)",
+    "opencodeClient.promptAsync was called with the initial prompt (proves the session has actually started doing work, not just been created)"
+  ],
+  "test_file": "apps/api_server/src/__tests__/agent_sessions.test.ts",
+  "test_names": [
+    "launches a session end-to-end when taskId is not present in the local tasks table (PR #619 acceptance)",
+    "launches a session end-to-end when taskId IS present in the local tasks table (happy path)"
+  ],
+  "mandate": "PASS = the two contract tests above are green AND the full agent_sessions test suite is green. PASS is not 'tsc clean' alone, and not 'fix is implemented'."
+}

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -1,6 +1,51 @@
 # Project State
 
-## Current Status (2026-05-18 — manual smoke of vbeta.18.36; iterate on `follow-up`, do not merge #617 yet)
+## Current Status (2026-05-19 — PR #621 open against follow-up; 5 follow-up bugs filed during smoke)
+
+🟡 **Branch `follow-up` stays open. PR #617 still not merged.** PR #621 stacked on top — FK tolerance for production task IDs in the local SQLite. Independent and shippable.
+
+### Today's work
+
+[**PR #621**](https://github.com/ajhochy/Rhythm/pull/621) — `fix(agent-sessions): tolerate taskId missing from local SQLite (rebased onto #617/follow-up)`. Branch `fix/agent-session-fk-task-id-tolerance-followup`. Supersedes the closed PR #619 (which was against stale `main`).
+
+**Bug fixed**: POST `/agent-sessions` with a `taskId` not in the local SQLite `tasks` table returned 500. Flutter picker reads tasks from production (`api.vcrcapps.com`) but POSTs hit localhost; the sync mirror is incomplete; SQLite raises `SQLITE_CONSTRAINT_FOREIGNKEY` on `agent_sessions.task_id REFERENCES tasks(id)`; controller doesn't catch it. New-session dialog showed "Something went wrong on the server"; Task-ready bubble showed "Internal server error".
+
+**Fix**: in `agent_sessions_controller.create()`, probe `TasksRepository.findByIdIncludingLegacy(taskId)` before insert. On miss, log `warn` and null out `task_id`; `task_title` is preserved (the schema stores them independently — see migration comment introducing `task_title`).
+
+**Acceptance contract** at `docs/ai/contracts/pr-619.json`. Two strengthened tests assert the full launch path: HTTP 201 + reconciled taskId + preserved taskTitle + `opencodeClient.createSession(name, cwd)` invoked + `opencodeSessionMap` populated + `promptAsync` invoked with initial prompt containing taskTitle. Red proven by reverting the controller fix → 2 fail with `expected 500 to be 201`. Green: 508/508.
+
+**Smoke infrastructure**: `apps/api_server/scripts/smoke-launch.sh` (`npm run smoke:launch`). Verifies sentinel Node + ABI match + dist build, spawns the api_server with exactly the env Flutter uses (`PORT=4001 AGENT_LOCAL=true DB_PATH=/tmp/rhythm-smoke/smoke.db`), hits `/health`, `/agents/capabilities`, and the PR's regression POST. Uses `set -m` + process-group kill on cleanup + `pkill -9 -f "opencode serve"` so the SDK's child server on `:4096` can't orphan and surface as "Reusing existing server on :4001" on the next Rhythm.app launch (which silently coupled stale dev servers earlier in this session).
+
+**Live verification**: against the running `flutter run -d macos` app, POST with bogus taskId returned **HTTP 201**, WARN was logged, taskTitle preserved. End-to-end through the actual SDK and Anthropic provider.
+
+### Bugs caught during manual smoke and filed as follow-ups
+
+| # | Title | Notes |
+|---|---|---|
+| [#620](https://github.com/ajhochy/Rhythm/issues/620) | sync: local SQLite tasks table missing tasks that exist on production | The underlying gap PR #621 defends against. #621 is the boundary fix; #620 fixes the mirror. |
+| [#622](https://github.com/ajhochy/Rhythm/issues/622) | agent chat: `question` tool call renders as raw args instead of an answer selector | Wall of JSON shown instead of clickable options. Any agent that asks structured questions becomes unusable. |
+| [#623](https://github.com/ajhochy/Rhythm/issues/623) | agent chat: Task-ready bubble forces agent pre-selection instead of using the composer picker | Bubble's `startAgent(agentId)` predates the #602 composer redesign. Should open agent-less. |
+| [#624](https://github.com/ajhochy/Rhythm/issues/624) | agent chat: follow-up user message accepted by SDK but no LLM call fires; UI stuck on "working" | **Critical**: first prompt's 7-step output works; second prompt logs only `message.updated` — no `step=N loop`, no `service=llm`, no deltas. Smells like a regression of the `40d4fee` "model on follow-up turns" fix. Includes the SDK timeline as repro. Also covers the related persistence desync (`lastActivityAt` stays null even after streamed output). |
+| [#625](https://github.com/ajhochy/Rhythm/issues/625) | agent chat: mini-bubble transcript blanks when a different session is selected in the Agents tab | Bubble reads from `_transcript[selectedSessionId]` instead of its own `widget.entry.sessionId`. Breaks the persistent-chat premise of the bubble overlay entirely. |
+
+### Critical-path before next release
+
+- **#624** blocks every follow-up turn → no agent chat usable past the first prompt.
+- **#622** + **#625** break the agent UX even when #624 lands.
+- **#620** is lower-urgency because PR #621 now keeps the symptom invisible to users.
+
+### Tooling lessons recorded
+
+Postmortem: `.agent-stack/postmortems/2026-05-19-pr-621-agent-fk-tolerance.json`. Two reusable artifacts:
+
+1. `apps/api_server/scripts/smoke-launch.sh` — repeatable build+spawn pipeline check. Catches ABI mismatches and orphan-port issues programmatically instead of "click Retry, repeat."
+2. The acceptance-contract pattern (`docs/ai/contracts/pr-619.json`) — tests that prove **launch**, not just **insert**. The mandate "PASS = sessions actually launch" came directly from the user when the earlier test was only proving the row was inserted.
+
+Workflow lesson: **before branching off `main`, check `gh pr list --state open` for an active draft trunk** (#617 was the real trunk; the original PR #619 was wasted effort branching off stale `main`).
+
+---
+
+## Previous Status (2026-05-18 — manual smoke of vbeta.18.36; iterate on `follow-up`, do not merge #617 yet)
 
 🟡 **Branch `follow-up` stays open. PR #617 NOT merged.** User decision after a full manual smoke pass: keep grinding bugs on this branch, re-smoke after each fix cluster, merge to `main` only when ≥80% of the original smoke checklist passes cleanly.
 


### PR DESCRIPTION
## Why this PR exists separate from #619

PR #619 was opened against `main`, but `main` is stale relative to the active development trunk `follow-up` (draft PR #617). The agent-session create dialog has been redesigned on `follow-up` (composer redesign moved the agent picker into the session window, removed it from the New-session dialog) — a tester pointed out the old branch shipped the obsolete UI.

This PR re-bases the same fix + acceptance contract + smoke pipeline onto `follow-up` so it can ride along with PR #617's release. Once this is in, PR #619 can be closed.

## Summary
- Fix HTTP 500 when starting an agent session linked to a task. Dialog showed "Something went wrong on the server"; bubble showed "Internal server error."
- Root cause: `PRAGMA foreign_keys = ON` + `agent_sessions.task_id REFERENCES tasks(id)`. Flutter task picker reads from production; POSTs hit localhost. The local SQLite tasks table doesn't always have the picked row (sync gap). SQLite raises `SQLITE_CONSTRAINT_FOREIGNKEY`, a plain `Error`, so `error_handler.ts` returns 500.
- Fix: defensive `TasksRepository.findByIdIncludingLegacy` lookup in `agent_sessions_controller.create()`. On miss, log a `warn` and null out `task_id` while preserving `task_title` (the schema stores them independently for exactly this case).

## Changes
- `apps/api_server/src/controllers/agent_sessions_controller.ts` — defensive FK lookup
- `apps/api_server/src/utils/logger.ts` — add `warn()`
- `apps/api_server/src/__tests__/agent_sessions.test.ts` — two acceptance-contract tests
- `apps/api_server/scripts/smoke-launch.sh` — full build + spawn + bind + health pipeline check
- `apps/api_server/package.json` — `npm run smoke:launch`
- `docs/ai/contracts/pr-619.json` — what "session actually launches" means

## Acceptance contract — sessions actually launch

The two new tests don't just assert HTTP 201. They assert the full SDK launch chain:

| Assertion | Why |
|---|---|
| 201 + `taskId: null` + `taskTitle` preserved + `status: 'starting'` | Response shape |
| `opencodeClient.createSession` called with `(name, cwd)` | SDK session created |
| `opencodeSessionMap.get(localId) === sdkId` | Stream-bridge mapping registered — otherwise WS prompts can't route |
| `promptAsync` called with prompt containing `taskTitle` | Session is actually doing work, not parked |

**Red proven:** reverting the fix while keeping the tests fails both new cases with "expected 500 to be 201".  
**Green:** 508/508 tests pass with the fix.

## Verification
- `npx tsc --noEmit` — clean
- `npm test` — **508/508**
- `npm run smoke:launch` — PASS (build + spawn + bind + agent-session FK path)
- Manual: POST against the running app's api_server with bogus taskId returned **201**, WARN logged, taskTitle preserved.

## Manual smoke against `flutter run -d macos`
- [ ] Quit Rhythm.app fully (Cmd+Q) and confirm `lsof -iTCP:4001 -sTCP:LISTEN` is empty.
- [ ] `flutter run -d macos`. Pick a task from the New-agent-session dialog → Start. Session is created (no "Something went wrong on the server"). Title appears in the session row.
- [ ] Trigger or wait for a Task-ready bubble → Start with Claude Code. Session starts (no "Internal server error").
- [ ] Open the session and send a prompt → streams a response (full launch path).

## Notes
- Closes the same surface as PR #619 — that PR will be closed once this lands.
- Follow-up #620 covers the underlying sync gap that lets production tasks be absent from local SQLite. This PR is the defensive boundary fix; #620 fixes the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
