### PR TITLE
chore(deploy): opt rhythm-api into Watchtower auto-updates

### DIFF
--- a/apps/api_server/docker-compose.synology.yml
+++ b/apps/api_server/docker-compose.synology.yml
@@ -3,6 +3,14 @@ services:
     image: ${RHYTHM_API_IMAGE:-ghcr.io/ajhochy/rhythm-api:main}
     container_name: rhythm-api
     restart: unless-stopped
+    # Opt into the host-wide Watchtower (run by the statements project in
+    # label-enable mode, 30-min poll, GHCR creds mounted): a new :main image
+    # published by "API Image Publish (GHCR)" is auto-pulled and this
+    # container recreated. Verify with: curl -s https://api.vcrcapps.com/health
+    # (the commit field must match the merged SHA). cloudflared is
+    # intentionally NOT labeled — the tunnel stays pinned.
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     ports:
       - '4000:4000'
     env_file:

--- a/apps/api_server/src/__tests__/watchtower_compose_contract.test.ts
+++ b/apps/api_server/src/__tests__/watchtower_compose_contract.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Acceptance-contract tests for the Watchtower opt-in label
+ * (chore/watchtower-label-rhythm-api — user-approved proposal, no issue #).
+ *
+ * The statements project runs a host-wide Watchtower in label-enable mode
+ * (WATCHTOWER_LABEL_ENABLE=true). Opting rhythm-api in means new :main
+ * images from GHCR are auto-pulled and the container recreated.
+ *
+ * c1: the rhythm-api service in docker-compose.synology.yml carries
+ *     com.centurylinklabs.watchtower.enable: "true". MUST FAIL pre-change.
+ * c2: the cloudflared service does NOT carry the enable label (the tunnel
+ *     stays pinned; regression guard).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const COMPOSE_PATH = path.join(__dirname, '..', '..', 'docker-compose.synology.yml');
+const ENABLE_LABEL = /com\.centurylinklabs\.watchtower\.enable['"]?\s*:\s*['"]true['"]/;
+
+/** Extract one top-level service block (2-space indent) from the compose file. */
+function serviceBlock(compose: string, name: string): string {
+  const lines = compose.split('\n');
+  const start = lines.findIndex((l) => l.trimEnd() === `  ${name}:`);
+  expect(start, `service '${name}' present in compose file`).toBeGreaterThan(-1);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === '') continue;
+    const indent = line.length - line.trimStart().length;
+    if (indent <= 2 && !line.trimStart().startsWith('#')) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join('\n');
+}
+
+describe('docker-compose.synology.yml — Watchtower opt-in contract', () => {
+  const compose = readFileSync(COMPOSE_PATH, 'utf8');
+
+  it('watchtower-rhythm-api-c1: rhythm-api opts into Watchtower label-enable updates', () => {
+    const block = serviceBlock(compose, 'rhythm-api');
+    expect(block, 'rhythm-api must carry the Watchtower enable label').toMatch(ENABLE_LABEL);
+  });
+
+  it('watchtower-rhythm-api-c2: cloudflared stays out of Watchtower auto-updates', () => {
+    const block = serviceBlock(compose, 'cloudflared');
+    expect(block, 'cloudflared must NOT carry the Watchtower enable label').not.toMatch(
+      ENABLE_LABEL,
+    );
+  });
+});

--- a/docs/ai/contracts/watchtower-rhythm-api.json
+++ b/docs/ai/contracts/watchtower-rhythm-api.json
@@ -1,0 +1,41 @@
+{
+  "issue": "watchtower-rhythm-api",
+  "generated": "2026-06-11",
+  "criteria": [
+    {
+      "criterion_id": "watchtower-rhythm-api-c1",
+      "text": "The rhythm-api service in apps/api_server/docker-compose.synology.yml carries the label com.centurylinklabs.watchtower.enable: \"true\" so the host-wide label-enable Watchtower (run by the statements project) auto-updates it.",
+      "mode": "unit",
+      "test_file": "apps/api_server/src/__tests__/watchtower_compose_contract.test.ts",
+      "test_id": "watchtower-rhythm-api-c1: rhythm-api opts into Watchtower label-enable updates",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "watchtower-rhythm-api-c2",
+      "text": "The cloudflared service does NOT carry the enable label — the tunnel container stays pinned and is never auto-recreated.",
+      "mode": "unit",
+      "test_file": "apps/api_server/src/__tests__/watchtower_compose_contract.test.ts",
+      "test_id": "watchtower-rhythm-api-c2: cloudflared stays out of Watchtower auto-updates",
+      "status": "pass"
+    },
+    {
+      "criterion_id": "watchtower-rhythm-api-c3",
+      "text": "The deployment runbook documents the auto-update path: deploys to rhythm-api are automatic within ~30 min of an image publish; the manual pull/up steps remain as the immediate-deploy fallback; verification stays the /health commit curl.",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Documentation change — verified by review of the runbook diff."
+    },
+    {
+      "criterion_id": "watchtower-rhythm-api-c4",
+      "text": "Live behavior: after the updated compose is deployed on the NAS (one last manual up -d), the next merge that publishes a new :main image results in Watchtower recreating rhythm-api within the 30-minute poll interval, observable as the /health commit field changing without any SSH step.",
+      "mode": "manual",
+      "status": "UNVERIFIED",
+      "reason": "Requires the live NAS Docker host and the statements Watchtower instance; verified on the first post-deploy auto-update via curl /health commit comparison."
+    }
+  ],
+  "stack": "typescript",
+  "not_tested": [
+    "watchtower-rhythm-api-c3",
+    "watchtower-rhythm-api-c4"
+  ]
+}

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -6,6 +6,16 @@ _(Parked bugs from before 2026-05-27 run. #638 and #635 below are now RESOLVED �
 
 ## Recent coding-agent runs
 
+### 2026-06-11 — chore/watchtower-label-rhythm-api (no issue; user-approved)
+- Files modified:
+  - `apps/api_server/docker-compose.synology.yml` — `rhythm-api` gained `com.centurylinklabs.watchtower.enable: "true"` (+ explanatory comment). Joins the host-wide label-enable Watchtower already run by the statements project (30-min poll, GHCR creds from root's docker login). `cloudflared` deliberately NOT labeled.
+  - `docs/release/hosted_deployment_synology_cloudflare.md` — "Deploying an update" now leads with the automatic Watchtower path; manual SSH pull/up demoted to immediate-deploy fallback; routine summary updated; verify-curl unchanged.
+  - `apps/api_server/src/__tests__/watchtower_compose_contract.test.ts` (new) + `docs/ai/contracts/watchtower-rhythm-api.json` (new) — c1 label present (red-proven → green), c2 cloudflared unlabeled (guard); c3 docs + c4 live auto-update are manual.
+- Checks run: contract 2/2 ✓ (c1 red before); compose YAML parses, label value is string 'true'.
+- Decisions made: reuse the statements Watchtower instead of running a Rhythm-scoped instance — one updater per host, label-enable filtering, creds already mounted. The bulletin-generator pattern (own scoped watchtower) rejected as redundant.
+- Deviations from spec: none.
+- Concerns: labels only apply on container recreate — the NAS needs ONE more manual `up -d` with the updated compose before auto-updates kick in. c4 verifies on the first post-deploy merge via /health commit drift. Watchtower availability now couples rhythm-api deploys to the statements stack staying up.
+
 ### 2026-06-11 — issue-677-health-build-commit (#677)
 - Files modified:
   - `apps/api_server/src/controllers/health_controller.ts` — `/health` now returns `commit` (`RHYTHM_BUILD_COMMIT` env, `'dev'` fallback) and `builtAt` (`RHYTHM_BUILD_TIME`, omitted when unset). Read at request time so tests can vary them.

--- a/docs/release/hosted_deployment_synology_cloudflare.md
+++ b/docs/release/hosted_deployment_synology_cloudflare.md
@@ -45,6 +45,25 @@ echo '<ghcr-read-token>' | docker login ghcr.io -u '<github-username>' --passwor
 
 ### Deploying an update
 
+**Updates are automatic (Watchtower).** The `rhythm-api` service carries
+`com.centurylinklabs.watchtower.enable: "true"`, so the host-wide Watchtower
+instance (run by the statements project in label-enable mode, 30-minute poll,
+GHCR credentials mounted from root's docker login) pulls each new
+`ghcr.io/ajhochy/rhythm-api:main` image and recreates the container
+automatically — typically within 30 minutes of the "API Image Publish (GHCR)"
+workflow finishing. The data volume is preserved. `cloudflared` is
+intentionally not labeled and never auto-updates.
+
+Verify an auto-deploy landed:
+
+```bash
+curl -s https://api.vcrcapps.com/health
+```
+
+The `commit` field must equal the SHA merged to `main`.
+
+**Manual fallback (deploy immediately, or if Watchtower is down):**
+
 After CI publishes a new image to GHCR (happens automatically on every push to
 `main`), SSH into the Synology and run:
 
@@ -82,12 +101,9 @@ SHA, the container did not restart on the new image.
 ### Routine update summary
 
 1. Push to `main` (or merge a PR).
-2. Wait for the "API Image Publish (GHCR)" GitHub Actions workflow to finish publishing `ghcr.io/ajhochy/rhythm-api:main`. **A green run means the image is published — NOT deployed.**
-3. SSH into the Synology.
-4. `cd /volume1/docker/Rhythm/api_server`
-5. `sudo docker compose -f docker-compose.synology.yml --env-file .env.production pull`
-6. `sudo docker compose -f docker-compose.synology.yml --env-file .env.production up -d`
-7. `curl -s https://api.vcrcapps.com/health` — confirm `commit` matches the merged SHA.
+2. Wait for the "API Image Publish (GHCR)" GitHub Actions workflow to finish publishing `ghcr.io/ajhochy/rhythm-api:main`. **A green run means the image is published — NOT yet deployed.**
+3. Wait up to ~30 minutes for Watchtower to pull the image and recreate `rhythm-api` (no SSH needed). To deploy immediately instead, run the manual fallback above (SSH → `pull` → `up -d`).
+4. `curl -s https://api.vcrcapps.com/health` — confirm `commit` matches the merged SHA.
 
 > **Note:** `sudo` is required on Synology — Docker commands will fail with permission errors without it.
 >


### PR DESCRIPTION
## Summary

Joins `rhythm-api` to the host-wide Watchtower already running on the Synology (the statements project's instance: `WATCHTOWER_LABEL_ENABLE=true`, 30-min poll, cleanup, GHCR creds mounted from root's docker login).

- `docker-compose.synology.yml`: `rhythm-api` gains `com.centurylinklabs.watchtower.enable: "true"` — new `:main` images from "API Image Publish (GHCR)" are auto-pulled and the container recreated within ~30 min, data volume preserved
- `cloudflared` is deliberately NOT labeled (tunnel stays pinned); `rhythm-postgres` is untouched
- Runbook: "Deploying an update" now leads with the automatic path; manual SSH `pull`/`up -d` demoted to immediate-deploy fallback; verification remains the `/health` commit curl (#677)
- Contract test asserts the label on `rhythm-api` and its absence on `cloudflared` ([watchtower_compose_contract.test.ts](apps/api_server/src/__tests__/watchtower_compose_contract.test.ts), red-proven)

## Verification (gate PASS)
`ai-workflow checks --level pr` all green (vitest includes the new contract 2/2); compose YAML validated (label parses as string `"true"`, rhythm-api only).

## After merge — one last manual step
Labels apply on container **recreate**, so the NAS needs one final manual deploy with the updated compose (I'll copy it to `/Volumes/docker/Rhythm/api_server/`; then SSH → `pull` → `up -d`). From then on, api_server deploys are hands-off — merge, wait ≤30 min, `curl /health` to confirm the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)