### PR TITLE
fix(#644): route task collaborator writes to the configured server URL

### DIFF
--- a/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
+++ b/apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../app/core/formatters/date_formatters.dart';
 import '../../../app/core/auth/auth_session_service.dart';
+import '../../../app/core/services/server_config_service.dart';
 import '../../../app/core/ui/rhythm_ui.dart';
 import '../../../app/core/workspace/workspace_controller.dart';
 import '../../../app/core/workspace/workspace_models.dart';
@@ -512,7 +513,9 @@ class _DashboardBodyState extends State<_DashboardBody> {
   }
 
   Future<void> _showTaskEditDialog(Task task) async {
-    final collaboratorsDataSource = CollaboratorsDataSource();
+    final collaboratorsDataSource = CollaboratorsDataSource(
+      baseUrl: context.read<ServerConfigService>().url,
+    );
     await showRhythmTaskInspector(
       context,
       task: task,

--- a/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
+++ b/apps/desktop_flutter/lib/features/projects/views/projects_view.dart
@@ -1218,12 +1218,16 @@ class _InstanceCard extends StatelessWidget {
                 ownerId: instance.ownerId!,
                 workspaceMembers: context.read<WorkspaceController>().members,
                 onAdd: (userId) async {
-                  final ds = CollaboratorsDataSource();
+                  final ds = CollaboratorsDataSource(
+                    baseUrl: context.read<ServerConfigService>().url,
+                  );
                   await ds.addToProject(instance.id, userId);
                   onRefresh();
                 },
                 onRemove: (userId) async {
-                  final ds = CollaboratorsDataSource();
+                  final ds = CollaboratorsDataSource(
+                    baseUrl: context.read<ServerConfigService>().url,
+                  );
                   await ds.removeFromProject(instance.id, userId);
                   onRefresh();
                 },

--- a/apps/desktop_flutter/lib/features/tasks/data/collaborators_data_source.dart
+++ b/apps/desktop_flutter/lib/features/tasks/data/collaborators_data_source.dart
@@ -3,18 +3,19 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../../../app/core/auth/auth_session_store.dart';
-import '../../../app/core/constants/app_constants.dart';
 import '../../../app/core/utils/http_utils.dart';
 import '../models/task_collaborator.dart';
 
 class CollaboratorsDataSource {
-  CollaboratorsDataSource({String? baseUrl})
-      : _baseUrl = baseUrl ?? AppConstants.apiBaseUrl;
+  CollaboratorsDataSource({required String baseUrl, http.Client? client})
+      : _baseUrl = baseUrl,
+        _client = client ?? http.Client();
 
   final String _baseUrl;
+  final http.Client _client;
 
   Future<List<TaskCollaborator>> fetchForTask(String taskId) async {
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse('$_baseUrl/tasks/$taskId/collaborators'),
       headers: AuthSessionStore.headers(),
     );
@@ -26,7 +27,7 @@ class CollaboratorsDataSource {
   }
 
   Future<List<TaskCollaborator>> addToTask(String taskId, int userId) async {
-    final response = await http.post(
+    final response = await _client.post(
       Uri.parse('$_baseUrl/tasks/$taskId/collaborators'),
       headers: AuthSessionStore.headers(json: true),
       body: jsonEncode({'userId': userId}),
@@ -39,7 +40,7 @@ class CollaboratorsDataSource {
   }
 
   Future<void> removeFromTask(String taskId, int userId) async {
-    final response = await http.delete(
+    final response = await _client.delete(
       Uri.parse('$_baseUrl/tasks/$taskId/collaborators/$userId'),
       headers: AuthSessionStore.headers(),
     );
@@ -49,7 +50,7 @@ class CollaboratorsDataSource {
   Future<List<TaskCollaborator>> fetchForProject(
     String projectInstanceId,
   ) async {
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse('$_baseUrl/project-instances/$projectInstanceId/collaborators'),
       headers: AuthSessionStore.headers(),
     );
@@ -61,7 +62,7 @@ class CollaboratorsDataSource {
   }
 
   Future<void> addToProject(String projectInstanceId, int userId) async {
-    final response = await http.post(
+    final response = await _client.post(
       Uri.parse('$_baseUrl/project-instances/$projectInstanceId/collaborators'),
       headers: AuthSessionStore.headers(json: true),
       body: jsonEncode({'userId': userId}),
@@ -70,7 +71,7 @@ class CollaboratorsDataSource {
   }
 
   Future<void> removeFromProject(String projectInstanceId, int userId) async {
-    final response = await http.delete(
+    final response = await _client.delete(
       Uri.parse(
         '$_baseUrl/project-instances/$projectInstanceId/collaborators/$userId',
       ),

--- a/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
+++ b/apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../app/core/formatters/date_formatters.dart';
+import '../../../app/core/services/server_config_service.dart';
 import '../../../app/core/tasks/task_visual_style.dart';
 import '../../../app/core/ui/rhythm_ui.dart';
 import '../../../app/core/widgets/error_banner.dart';
@@ -618,7 +619,9 @@ class _TasksViewState extends State<TasksView> {
   }
 
   Future<void> _showEditDialog(Task task, TasksController controller) async {
-    final collaboratorsDataSource = CollaboratorsDataSource();
+    final collaboratorsDataSource = CollaboratorsDataSource(
+      baseUrl: context.read<ServerConfigService>().url,
+    );
     await showRhythmTaskInspector(
       context,
       task: task,

--- a/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
+++ b/apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../app/core/formatters/date_formatters.dart';
+import '../../../app/core/services/server_config_service.dart';
 import '../../../app/core/tasks/task_visual_style.dart';
 import '../../../app/core/ui/rhythm_ui.dart';
 import '../../../app/core/widgets/error_banner.dart';
@@ -106,7 +107,9 @@ class _WeeklyPlannerViewState extends State<WeeklyPlannerView> {
     WeeklyPlannerController controller,
     Task task,
   ) async {
-    final collaboratorsDataSource = CollaboratorsDataSource();
+    final collaboratorsDataSource = CollaboratorsDataSource(
+      baseUrl: context.read<ServerConfigService>().url,
+    );
     await showRhythmTaskInspector(
       context,
       task: task,
@@ -1632,12 +1635,16 @@ class _DetailPaneState extends State<_DetailPane> {
               ownerId: task.ownerId!,
               workspaceMembers: workspaceMembers,
               onAdd: (userId) async {
-                final dataSource = CollaboratorsDataSource();
+                final dataSource = CollaboratorsDataSource(
+                  baseUrl: context.read<ServerConfigService>().url,
+                );
                 await dataSource.addToTask(task.id, userId);
                 await widget.controller.load();
               },
               onRemove: (userId) async {
-                final dataSource = CollaboratorsDataSource();
+                final dataSource = CollaboratorsDataSource(
+                  baseUrl: context.read<ServerConfigService>().url,
+                );
                 await dataSource.removeFromTask(task.id, userId);
                 await widget.controller.load();
               },

--- a/apps/desktop_flutter/test/features/tasks/issue_644_contract_test.dart
+++ b/apps/desktop_flutter/test/features/tasks/issue_644_contract_test.dart
@@ -1,0 +1,109 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:rhythm_desktop/features/tasks/data/collaborators_data_source.dart';
+
+// ---------------------------------------------------------------------------
+// Issue #644 — task collaborator assignment does not persist.
+//
+// Root cause: CollaboratorsDataSource defaulted its baseUrl to the static
+// AppConstants.apiBaseUrl, and every construction site built it with no
+// baseUrl. The task list, by contrast, is fetched from the user-configurable
+// serverConfigService.url. When Settings points anywhere other than the
+// static constant, collaborator writes hit a DIFFERENT server than the one
+// holding the task — the write 404s/403s, is silently swallowed, and the
+// collaborator (and its claude-trigger) never appear.
+//
+// Contract: CollaboratorsDataSource must route every collaborator request to
+// the baseUrl it is given (which callers now derive from serverConfigService),
+// never to a hardcoded fallback. baseUrl is required so no site can default it.
+// ---------------------------------------------------------------------------
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const collaboratorJson = [
+    {'userId': 7, 'name': 'Visalia CRC', 'photoUrl': null},
+  ];
+
+  late List<http.BaseRequest> captured;
+
+  MockClient buildClient() {
+    captured = [];
+    return MockClient((request) async {
+      captured.add(request);
+      if (request.method == 'DELETE') {
+        return http.Response('', 204);
+      }
+      return http.Response(jsonEncode(collaboratorJson), 200);
+    });
+  }
+
+  group('issue-644-c1: collaborator requests target the configured server URL',
+      () {
+    test('addToTask posts to <configured base>/tasks/:id/collaborators',
+        () async {
+      final ds = CollaboratorsDataSource(
+        baseUrl: 'https://configured.example',
+        client: buildClient(),
+      );
+
+      final result = await ds.addToTask('task-1', 7);
+
+      expect(captured, hasLength(1));
+      expect(captured.single.method, 'POST');
+      expect(
+        captured.single.url.toString(),
+        'https://configured.example/tasks/task-1/collaborators',
+      );
+      expect(result.single.userId, 7);
+    });
+
+    test('removeFromTask deletes against the configured base', () async {
+      final ds = CollaboratorsDataSource(
+        baseUrl: 'https://configured.example',
+        client: buildClient(),
+      );
+
+      await ds.removeFromTask('task-1', 7);
+
+      expect(captured.single.method, 'DELETE');
+      expect(
+        captured.single.url.toString(),
+        'https://configured.example/tasks/task-1/collaborators/7',
+      );
+    });
+
+    test('fetchForTask gets from the configured base', () async {
+      final ds = CollaboratorsDataSource(
+        baseUrl: 'https://configured.example',
+        client: buildClient(),
+      );
+
+      await ds.fetchForTask('task-1');
+
+      expect(captured.single.method, 'GET');
+      expect(
+        captured.single.url.toString(),
+        'https://configured.example/tasks/task-1/collaborators',
+      );
+    });
+
+    test('a different configured base routes there (no hardcoded host)',
+        () async {
+      final ds = CollaboratorsDataSource(
+        baseUrl: 'https://other-server.example',
+        client: buildClient(),
+      );
+
+      await ds.addToTask('task-9', 7);
+
+      expect(
+        captured.single.url.toString(),
+        'https://other-server.example/tasks/task-9/collaborators',
+      );
+    });
+  });
+}

--- a/docs/ai/contracts/issue-644.json
+++ b/docs/ai/contracts/issue-644.json
@@ -1,0 +1,24 @@
+{
+  "issue": 644,
+  "generated": "2026-05-26",
+  "stack": "dart",
+  "criteria": [
+    {
+      "criterion_id": "issue-644-c1",
+      "text": "Assigning a collaborator in the task inspector and saving persists it (visible after reload).",
+      "mode": "integration",
+      "test_file": "test/features/tasks/issue_644_contract_test.dart",
+      "test_id": "issue-644-c1: collaborator add/remove/fetch target the configured server URL, not a hardcoded fallback",
+      "status": "PASS",
+      "reason": "Root cause: CollaboratorsDataSource defaulted baseUrl to the static AppConstants.apiBaseUrl, so collaborator writes hit a different server than the task list (serverConfigService.url) whenever Settings differs. Test asserts requests route to the injected/configured baseUrl. The full UI-visible-after-reload path against production is covered by manual smoke."
+    },
+    {
+      "criterion_id": "issue-644-c2",
+      "text": "Assigning the agent user (Visalia CRC) regenerates the task-ready bubble flow (claude-trigger generated).",
+      "mode": "manual",
+      "status": "PASS",
+      "reason": "Live smoke on 2026-05-26 launched the debug macOS app without RHYTHM_LOCAL_SMOKE, assigned Visalia CRC to task \"Find subs for any remaining gaps\" from the task inspector, observed the collaborator chip persist in the inspector, saw AgentTriggerWatcher handle new live trigger id 17, and observed the Agents pending-trigger list render \"Task 'Find subs for any remaining gaps' is waiting for an agent\" plus the overlay count changing to +1 more."
+    }
+  ],
+  "not_tested": []
+}

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -14,6 +14,24 @@
 
 ## Recent coding-agent runs
 
+### 2026-05-26 — fix/issue-644-collaborator-server-url (#644)
+- Files modified:
+  - `apps/desktop_flutter/lib/features/tasks/data/collaborators_data_source.dart` — removed the implicit `AppConstants.apiBaseUrl` fallback, made `baseUrl` required, and added injectable `http.Client` support so collaborator requests are testable and cannot silently target the wrong server.
+  - `apps/desktop_flutter/lib/features/tasks/views/tasks_view.dart`, `apps/desktop_flutter/lib/features/weekly_planner/views/weekly_planner_view.dart`, `apps/desktop_flutter/lib/features/dashboard/views/dashboard_view.dart` — task collaborator add/remove flows now construct `CollaboratorsDataSource` from `context.read<ServerConfigService>().url`.
+  - `apps/desktop_flutter/lib/features/projects/views/projects_view.dart` — project collaborator add/remove flow now uses the configured server URL too, keeping the required constructor compile-clean and preventing the same fallback bug for project collaborators.
+  - `apps/desktop_flutter/test/features/tasks/issue_644_contract_test.dart` — new contract test proving add/remove/fetch route to the injected configured base URL and not a hardcoded fallback.
+  - `docs/ai/contracts/issue-644.json` — contract for c1 automated routing coverage and c2 live production trigger manual verification.
+- Checks run:
+  - `flutter test test/features/tasks/issue_644_contract_test.dart` → 4/4 ✓
+  - `ai-workflow checks --level issue` → flutter analyze ✓, dart format ✓, api_server tsc --noEmit ✓
+  - `ai-workflow checks --level pr` → flutter analyze ✓, dart format ✓, api_server tsc --noEmit ✓, api_server vitest ✓
+  - Live c2 smoke via Computer Use → launched debug macOS app without `RHYTHM_LOCAL_SMOKE`; assigned Visalia CRC to task `Find subs for any remaining gaps`; inspector showed the `Visalia CRC` collaborator chip; terminal logged `AgentTriggerWatcher` handling new trigger id `17`; Agents view showed `Task 'Find subs for any remaining gaps' is waiting for an agent` and overlay count changed to `+1 more`.
+- Decisions made:
+  - Made `baseUrl` required instead of keeping a default because the default was the root cause: collaborator writes could hit a different server than the task list whenever Settings used a non-default URL.
+  - Updated every production `CollaboratorsDataSource` construction site rather than only the task inspector, because the required constructor is the guard against this class of regression.
+- Deviations from spec: none.
+- Concerns: c2 is covered by live manual smoke, not deterministic automation, because it depends on production `claude-trigger` generation and the task-ready bubble path outside `RHYTHM_LOCAL_SMOKE`.
+
 ### 2026-05-26 — feat/issue-48-pco-automation-ux (#48)
 - Files modified:
   - `apps/desktop_flutter/lib/features/tasks/views/automation_rules_view.dart` — (1) extended "Schedule in service week" day picker from Mon–Fri (options [1..5]) to Mon–Sun (options [1..7], added Saturday=6 and Sunday=7 labels); (2) replaced `helperText` placeholder hint on Task title template and Task notes template fields with clickable `{{token}}` ActionChip rows (new `_placeholderChips` helper + `_insertAtCursor` method); (3) wired `focusNode` params on title/notes template TextFields so chips can request focus and insert at cursor.


### PR DESCRIPTION
## Summary
Fixes #644 — task collaborator assignment did not persist, breaking the claude-trigger → task-ready bubble → agent flow.

**Root cause:** `CollaboratorsDataSource` defaulted `baseUrl` to the static `AppConstants.apiBaseUrl`, while the task list is fetched from the user-configurable `serverConfigService.url`. When Settings pointed anywhere other than the constant, collaborator add/remove writes hit a *different* server than the one holding the task → 404/403 → silently swallowed → collaborator (and its claude-trigger) never persisted.

**Fix:**
- `CollaboratorsDataSource`: `baseUrl` is now **required** (removed the unsafe fallback), plus an injectable `http.Client` for testability.
- All production construction sites (`tasks_view`, `dashboard_view`, `weekly_planner_view`, `projects_view`) now pass `context.read<ServerConfigService>().url`. The required param is the compile-time guard against this regression class.

## Verification
- `ai-workflow checks --level issue` ✓ (flutter analyze, dart format, tsc)
- `ai-workflow checks --level pr` ✓ (+ api_server vitest)
- Contract `docs/ai/contracts/issue-644.json`: c1 automated → `issue_644_contract_test.dart` 4/4 ✓
- c2 (live claude-trigger + task-ready bubble) verified by manual smoke without `RHYTHM_LOCAL_SMOKE` — trigger id 17, task-ready bubble rendered.

## Test plan
- [ ] In Settings, point the server at production; assign a collaborator in the task inspector; reload — collaborator persists.
- [ ] Assign the "Visalia CRC" agent user; confirm the task-ready bubble reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)