### PR TITLE
fix(api-deploy): copy scripts/ into Docker deps stages

### DIFF
--- a/apps/api_server/Dockerfile
+++ b/apps/api_server/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
 
 FROM build-tools AS deps
 COPY package.json package-lock.json ./
+COPY scripts ./scripts
 RUN npm ci
 
 FROM deps AS build
@@ -20,6 +21,7 @@ RUN npm run build
 # and we only compile native modules once (here).
 FROM build-tools AS prod-deps
 COPY package.json package-lock.json ./
+COPY scripts ./scripts
 RUN npm ci --omit=dev && npm cache clean --force
 
 FROM base AS runtime


### PR DESCRIPTION
## Summary
- API Deploy (Synology) failed on the #617 merge: `Error: Cannot find module '/app/scripts/postinstall.js'` during `npm ci` in the `prod-deps` stage.
- PR #617 added a `postinstall` hook (`node scripts/postinstall.js`) in `apps/api_server/package.json`, but the Dockerfile only copies `package.json` + `package-lock.json` before `npm ci`, so the hook target is missing.
- Fix: `COPY scripts ./scripts` before `npm ci` in both `deps` and `prod-deps` stages. `build-tools` already has python3/make/g++, so the better-sqlite3 rebuild the script triggers will succeed.

## Test plan
- [ ] Re-run API Deploy workflow on this branch and confirm the Docker build completes through `prod-deps`.
- [ ] Confirm resulting image still starts cleanly on Synology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)