### PR TITLE
chore: postmortem for #677 deploy smoke (PASS)

### DIFF
--- a/.agent-stack/failure-patterns.md
+++ b/.agent-stack/failure-patterns.md
@@ -61,3 +61,11 @@
 - **Root cause**: "API Deploy (Synology)" workflow only publishes the image to GHCR; the manual `docker compose pull && up -d` on the NAS was never run, so production served pre-#674 code. Orchestrator claimed "deploy is live" off a /health 200 that cannot identify code version (W5).
 - **Suggested fix**: expose build commit in /health for one-curl deploy verification; rename or extend the publish workflow.
   - **Resolved 2026-06-11**: user ran `docker compose pull && up -d` on the NAS; re-smoke PASS (Wednesday task landed in Wednesday column). C5 diagnosis confirmed — no code change. Deploy-verifiability follow-up: #677.
+
+## 2026-06-11 — Issue 677 + watchtower label — deploy-verifiability smoke PASS
+
+- **Result**: smoke PASS (verification claimed PASS — no divergence)
+- **Category**: none
+- **Criteria affected**: issue-677-c1/c3 closed live (production /health returned commit 3313c97 + builtAt after NAS pull); watchtower-rhythm-api-c4 (auto-update without SSH) is the one open criterion, observable on the next api_server merge.
+- **Root cause**: n/a — clean run.
+- **Suggested fix**: n/a.

--- a/.agent-stack/postmortems/2026-06-11-issue-677-deploy-smoke.json
+++ b/.agent-stack/postmortems/2026-06-11-issue-677-deploy-smoke.json
@@ -1,0 +1,52 @@
+{
+  "run_id": "2026-06-11-issue-677-deploy-smoke",
+  "issue": 677,
+  "date": "2026-06-11",
+  "smoke_result": "pass",
+  "verification_claimed": "PASS",
+  "divergence": false,
+  "criteria_results": [
+    {
+      "criterion_id": "issue-677-c1",
+      "text": "GET /health additionally returns the build commit SHA (and optionally build timestamp).",
+      "contract_status": "pass",
+      "smoke_status": "pass",
+      "category": "none",
+      "notes": "User's production curl: {\"status\":\"ok\",\"service\":\"rhythm-api-server\",\"commit\":\"3313c97951a1e4477de69ff7d2f699c620afc9a4\",\"builtAt\":\"2026-06-11T23:20:29Z\"} — matches HEAD of main exactly."
+    },
+    {
+      "criterion_id": "issue-677-c3",
+      "text": "The SHA is baked into the image at build time by the publish workflow (build-arg GIT_SHA → env var read by the server).",
+      "contract_status": "untested",
+      "smoke_status": "pass",
+      "category": "none",
+      "notes": "Closed live: the GHCR image built by the renamed 'API Image Publish (GHCR)' run carried the merge SHA and builtAt through to the production /health response after the NAS pull + up -d."
+    },
+    {
+      "criterion_id": "watchtower-rhythm-api-c4",
+      "text": "Next merge that publishes a new :main image results in Watchtower recreating rhythm-api within the 30-minute poll, observable as /health commit drift without SSH.",
+      "contract_status": "untested",
+      "smoke_status": "not_checked",
+      "category": "none",
+      "notes": "Label is now APPLIED (container recreated with the labeled compose), but the auto-update behavior itself can only be observed on the next api_server merge. Remains the single open criterion across all current contracts."
+    }
+  ],
+  "process_issues": [],
+  "workflow_adherence": {
+    "overall_score": "strict",
+    "expected_chain": ["workflow-orchestrator", "acceptance-contract", "coding-agent", "verification-gate", "project-state-updater (run entries)", "PR + CI gate", "manual smoke", "failure-postmortem"],
+    "observed_chain": ["workflow-orchestrator (routing both #677 and watchtower runs)", "acceptance-contract (×2, red-proven)", "coding-agent (×2)", "verification-gate (×2, evidence blocks)", "PR #679 + #680 opened, CI watched green", "user merges", "NAS compose copied + manual pull/up -d", "deploy smoke (user curl)", "failure-postmortem"],
+    "skipped_skills": [],
+    "issues": []
+  },
+  "implementation_files": [
+    "apps/api_server/src/controllers/health_controller.ts",
+    "apps/api_server/Dockerfile",
+    ".github/workflows/api_deploy_synology.yml",
+    "docs/release/hosted_deployment_synology_cloudflare.md",
+    "apps/api_server/docker-compose.synology.yml"
+  ],
+  "failure_output": "",
+  "overall_category": "none",
+  "suggested_follow_up": "None needed — the deploy-verifiability loop closed on first try. Watch for watchtower-rhythm-api-c4 on the next api_server merge (auto-recreate without SSH) and record it then."
+}

--- a/docs/ai/contracts/issue-677.json
+++ b/docs/ai/contracts/issue-677.json
@@ -22,22 +22,22 @@
       "criterion_id": "issue-677-c3",
       "text": "The SHA is baked into the image at build time by the publish workflow (e.g. --build-arg GIT_SHA=${{ github.sha }} → env var read by the server).",
       "mode": "manual",
-      "status": "UNVERIFIED",
-      "reason": "Docker image build with build-args cannot run inside vitest; verified by static review of Dockerfile + workflow and live-confirmed on the first post-merge image publish (curl /health on the NAS after pull shows the merge SHA)."
+      "status": "pass",
+      "reason": "Closed live 2026-06-11: production /health returned commit 3313c97...afc9a4 + builtAt 2026-06-11T23:20:29Z after NAS pull — the workflow build-arg → Dockerfile env → server chain works end-to-end."
     },
     {
       "criterion_id": "issue-677-c4",
       "text": "docs/release/hosted_deployment_synology_cloudflare.md routine-update section gains a final verify step: curl /health and compare commit to the just-merged SHA.",
       "mode": "manual",
-      "status": "UNVERIFIED",
-      "reason": "Documentation change — verified by review of the runbook diff."
+      "status": "pass",
+      "reason": "Runbook verify step merged in PR #679 and exercised successfully by the user on this deploy."
     },
     {
       "criterion_id": "issue-677-c5",
       "text": "Consider renaming the workflow from 'API Deploy (Synology)' to 'API Image Publish (GHCR)' so a green run is not mistaken for a completed deployment.",
       "mode": "manual",
-      "status": "UNVERIFIED",
-      "reason": "Resolved: workflow renamed to 'API Image Publish (GHCR)' in this PR with an explanatory comment. Listed manual because the rename is verified by PR review, not a test."
+      "status": "pass",
+      "reason": "Rename applied and merged in PR #679 (user-reviewed); run list now shows 'API Image Publish (GHCR)'."
     }
   ],
   "stack": "typescript",

--- a/docs/ai/contracts/watchtower-rhythm-api.json
+++ b/docs/ai/contracts/watchtower-rhythm-api.json
@@ -22,8 +22,8 @@
       "criterion_id": "watchtower-rhythm-api-c3",
       "text": "The deployment runbook documents the auto-update path: deploys to rhythm-api are automatic within ~30 min of an image publish; the manual pull/up steps remain as the immediate-deploy fallback; verification stays the /health commit curl.",
       "mode": "manual",
-      "status": "UNVERIFIED",
-      "reason": "Documentation change — verified by review of the runbook diff."
+      "status": "pass",
+      "reason": "Runbook auto-update section merged in PR #680 (user-reviewed)."
     },
     {
       "criterion_id": "watchtower-rhythm-api-c4",


### PR DESCRIPTION
Deploy-verifiability smoke PASS: production /health returned the merged SHA (3313c97) + builtAt after the NAS update. Closes out #677 contract criteria live; watchtower-rhythm-api-c4 (auto-update on next merge) is the one criterion still open. Observability-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)