### PR TITLE
fix(#656): composer-draft consume must not notifyListeners during build

### DIFF
--- a/apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart
+++ b/apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart
@@ -452,10 +452,15 @@ class AgentsController extends ChangeNotifier with WidgetsBindingObserver {
 
   /// Read and clear the draft for [sessionId]. Returns null if no draft was
   /// staged. One-shot — subsequent calls return null.
+  ///
+  /// Issue #656: this is invoked from `_TranscriptPanel.build()`, so it MUST
+  /// NOT call `notifyListeners()` — firing a notify during build marks the
+  /// building widget dirty mid-build, which in release silently corrupts the
+  /// transcript panel's rebuild scheduling (dead clicks, no streaming). The
+  /// caller applies the returned draft directly to its TextEditingController
+  /// via a post-frame callback; no rebuild is required here.
   String? consumeComposerDraft(String sessionId) {
-    final draft = _composerDraftBySession.remove(sessionId);
-    if (draft != null) notifyListeners();
-    return draft;
+    return _composerDraftBySession.remove(sessionId);
   }
 
   /// True if a draft exists for [sessionId] without consuming it (used by

--- a/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
+++ b/apps/desktop_flutter/lib/features/agents/views/agents_view.dart
@@ -1167,18 +1167,20 @@ class _TranscriptPanelState extends State<_TranscriptPanel> {
   void _maybeConsumeComposerDraft(
       BuildContext context, AgentSession? selected) {
     if (selected == null) return;
-    if (_draftConsumedForSession.contains(selected.id)) return;
+    final sessionId = selected.id;
+    if (_draftConsumedForSession.contains(sessionId)) return;
     final controller = context.read<AgentsController>();
-    if (!controller.hasComposerDraft(selected.id)) return;
-    final draft = controller.consumeComposerDraft(selected.id);
-    if (draft == null || draft.isEmpty) {
-      _draftConsumedForSession.add(selected.id);
-      return;
-    }
-    _draftConsumedForSession.add(selected.id);
-    // Apply the prefill on the next frame so the input controller is wired up.
+    if (!controller.hasComposerDraft(sessionId)) return;
+    // Issue #656: do NOT consume (mutate controller state) or touch the input
+    // controller synchronously during build. Mark this session handled now
+    // (local State set, no notify) and defer the actual consume + prefill to a
+    // post-frame callback. This guarantees no controller mutation happens in
+    // the build phase, keeping transcript reactivity intact.
+    _draftConsumedForSession.add(sessionId);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      final draft = controller.consumeComposerDraft(sessionId);
+      if (draft == null || draft.isEmpty) return;
       if (_inputController.text.isNotEmpty) return; // user already typed
       _inputController.value = TextEditingValue(
         text: draft,

--- a/apps/desktop_flutter/test/features/agents/issue_656_contract_test.dart
+++ b/apps/desktop_flutter/test/features/agents/issue_656_contract_test.dart
@@ -1,0 +1,134 @@
+/// Acceptance contract for issue #656 — composer-draft consume must be
+/// build-safe (must NOT call notifyListeners during build).
+///
+/// ROOT CAUSE
+/// ----------
+/// #654 added `_TranscriptPanelState._maybeConsumeComposerDraft`, called from
+/// `build()`. It invoked `AgentsController.consumeComposerDraft(id)`, which
+/// called `notifyListeners()`. Calling notifyListeners() synchronously during
+/// build marks the building widget dirty mid-build — illegal. In debug it
+/// throws; in release the assert is stripped and it silently corrupts the
+/// transcript panel's rebuild scheduling, so clicks/streaming/optimistic
+/// input stop reliably updating the view.
+///
+/// CONTRACT
+/// --------
+/// `consumeComposerDraft` is a one-shot read invoked during build. It must
+/// return + clear the staged draft WITHOUT firing listeners. `setComposerDraft`
+/// (called outside build, before selectSession which notifies) likewise does
+/// not need to notify, but the load-bearing invariant for the regression is
+/// the consume path.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rhythm_desktop/app/core/agents/agent_server_controller.dart';
+import 'package:rhythm_desktop/app/core/notifications/local_notification_service.dart';
+import 'package:rhythm_desktop/app/core/server/api_server_service.dart';
+import 'package:rhythm_desktop/features/agents/controllers/agents_controller.dart';
+import 'package:rhythm_desktop/features/agents/models/agent_ws_message.dart';
+import 'package:rhythm_desktop/features/agents/repositories/agents_repository.dart';
+import 'package:rhythm_desktop/features/notifications/controllers/notifications_controller.dart';
+import 'package:rhythm_desktop/features/notifications/data/notifications_data_source.dart';
+import 'package:rhythm_desktop/features/notifications/repositories/notifications_repository.dart';
+
+class _FakeApiServerService extends ApiServerService {
+  @override
+  Future<AgentServerStartResult> start() async =>
+      (ok: true, reason: null, stderrTail: null, failureMessage: null);
+  @override
+  Future<void> stop() async {}
+}
+
+class _FakeAgentServerController extends AgentServerController {
+  _FakeAgentServerController() : super(_FakeApiServerService());
+  @override
+  bool get isReady => true;
+  @override
+  bool get hasAnyAgent => true;
+  @override
+  Future<void> initialize() async {}
+}
+
+class _FakeLocalNotificationService extends LocalNotificationService {
+  @override
+  Future<void> initialize() async {}
+}
+
+class _FakeNotificationsController extends NotificationsController {
+  _FakeNotificationsController()
+      : super(NotificationsRepository(
+            NotificationsDataSource(baseUrl: 'http://x')));
+  @override
+  void startPolling() {}
+  @override
+  void stopPolling() {}
+}
+
+class _FakeAgentsRepository implements AgentsRepository {
+  @override
+  Future<void> connect() async {}
+  @override
+  Stream<AgentWsMessage> get messages => const Stream.empty();
+  @override
+  Stream<bool> get connectivityStream => const Stream.empty();
+  @override
+  bool get isConnected => true;
+  @override
+  void send(Map<String, dynamic> msg) {}
+  @override
+  Future<void> dispose() async {}
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AgentsController controller;
+
+  setUp(() {
+    controller = AgentsController(
+      _FakeAgentsRepository(),
+      _FakeAgentServerController(),
+      _FakeLocalNotificationService(),
+      _FakeNotificationsController(),
+    );
+  });
+
+  tearDown(() => controller.dispose());
+
+  test(
+      'issue-656-c1: consumeComposerDraft returns the draft WITHOUT firing '
+      'listeners (safe to call during build)', () {
+    controller.setComposerDraft('s1', 'Add Annette Rip and Nate Rip');
+
+    var notified = 0;
+    controller.addListener(() => notified++);
+
+    final draft = controller.consumeComposerDraft('s1');
+
+    expect(draft, 'Add Annette Rip and Nate Rip');
+    expect(
+      notified,
+      0,
+      reason:
+          'consumeComposerDraft is invoked during _TranscriptPanel.build(); '
+          'firing notifyListeners() there marks the building widget dirty '
+          'mid-build and corrupts transcript reactivity (#656).',
+    );
+
+    // One-shot: a second consume returns null and still does not notify.
+    expect(controller.consumeComposerDraft('s1'), isNull);
+    expect(notified, 0);
+  });
+
+  test(
+      'issue-656-c1b: hasComposerDraft reflects staged state, consume clears it',
+      () {
+    expect(controller.hasComposerDraft('s2'), isFalse);
+    controller.setComposerDraft('s2', 'hello');
+    expect(controller.hasComposerDraft('s2'), isTrue);
+    controller.consumeComposerDraft('s2');
+    expect(controller.hasComposerDraft('s2'), isFalse);
+  });
+}

--- a/apps/desktop_flutter/test/features/agents/issue_656_contract_test.dart
+++ b/apps/desktop_flutter/test/features/agents/issue_656_contract_test.dart
@@ -20,7 +20,9 @@
 /// the consume path.
 library;
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 import 'package:rhythm_desktop/app/core/agents/agent_server_controller.dart';
 import 'package:rhythm_desktop/app/core/notifications/local_notification_service.dart';
 import 'package:rhythm_desktop/app/core/server/api_server_service.dart';
@@ -130,5 +132,68 @@ void main() {
     expect(controller.hasComposerDraft('s2'), isTrue);
     controller.consumeComposerDraft('s2');
     expect(controller.hasComposerDraft('s2'), isFalse);
+  });
+
+  // c2 — Widget-level reproduction of the reported regression: when a widget
+  // consumes a composer draft DURING its build (as _TranscriptPanel does),
+  // the surrounding Provider subtree must remain reactive — i.e. a subsequent
+  // controller mutation + notifyListeners() must still rebuild the view.
+  //
+  // On the pre-fix code, `consumeComposerDraft` fired notifyListeners() during
+  // build, which (in debug) throws "notifyListeners during build" the first
+  // time the drafted widget builds — this testWidgets run captures that throw
+  // via tester.takeException(). On the fixed code there is no throw and the
+  // later notify drives a rebuild that shows the updated value.
+  testWidgets(
+      'issue-656-c2: consuming a draft during build keeps the Provider '
+      'subtree reactive (clicking/selecting still updates the view)',
+      (tester) async {
+    controller.setComposerDraft('drafted-session', 'task title\n\nnotes');
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AgentsController>.value(
+        value: controller,
+        child: MaterialApp(
+          home: Scaffold(
+            body: Consumer<AgentsController>(
+              builder: (context, c, _) {
+                // Mimic _TranscriptPanel.build: consume the staged draft once
+                // during build. Must NOT corrupt reactivity.
+                if (c.hasComposerDraft('drafted-session')) {
+                  c.consumeComposerDraft('drafted-session');
+                }
+                // Observe a separate "probe" draft to prove later notifies
+                // still drive rebuilds.
+                return Text('probe:${c.hasComposerDraft('probe')}');
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // No "notifyListeners during build" exception should have occurred.
+    expect(
+      tester.takeException(),
+      isNull,
+      reason: 'consuming a draft during build must not throw / mark dirty '
+          'mid-build (#656).',
+    );
+    expect(find.text('probe:false'), findsOneWidget);
+
+    // Now mutate the controller (setComposerDraft notifies, same as a
+    // session-row tap → selectSession or a delete → notifyListeners) and
+    // confirm the subtree rebuilds — proving reactivity survived the
+    // during-build consume.
+    controller.setComposerDraft('probe', 'x');
+    await tester.pump();
+
+    expect(
+      find.text('probe:true'),
+      findsOneWidget,
+      reason: 'after a during-build consume, a later notifyListeners() must '
+          'still rebuild the view — this is the "clicking a chat does not '
+          'change it / deletes do not reflect" regression (#656).',
+    );
   });
 }


### PR DESCRIPTION
## Summary

v18.40 smoke regression: after opening a chat from the task-ready bubble, clicking session rows didn't visibly open them, user messages were slow to populate, and sessions showed "Working" with no streaming output.

**Root cause (introduced in #654):** `_TranscriptPanelState._maybeConsumeComposerDraft` runs during `build()` and called `AgentsController.consumeComposerDraft`, which called `notifyListeners()`. Notifying during build marks the building widget dirty mid-build — illegal. Debug throws; **release strips the assert** and silently corrupts the transcript panel's rebuild scheduling, so later notifies (selectSession, WS stream frames, optimistic input) stop reliably rebuilding the view. One bug → all three symptoms.

## Fix

- `consumeComposerDraft`: drop the `notifyListeners()` (one-shot map read invoked during build; caller applies the draft to its TextEditingController directly).
- `_maybeConsumeComposerDraft`: defense-in-depth — mark handled via a local State Set (no notify) and defer the consume + prefill into the post-frame callback. Zero controller mutation during build.

## Test plan

- [x] New `issue_656_contract_test.dart` — c1 (consume must not fire listeners; red on pre-fix code) + c1b (staged/clear lifecycle). 2/2 green.
- [x] `flutter test` → 295/295 ✓ (was 293)
- [x] `ai-workflow checks --level pr` → analyze ✓ / dart format ✓ / tsc ✓ / vitest ✓
- [ ] **Manual smoke (v18.41):** open chat from task bubble → composer prefilled → send → streaming output appears; click other session rows → they open immediately.

Closes #656.

Lesson: the #654 c3–c6 widget tests (composer prefill / bubble picker UI) were deferred — they'd have caught this. This PR adds the controller-level contract; the widget-level coverage should still follow.