### PR TITLE
fix(mcp-server): build config + ignore local auth probes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ npm-debug.log*
 # api_server install-time runtime sentinel (issue #585)
 apps/api_server/.node-runtime.json
 
+# Local-only auth-strategy probes (read real OAuth tokens — never commit)
+apps/api_server/scripts/auth-strategy-probe.ts
+apps/api_server/scripts/probe-output.log
+
 # IDEs
 .vscode/
 .idea/

--- a/apps/mcp_server/package.json
+++ b/apps/mcp_server/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "main": "dist/index.js",
   "bin": {
-    "rhythm-mcp": "./dist/index.js"
+    "rhythm-mcp": "dist/index.js"
   },
   "files": [
     "dist",

--- a/apps/mcp_server/tsconfig.json
+++ b/apps/mcp_server/tsconfig.json
@@ -11,5 +11,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary
Small standalone build-config fix, split out from the workflow run.

- `apps/mcp_server/package.json`: normalize `bin` path to relative `dist/index.js`
- `apps/mcp_server/tsconfig.json`: exclude `*.test.ts` / `__tests__` from the published tsc build
- `.gitignore`: ignore local-only auth-strategy probe scripts (they read real OAuth tokens — never commit)

## Test plan
- [ ] `cd apps/mcp_server && npm run build` produces `dist/index.js` and no test files
- [ ] `npx rhythm-mcp` resolves the bin

🤖 Generated with [Claude Code](https://claude.com/claude-code)