### PR TITLE
Expose build commit in /health so Synology deploys are verifiable (#677)

### DIFF
--- a/.github/workflows/api_deploy_synology.yml
+++ b/.github/workflows/api_deploy_synology.yml
@@ -1,4 +1,6 @@
-name: API Deploy (Synology)
+# Renamed from "API Deploy (Synology)" (issue #677): a green run publishes the
+# image to GHCR only — deploying to the NAS is a manual pull + up -d.
+name: API Image Publish (GHCR)
 
 on:
   push:
@@ -54,6 +56,10 @@ jobs:
             type=raw,value=main
             type=sha,format=short
 
+      - name: Set build time
+        id: buildinfo
+        run: echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push API image
         uses: docker/build-push-action@v6
         with:
@@ -62,6 +68,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ steps.buildinfo.outputs.time }}
 
       - name: Manual server update required
         run: |
@@ -72,4 +81,8 @@ jobs:
           echo ""
           echo "    docker pull ghcr.io/${{ github.repository_owner }}/rhythm-api:main"
           echo "    docker compose -f /volume1/docker/Rhythm/api_server/docker-compose.synology.yml up -d"
+          echo ""
+          echo "  Then verify the new code is live (commit must be ${{ github.sha }}):"
+          echo ""
+          echo "    curl -s https://api.vcrcapps.com/health"
           echo "============================================================"

--- a/apps/api_server/Dockerfile
+++ b/apps/api_server/Dockerfile
@@ -25,7 +25,11 @@ COPY scripts ./scripts
 RUN npm ci --omit=dev && npm cache clean --force
 
 FROM base AS runtime
-ENV NODE_ENV=production
+ARG GIT_SHA=dev
+ARG BUILD_TIME=
+ENV NODE_ENV=production \
+    RHYTHM_BUILD_COMMIT=$GIT_SHA \
+    RHYTHM_BUILD_TIME=$BUILD_TIME
 WORKDIR /app
 
 COPY package.json package-lock.json ./

--- a/apps/api_server/src/__tests__/issue_677_contract.test.ts
+++ b/apps/api_server/src/__tests__/issue_677_contract.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Acceptance-contract tests for issue #677
+ * "Expose build commit in /health so Synology deploys are verifiable"
+ *
+ * c1: GET /health returns the build commit (and builtAt) when the image's
+ *     build-info env vars are set.
+ * c2: Local/dev runs without the env vars return commit: 'dev'.
+ *
+ * Both MUST FAIL on the current health_controller.ts (returns only
+ * {status, service}) and PASS after the fix.
+ */
+
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import type { AddressInfo } from 'node:net';
+import { runMigrations } from '../database/migrations';
+import { setDb } from '../database/db';
+
+vi.mock('../services/opencode_engine', () => {
+  const mockClient = {
+    isReady: true,
+    listProviders: vi.fn().mockResolvedValue([]),
+    listAuthedProviders: vi.fn().mockResolvedValue([]),
+    statusMessage: 'Opencode SDK ready',
+    createSession: vi.fn().mockResolvedValue({ id: 'sdk-session-677' }),
+    setAuth: vi.fn().mockResolvedValue(true),
+    prompt: vi.fn().mockResolvedValue({}),
+    promptAsync: vi.fn().mockResolvedValue(true),
+    subscribeToEvents: vi.fn().mockResolvedValue(null),
+    ensureReady: vi.fn().mockResolvedValue(true),
+  };
+  return { opencodeClient: mockClient, opencodeSessionMap: new Map<string, string>() };
+});
+
+vi.mock('../services/opencode_stream_bridge', () => ({
+  streamBridge: {
+    streamSession: vi.fn().mockResolvedValue(undefined),
+    stopStream: vi.fn(),
+    dispose: vi.fn(),
+    clearPendingPermission: vi.fn(),
+  },
+}));
+
+vi.mock('../services/ws_gateway', () => ({
+  broadcast: vi.fn(),
+  broadcastSessionUpdated: vi.fn(),
+  broadcastSessionRemoved: vi.fn(),
+}));
+
+import { createApp } from '../app';
+
+const COMMIT = 'abc1234def5678';
+const BUILT_AT = '2026-06-11T16:00:00Z';
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  runMigrations(db);
+  return db;
+}
+
+describe('health route — issue #677: build commit in /health', () => {
+  let baseUrl: string;
+  let closeServer: () => Promise<void>;
+  const savedCommit = process.env.RHYTHM_BUILD_COMMIT;
+  const savedBuiltAt = process.env.RHYTHM_BUILD_TIME;
+
+  beforeEach(async () => {
+    setDb(makeDb());
+    const server = createApp().listen(0);
+    await new Promise<void>((r) => server.once('listening', () => r()));
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+    closeServer = () =>
+      new Promise<void>((res, rej) => server.close((e) => (e ? rej(e) : res())));
+  });
+
+  afterEach(async () => {
+    await closeServer();
+    if (savedCommit === undefined) delete process.env.RHYTHM_BUILD_COMMIT;
+    else process.env.RHYTHM_BUILD_COMMIT = savedCommit;
+    if (savedBuiltAt === undefined) delete process.env.RHYTHM_BUILD_TIME;
+    else process.env.RHYTHM_BUILD_TIME = savedBuiltAt;
+    vi.clearAllMocks();
+  });
+
+  it('issue-677-c1: /health returns commit and builtAt from build-info env vars', async () => {
+    process.env.RHYTHM_BUILD_COMMIT = COMMIT;
+    process.env.RHYTHM_BUILD_TIME = BUILT_AT;
+
+    const res = await fetch(`${baseUrl}/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe('ok');
+    expect(body.commit).toBe(COMMIT);
+    expect(body.builtAt).toBe(BUILT_AT);
+  });
+
+  it("issue-677-c2: /health returns commit 'dev' when build-info env vars are unset", async () => {
+    delete process.env.RHYTHM_BUILD_COMMIT;
+    delete process.env.RHYTHM_BUILD_TIME;
+
+    const res = await fetch(`${baseUrl}/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.commit).toBe('dev');
+    expect(body).not.toHaveProperty('builtAt');
+  });
+});

--- a/apps/api_server/src/controllers/health_controller.ts
+++ b/apps/api_server/src/controllers/health_controller.ts
@@ -18,9 +18,17 @@ export class HealthController {
       }
     }
 
+    // Build info is baked into the Docker image by the publish workflow
+    // (issue #677) so a deployed server's code version is one curl away.
+    // Read at request time, not module load, so tests can vary it.
+    const commit = process.env.RHYTHM_BUILD_COMMIT || 'dev';
+    const builtAt = process.env.RHYTHM_BUILD_TIME;
+
     res.json({
       status: 'ok',
       service: 'rhythm-api-server',
+      commit,
+      ...(builtAt ? { builtAt } : {}),
       ...(authenticatedAs !== null ? { authenticatedAs } : {}),
     });
   }

--- a/docs/ai/contracts/issue-677.json
+++ b/docs/ai/contracts/issue-677.json
@@ -1,0 +1,49 @@
+{
+  "issue": 677,
+  "generated": "2026-06-11",
+  "criteria": [
+    {
+      "criterion_id": "issue-677-c1",
+      "text": "GET /health additionally returns the build commit SHA (and optionally build timestamp), e.g. {\"status\":\"ok\",\"service\":\"rhythm-api-server\",\"commit\":\"64c6b06\",\"builtAt\":\"...\"}.",
+      "mode": "integration",
+      "test_file": "apps/api_server/src/__tests__/issue_677_contract.test.ts",
+      "test_id": "issue-677-c1: /health returns commit and builtAt from build-info env vars",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-677-c2",
+      "text": "Local dev runs return commit: \"dev\" or the local SHA when available.",
+      "mode": "integration",
+      "test_file": "apps/api_server/src/__tests__/issue_677_contract.test.ts",
+      "test_id": "issue-677-c2: /health returns commit 'dev' when build-info env vars are unset",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "issue-677-c3",
+      "text": "The SHA is baked into the image at build time by the publish workflow (e.g. --build-arg GIT_SHA=${{ github.sha }} → env var read by the server).",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Docker image build with build-args cannot run inside vitest; verified by static review of Dockerfile + workflow and live-confirmed on the first post-merge image publish (curl /health on the NAS after pull shows the merge SHA)."
+    },
+    {
+      "criterion_id": "issue-677-c4",
+      "text": "docs/release/hosted_deployment_synology_cloudflare.md routine-update section gains a final verify step: curl /health and compare commit to the just-merged SHA.",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Documentation change — verified by review of the runbook diff."
+    },
+    {
+      "criterion_id": "issue-677-c5",
+      "text": "Consider renaming the workflow from 'API Deploy (Synology)' to 'API Image Publish (GHCR)' so a green run is not mistaken for a completed deployment.",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Resolved: workflow renamed to 'API Image Publish (GHCR)' in this PR with an explanatory comment. Listed manual because the rename is verified by PR review, not a test."
+    }
+  ],
+  "stack": "typescript",
+  "not_tested": [
+    "issue-677-c3",
+    "issue-677-c4",
+    "issue-677-c5"
+  ]
+}

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -6,6 +6,18 @@ _(Parked bugs from before 2026-05-27 run. #638 and #635 below are now RESOLVED �
 
 ## Recent coding-agent runs
 
+### 2026-06-11 — issue-677-health-build-commit (#677)
+- Files modified:
+  - `apps/api_server/src/controllers/health_controller.ts` — `/health` now returns `commit` (`RHYTHM_BUILD_COMMIT` env, `'dev'` fallback) and `builtAt` (`RHYTHM_BUILD_TIME`, omitted when unset). Read at request time so tests can vary them.
+  - `apps/api_server/Dockerfile` — runtime stage gained `ARG GIT_SHA=dev` / `ARG BUILD_TIME=` baked into `ENV RHYTHM_BUILD_COMMIT` / `RHYTHM_BUILD_TIME`.
+  - `.github/workflows/api_deploy_synology.yml` — workflow renamed **"API Image Publish (GHCR)"** (was "API Deploy (Synology)" — the misleading name behind the 2026-06-11 smoke failure); passes `GIT_SHA`/`BUILD_TIME` build-args; final echo step now includes the verify-curl with the expected SHA.
+  - `docs/release/hosted_deployment_synology_cloudflare.md` — routine update gains step 7: curl /health and compare `commit` to the merged SHA; publish-vs-deploy warning added.
+  - `apps/api_server/src/__tests__/issue_677_contract.test.ts` (new) + `docs/ai/contracts/issue-677.json` (new) — 5 criteria: 2 automated (red-proven 2/2 → green 2/2), 3 manual (image build-arg wiring verified on next publish; docs + rename by PR review).
+- Checks run: contract 2/2 ✓ (red 2/2 before); `ai-workflow checks --level issue` → analyze ✓, format ✓, tsc ✓.
+- Decisions made: env vars read at request time (not via cached `env.ts`) so contract tests can set/unset per test; `builtAt` omitted rather than null when unset.
+- Deviations from spec: none; the optional rename criterion was applied (not declined).
+- Concerns: c3 (build-arg → running image) is only fully provable on the first post-merge image publish + NAS pull — the runbook verify-curl is the closing check. Workflow rename keeps the same filename (`api_deploy_synology.yml`) so the `paths:` self-trigger still works.
+
 ### 2026-06-01 — fix/google-token-refresh-client-mismatch — Google OAuth `unauthorized_client` on token refresh
 - Recurring Integrations-page bug: `Google token refresh failed: { "error": "unauthorized_client", "error_description": "Unauthorized" }`. Root cause = OAuth **client mismatch**: tokens are minted by the *desktop* PKCE client (`exchangeDesktopCode` → `googleAuthClientId/Secret`, the only live connect path via Flutter `desktop-exchange`) but `refreshTokens` refreshed with the *web* client (`googleClientId/Secret`). The two clients are distinct in the shipped build (`desktop_release.yml:34-37`). Re-auth "fixed" it only until the next ~1h access-token expiry.
 - Files modified:

--- a/docs/release/hosted_deployment_synology_cloudflare.md
+++ b/docs/release/hosted_deployment_synology_cloudflare.md
@@ -68,14 +68,26 @@ sudo docker compose -f docker-compose.synology.yml --env-file .env.production up
 The `up -d` command recreates any container whose image changed and leaves
 the rest running. The SQLite data volume is preserved across restarts.
 
+Finally, **verify the new code is actually live** (issue #677 — the running
+container is otherwise indistinguishable from a stale one):
+
+```bash
+curl -s https://api.vcrcapps.com/health
+```
+
+The `commit` field must equal the SHA of the commit you just merged to `main`
+(compare with `git rev-parse --short origin/main`). If it still shows the old
+SHA, the container did not restart on the new image.
+
 ### Routine update summary
 
 1. Push to `main` (or merge a PR).
-2. Wait for the GitHub Actions workflow to finish publishing `ghcr.io/ajhochy/rhythm-api:main`.
+2. Wait for the "API Image Publish (GHCR)" GitHub Actions workflow to finish publishing `ghcr.io/ajhochy/rhythm-api:main`. **A green run means the image is published — NOT deployed.**
 3. SSH into the Synology.
 4. `cd /volume1/docker/Rhythm/api_server`
 5. `sudo docker compose -f docker-compose.synology.yml --env-file .env.production pull`
 6. `sudo docker compose -f docker-compose.synology.yml --env-file .env.production up -d`
+7. `curl -s https://api.vcrcapps.com/health` — confirm `commit` matches the merged SHA.
 
 > **Note:** `sudo` is required on Synology — Docker commands will fail with permission errors without it.
 >


### PR DESCRIPTION
Closes #677.

## Summary

Follow-up from the PR #676 smoke failure, where a stale Synology container was indistinguishable from a deployed one.

- `GET /health` now returns `commit` (from `RHYTHM_BUILD_COMMIT`, `"dev"` fallback) and `builtAt` (from `RHYTHM_BUILD_TIME`, omitted when unset)
- The Dockerfile bakes `GIT_SHA`/`BUILD_TIME` build-args into those env vars; the publish workflow passes `github.sha` + a UTC timestamp
- Workflow renamed **"API Image Publish (GHCR)"** (was "API Deploy (Synology)") — a green run means published, not deployed; its final log step now prints the verify-curl with the expected SHA
- Runbook routine-update section gains step 7: `curl -s https://api.vcrcapps.com/health` and compare `commit` to the merged SHA

## Verification (gate PASS)

- `ai-workflow checks --level pr`: analyze ✓ · format ✓ · tsc ✓ · vitest ✓ (includes [issue_677_contract.test.ts](apps/api_server/src/__tests__/issue_677_contract.test.ts) 2/2, red-proven first)
- Live probe on branch server: with env → `{"commit":"e6df62a-test","builtAt":"..."}`; without → `{"commit":"dev"}`, no `builtAt`
- Workflow YAML validated; filename unchanged so the `paths:` self-trigger still works

## After merge

The first "API Image Publish (GHCR)" run bakes the real SHA. After your next NAS `pull && up -d`, `curl https://api.vcrcapps.com/health` should show the merge SHA — that also closes contract criterion c3 and gives you the deploy check you asked for. (The pending Google-token image will ride along on the same pull.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)