### PR TITLE
Plan: OpenCode v1.14.49 parity in the Agents tab (issues #685-#703)

### DIFF
--- a/.agent-stack/patterns.json
+++ b/.agent-stack/patterns.json
@@ -282,7 +282,7 @@
     }
   ],
   "last_updated": "2026-06-12",
-  "total_runs_analyzed": 17,
+  "total_runs_analyzed": 18,
   "min_occurrences_threshold": 2,
   "process_min_occurrences_threshold": 1,
   "workflow_min_occurrences_threshold": 1

--- a/.agent-stack/postmortems/2026-06-12-retro-opencode-parity-plan.json
+++ b/.agent-stack/postmortems/2026-06-12-retro-opencode-parity-plan.json
@@ -1,0 +1,59 @@
+{
+  "run_id": "2026-06-12-retro-opencode-parity-plan",
+  "issue": null,
+  "pr": 704,
+  "date": "2026-06-12",
+  "smoke_result": "unknown",
+  "verification_claimed": "N/A",
+  "divergence": false,
+  "criteria_results": [],
+  "process_issues": [
+    {
+      "category": "infra",
+      "description": "AgentFlow plan_and_issues run orphaned mid-flight: the agentflow MCP server restarted between phases, losing its in-memory instance registry. Disk state (<uuid>.state.json + output/plan_and_issues/) survived; user noticed the stall ('nothing happening?') before the orchestrator's fallback wakeup fired. Phase outputs written by the dying server (issue files 16:13-16:18) predated the recorded plan-phase completion (16:23) in the resumed run's log.",
+      "detected_by": "user + state-file mtime inspection"
+    },
+    {
+      "category": "infra",
+      "description": "First CLI resume attempt failed with 'fetch failed': agentflow's model-resolver silently fell back to ollama qwen2.5:14b because agentflow.config.json is only discovered via CWD or $AGENTFLOW_WORKFLOWS_DIR, and neither was set. The fallback is silent until an agent executes. Fix: AGENTFLOW_WORKFLOWS_DIR=$HOME/.config/agentflow/workflows on every CLI resume. Recorded in Rhythm docs/ai/decisions.md.",
+      "detected_by": "resume output line '📦 [planner] model: qwen2.5:14b (ollama)'"
+    },
+    {
+      "category": "process",
+      "description": "Obsidian project-log append (Rhythm CLAUDE.md required step) failed twice with 'fetch failed' — Obsidian REST endpoint unreachable during the run. Entry content preserved in the session summary; needs manual append or retry when Obsidian is running.",
+      "detected_by": "obsidian_post_file tool error"
+    }
+  ],
+  "workflow_adherence": {
+    "overall_score": "strict",
+    "expected_chain": [
+      "workflow-orchestrator (Guard 1 entry + Intake E routing)",
+      "upfront alignment (skippable: user message front-loaded decisions)",
+      "planning-agent + issue-writer via mcp__agentflow__plan_and_issues (AgentFlow dispatcher path)",
+      "align human-gate resumed with user_inputs",
+      "remote issue creation (explicitly requested by user)",
+      "branch + PR for planning artifacts (Guard 4 before push/PR)",
+      "project-state-updater",
+      "workflow-retrospective"
+    ],
+    "observed_chain": [
+      "workflow-orchestrator Skill invoked first; announced; Intake E routing decision emitted",
+      "upfront alignment legitimately skipped — user request specified audits, architecture-decision mandate, issue deliverable, and constraints; autonomous-mode session",
+      "pre-dispatch checks: AgentFlow context docs copied into repo (docs/failure-taxonomy.md, docs/contract-schema.md); .gitignore already covered output/ and *.state.json; OpenCode cloned pinned at v1.14.49 to match embedded SDK",
+      "two parallel read-only audit agents (sonnet/Tier 2) — sanctioned investigation parallelism; disjoint questions",
+      "gap synthesis in-orchestrator incl. SDK surface verification (sdk.gen.ts URL extraction) before planning dispatch",
+      "mcp__agentflow__plan_and_issues dispatched (valid Guard 1 dispatch); align gate resumed via user_inputs derived from the user's message",
+      "MCP-server restart orphaned the run; recovered via CLI agentflow resume with AGENTFLOW_WORKFLOWS_DIR set; plan + write_issues completed on tier1",
+      "artifact verification before trusting 'completed' (19 issue files vs manifest, plan read, 2 issue specs spot-checked)",
+      "Guard 4 emitted (remote ajhochy/Rhythm + branch) before push/PR/issue creation",
+      "branch workflow/run-2026-06-12-opencode-parity-plan; commit; push; 19 GitHub issues #685-#703; PR #704 (no Closes lines — planning PR completes no issues, stated explicitly)",
+      "CI gate: gh run list returned no runs for the branch — stated as fact (docs-only; Actions are workflow_dispatch/paths-filtered)",
+      "project-state-updater Skill invoked — run entry + 2 decisions.md entries committed and pushed to the PR branch",
+      "Obsidian log append attempted twice, failed (endpoint unreachable); surfaced, not silently skipped",
+      "workflow-retrospective Skill invoked — this postmortem"
+    ],
+    "skipped_skills": [],
+    "issues": []
+  },
+  "notes": "Planning-only run: acceptance-contract / coding-agent / verification-gate / failure-triage are N/A by design (no code changed). The 19 issues each carry contract-ready acceptance criteria with a real-fixture rule targeting the C2 pattern that dominated prior agent-tab failures."
+}

--- a/docs/ai/current-plan.md
+++ b/docs/ai/current-plan.md
@@ -132,7 +132,9 @@ dependencies are merged. M1 is strictly serial after the first two (which can pa
    No replacement surface designed in M1-3 — follow-up issue if it feels under-surfaced.
 4. **Cost display (M2-4): RESOLVED** — keep dollars on (cost primary, token breakdown in
    tooltip), as planned.
-5. **Custom agents (M4-4): OPEN** — awaiting user decision after explanation of what OpenCode
-   custom agents are and what the no-authoring-UI scope means.
+5. **Custom agents (M4-4): RESOLVED** — keep #703 as-is (render what the SDK reports, no
+   authoring UI). The persona-builder UI ("Bulletin Writer"-style custom assistants defined
+   inside Rhythm) is filed as unscheduled future issue **#705**
+   (`opencode-future-agent-builder-ui.md`) — depends on #703, explicitly outside M1-M4.
 6. **Vague-criteria flags:** "terminal-style output" (M2-3) and "renders as markdown" (M2-1)
    were pinned to concrete testable assertions in the issue files; review during PR/issue read.

--- a/docs/ai/current-plan.md
+++ b/docs/ai/current-plan.md
@@ -1,129 +1,143 @@
-# Current Plan — PR #617 bug-fix sprint (2026-05-18)
+# Current Plan — OpenCode parity in the Agents tab (2026-06-12)
 
 ## Status
-Active. **Replaces** the now-superseded M1-M5 parity plan (preserved in git history under `2dde632`-era commits; that plan's six milestones all shipped behind PR #617 / branch `follow-up`, but a full manual smoke against vbeta.18.36 revealed they shipped **broken** — see scoreboard below).
 
-## What happened
-
-PR #617 ("Follow Up") consolidates 13 issues (#601-#611, #614, #615) across install hardening, sessions, archive, WS events, permissions, composer redesign, model picker, OpenRouter curation, slash popover, action row, and VCS chip / branch dropdown. Local verification was reported as green:
-
-- api_server: 499/499 → 503/503 vitest, tsc clean, build clean.
-- desktop_flutter: 218/218 test, dart format clean, flutter analyze clean.
-
-A real manual smoke against the packaged DMG (vbeta.18.36, installed at `/Applications/Rhythm.app/`) on 2026-05-18 returned **6 PASS / 1 PARTIAL / 10 FAIL** out of 20 testable items — a 30% pass rate. Auto-tests were green because:
-
-- **Mocks hid the binding bug.** The vitest mock for `opencodeClient.promptAsync` wrapped the spy in an arrow function. Arrow functions have lexical `this`, so the cast-to-alias regression (`const promptFn = opencodeClient.promptAsync as unknown as (...)`) didn't surface in tests — but production code throws `TypeError: Cannot read properties of undefined (reading 'client')` on every send.
-- **No e2e coverage for the permission pipeline.** #608 claims `permission.asked → WS → PermissionCard → respond` end-to-end, but no test asserts the pipeline actually fires for a real provider. In production it doesn't fire at all for Claude direct.
-- **UI controls weren't verified to reach the SDK.** The thinking-budget / fast-mode toggles render and persist to the DB, but a silent 5th-arg drop in `OpencodeClientService.promptAsync` means they never affect the SDK call. No integration test caught this.
-- **No widget tests for the broken features.** File-attach, slash popover, VCS chip — all have zero coverage.
-
-**Decision: keep iterating on the `follow-up` branch; do NOT merge #617 to `main` until ≥80% of the original smoke checklist passes cleanly. The AI workflow's verification gate failed this round — `vitest run` clean is necessary but nowhere near sufficient.**
-
-## Smoke scoreboard (vbeta.18.36)
-
-✅ PASS (6) | ⚠️ PARTIAL (1) | ❌ FAIL (10)
-
-| Section | Result |
-|---|---|
-| Cmd+Q lifecycle (both ports clear) | ✅ |
-| New session + send message (TypeError gone) | ✅ |
-| Sessions 1 (soft-close live) | ✅ |
-| Sessions 2 (hard-delete live) | ✅ |
-| Composer 1 (no agent dropdown, model prompt) | ✅ |
-| Composer 2 (picker sectioned + Connect) | ✅ |
-| Sessions 3 (archive — active-list live, **archived list not live**) | ⚠️ |
-| Permissions 1-4 (#608 pipeline NEVER fires for Claude direct) | ❌ |
-| Composer 3 (#604 thinking + fast-mode never reach SDK) | ❌ |
-| Composer 4 (#602 file-attach paperclip no-op) | ❌ |
-| Composer 5 (#610 slash popover doesn't appear) | ❌ |
-| Composer 6 notify (#606 never fires macOS notification) | ❌ |
-| Composer 6 timestamp ticker (relative times don't update) | ❌ |
-| Composer 7 (#609 curation saves but picker over-filters; duplicate rows) | ❌ |
-| VCS 1 (#603 branch dropdown — Dart type cast error + switch fails) | ❌ |
-| VCS 2/3 (#607 chip never renders) | ❌ |
+Active. **Replaces** the PR #617 bug-fix sprint plan (completed; preserved in git history).
+Planning-only run: this document + `docs/ai/generated-issues/opencode-m*-*.md`.
+No implementation in this run. GitHub issues will be created by the orchestrator after review.
 
 ## Goal (one sentence)
 
-Drive #617's pass rate from 30% → ≥80% by working the bugs in severity order, re-smoking each cluster on a new DMG, before merging.
+Bring Rhythm's Agents tab to functional + UI parity with OpenCode v1.14.49's client feature
+set, on the existing embedded-SDK architecture, by first eliminating the root causes that
+made the previous attempt rot (dual transcript stores, duck-typed SDK access, in-memory
+sentinels), then layering rendering parity, session features, and input/config features —
+each issue building on the last.
 
-## Constraints
+## Architecture decision (locked — do not relitigate)
 
-- Stay on `follow-up` branch. No new feature work until bugs cleared.
-- Every fix must include the test that would have caught the bug in `vitest run` or `flutter test` — no more "mocks pass but production fails."
-- For Flutter UI features (file-attach, slash popover, VCS chip, PermissionCard), at least one widget test exercising the user-visible path.
-- For server↔SDK plumbing (binding, params, body fields), at least one test that asserts the SDK call is invoked with the expected shape (use spy.mock.calls inspection).
-- Re-smoke against a packaged DMG, not `flutter run -d macos`, before claiming each fix is shipped — the bugs in this batch (PATH stripping, NSApp.terminate, body-limit, server.close miss) all manifested only in the packaged build.
-- ABI: keep using `vbeta.18.NN` versioning, increment per smoke build.
+- `@opencode-ai/sdk` v1.14.49 embedded in-process in `apps/api_server` (opencode server on :4096).
+- SSE → WS bridge (`opencode_stream_bridge.ts` → `ws_gateway.ts`) to Flutter.
+- Native Flutter UI (consume opencode's server API + reimplement client UI natively).
+- PTY is dead (removed in PR #574/#571); `pty_runner.ts` removal is part of M1.
+- VERIFIED: the embedded SDK exposes every endpoint needed for the gaps:
+  `/session/{id}/diff`, `/revert`, `/unrevert`, `/summarize`, `/todo`, `/fork`, `/share`,
+  `/command`, `/message` (list), `/children`, `/permissions/{permissionID}`, `/mcp`,
+  `/provider`, `/config`, `/file/status`.
 
-## Fix clusters (work in this order)
+## Root causes of the prior failure (each is explicitly fixed by an M1 issue)
 
-### Cluster A — Safety + visible regressions (highest)
-
-| Issue file | What | Why first |
+| # | Root cause (postmortem-mined) | Fixed by |
 |---|---|---|
-| `fix-permission-pipeline-not-firing-claude-direct.md` | #608 `permission.asked → PermissionCard` chain |  **Safety feature broken.** Claude can run `bash` unprompted in default mode. The whole permission UX is non-functional. |
-| `fix-vcs-branch-dropdown-type-cast-and-switch.md` | #603 branch dropdown Dart type cast + HEAD switch | High visibility, blocks VCS 2/3 spot-test. Likely a one-spot parser fix. |
-| `fix-vcs-chip-not-rendering-in-session-header.md` | #607 chip never renders | Entire #607 surface invisible. Probably same root cause as VCS 1. |
+| 1 | Dual transcript stores (`_chatMessagesBySession` in-memory parts vs `_transcriptsBySession` SQLite plain text) with two render branches — every reconnect silently downgrades; every feature wired twice | OPC-M1-2, OPC-M1-3 |
+| 2 | Duck-typed SDK access (`diffSession` doesn't exist; permission-respond probe; command cast) → silent no-ops | OPC-M1-1 |
+| 3 | C2 contract failures — tests asserting injected values production never produces | Validation plan rule 2 (every contract test uses real SDK event/response shapes captured from v1.14.49) |
+| 4 | Provider-id vs agent-id conflation papered with duplicated maps | OPC-M1-1 (single server-side mapping, exported constant consumed by capabilities route) |
+| 5 | In-memory sentinels (`erroredSessions` 5s setTimeout, `__pending__` rows) leaking across turns | OPC-M1-4 |
 
-### Cluster B — Composer behavioral features (medium)
+## Milestones
 
-| Issue file | What |
+Sequencing rule: within a milestone, issues are ordered; an issue may start only when its
+dependencies are merged. M1 is strictly serial after the first two (which can parallel).
+
+### M1 — Foundation (fixes root causes; nothing else lands first)
+
+| Order | Issue file | Title | Goal | Likely files | Tests | Depends on |
+|---|---|---|---|---|---|---|
+| 1 | `opencode-m1-1-typed-sdk-wrappers.md` | Typed SDK wrappers replace all duck-typing | Every SDK call goes through a typed `OpencodeClientService` method that throws loudly on missing SDK surface; fixes the `diffSession` bug class and the silent permission no-op | `apps/api_server/src/services/opencode_client_service.ts`, `@types/opencode-ai-sdk.d.ts`, `controllers/agent_sessions_controller.ts` | vitest | — |
+| 2 | `opencode-m1-2-structured-parts-persistence.md` | Persist structured messages/parts server-side | Single durable source of truth: stream bridge writes full part-typed message rows; REST returns them | `apps/api_server/src/database/migrations.ts`, `repositories/agent_session_messages_repository.ts`, `services/opencode_stream_bridge.ts`, `controllers/agent_sessions_controller.ts` | vitest | — |
+| 3 | `opencode-m1-3-flutter-rehydration-single-path.md` | Flutter rehydrates parts from REST; legacy plain-text path deleted | One render path everywhere (main view + mini-bubble); reconnect/restart no longer downgrades; stuck-detection uses parts state | `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`, `views/agents_view.dart`, `app/core/agents/agent_bubble_overlay.dart`, `features/agents/data/*` | flutter test | M1-2 |
+| 4 | `opencode-m1-4-stream-sentinel-cleanup.md` | Stream lifecycle + sentinel cleanup, dead code removal | Real `stopStream`, no time-based sentinels, `pty_runner.ts` deleted | `apps/api_server/src/services/opencode_stream_bridge.ts`, `controllers/agent_sessions_controller.ts`, `services/pty_runner.ts` (delete), `agents_controller.dart` | vitest + flutter test | M1-3 |
+| 5 | `opencode-m1-5-resume-continuity.md` | Resume with real conversation continuity | `resume()` re-attaches to the persisted SDK session id and rehydrates; no more fresh-session amnesia | `apps/api_server/src/controllers/agent_sessions_controller.ts`, `services/opencode_engine.ts`, `migrations.ts` (persist sdk session id), `agents_controller.dart` | vitest + flutter test | M1-2, M1-3 |
+
+### M2 — Rendering parity
+
+| Order | Issue file | Title | Goal | Likely files | Tests | Depends on |
+|---|---|---|---|---|---|---|
+| 6 | `opencode-m2-1-markdown-rendering.md` | Markdown rendering in chat bubbles | Assistant text parts render as markdown (code blocks, lists, links), selectable | `agents_view.dart`, new `views/_markdown_message_body.dart`, `pubspec.yaml` | flutter test | M1-3 |
+| 7 | `opencode-m2-2-reasoning-block-and-delta-fix.md` | Reasoning collapsible block + non-text delta fix | `_appendChatDelta` routes deltas by part field; reasoning renders as a collapsed "Thinking…" block | `agents_controller.dart` (≈line 1322), `agents_view.dart` (≈line 1881) | flutter test | M1-3 |
+| 8 | `opencode-m2-3-tool-specific-renderers.md` | Tool-specific renderers | edit/write→unified diff widget, bash→terminal-style output, todowrite→checklist, task→child-session chip; generic card stays the fallback | `agents_view.dart`, new `views/_tool_renderers/*.dart`, new `views/_unified_diff_view.dart` | flutter test | M2-1 |
+| 9 | `opencode-m2-4-retry-status-tokens-cost.md` | Retry surfacing + token/cost display | Retry parts shown inline; per-message token/cost; session totals in sidebar/header | `opencode_stream_bridge.ts`, `agents_controller.dart`, `agents_view.dart`, message model | vitest + flutter test | M1-2, M1-3 |
+
+### M3 — Session features
+
+| Order | Issue file | Title | Goal | Likely files | Tests | Depends on |
+|---|---|---|---|---|---|---|
+| 10 | `opencode-m3-1-changes-tab-real-diff.md` | Changes tab via real GET /session/{id}/diff | Fix the always-empty Changes tab using the typed diff wrapper | `agent_sessions_controller.ts` (362-383), `opencode_client_service.ts`, `agents_view.dart`, `agents_controller.dart` | vitest + flutter test | M1-1, M2-3 |
+| 11 | `opencode-m3-2-revert-unrevert.md` | Undo: revert/unrevert UI | Per-message revert affordance + session-level unrevert, with confirmation | `opencode_client_service.ts`, `agent_sessions_controller.ts`, `agents_view.dart`, `agents_controller.dart` | vitest + flutter test | M3-1 |
+| 12 | `opencode-m3-3-compaction-summarize.md` | Compaction (summarize) with UI affordance | Manual "Compact session" action + compaction part rendering + context-usage hint | `opencode_client_service.ts`, `agent_sessions_controller.ts`, `agents_view.dart` | vitest + flutter test | M1-1, M1-3 |
+| 13 | `opencode-m3-4-structured-command-dispatch.md` | Slash commands via POST /session/{id}/command | Popover selection dispatches the structured command endpoint instead of text-prefix injection | `opencode_client_service.ts`, `ws_gateway.ts` or REST route, `views/_slash_command_popover.dart`, `agents_controller.dart` | vitest + flutter test | M1-1 |
+| 14 | `opencode-m3-5-todo-panel.md` | Session todo panel | Live todo list (todo.updated events + GET /session/{id}/todo) in a collapsible side panel | `opencode_stream_bridge.ts`, `agent_sessions_controller.ts`, `agents_view.dart`, `agents_controller.dart` | vitest + flutter test | M1-2, M2-3 |
+| 15 | `opencode-m3-6-subagent-child-sessions.md` | Subagent child-session navigation | task tool chip opens the child session's transcript (GET /session/{id}/children); breadcrumb back to parent | `agent_sessions_controller.ts`, `opencode_client_service.ts`, `agents_controller.dart`, `agents_view.dart` | vitest + flutter test | M2-3 |
+
+### M4 — Input & config
+
+| Order | Issue file | Title | Goal | Likely files | Tests | Depends on |
+|---|---|---|---|---|---|---|
+| 16 | `opencode-m4-1-real-file-attachments.md` | Real image/file attachments (FilePart) | Paperclip sends FilePart with data URI (bytes), not "[image] /path" text; thumbnails in transcript | `agents_controller.dart`, `agents_view.dart`, `ws_gateway.ts`, `opencode_client_service.ts` | vitest + flutter test | M1-3 |
+| 17 | `opencode-m4-2-session-fork.md` | Session fork | Fork from a message → new session appears in list with copied transcript | `opencode_client_service.ts`, `agent_sessions_controller.ts`, `agents_controller.dart`, `agents_view.dart` | vitest + flutter test | M1-5 |
+| 18 | `opencode-m4-3-mcp-config-ui.md` | MCP server management UI | Settings section: list/connect/disconnect MCP servers via SDK /mcp | `opencode_client_service.ts`, new `routes/opencode_mcp_routes.ts`, `features/settings/widgets/mcp_section.dart` (new) | vitest + flutter test | M1-1 |
+| 19 | `opencode-m4-4-custom-agent-selection.md` | Custom agent/mode selection | If SDK config exposes custom agents, surface an agent picker per session; otherwise ship the documented built-in set only | `opencode_client_service.ts`, `agents_capabilities_routes.ts`, `agents_view.dart`, `agents_controller.dart` | vitest + flutter test | M1-1 |
+
+## Explicitly out of scope (with justification)
+
+| Feature | Why excluded |
 |---|---|
-| `fix-thinking-budget-fast-mode-never-applied.md` | #604 — fix `promptAsync` signature to actually accept + forward `thinking` / `fastMode` to the SDK body |
-| `fix-composer-file-attach-paperclip-no-op.md` | #602 — wire the paperclip click to the new osascript-based file picker (the `file_picker` plugin was removed earlier) |
-| `fix-slash-command-popover-not-firing.md` | #610 — typing `/` opens the popover; arrow / Enter / Escape work |
-| `fix-notify-on-completion-not-firing.md` | #606 — covers BOTH the notify-on-completion authorization + the relative-timestamp ticker |
+| Share server (`/session/{id}/share`) | Publishes session content to opencode's public share infrastructure — church staff sessions can contain congregant PII and internal data. Recommend shipping with share **disabled**; revisit only if a self-hosted share target exists. |
+| Themes / keybinds | Rhythm has its own design system (`RhythmColorRoles` tokens) and macOS conventions (`KeybindsService`). Porting OpenCode's TUI theming would fork the design system for one tab. |
+| LSP / formatter status | TUI affordance for a code-editing terminal context; Rhythm sessions run against task cwds, not an open editor. No UI surface where this earns its complexity. |
+| PTY terminal pane | PTY architecture removed in PR #574; reintroducing a terminal contradicts the locked decision. Bash tool output gets terminal-style *rendering* (M2-3) instead. |
+| TUI remote-control routes | Drive opencode's own TUI — meaningless when the client is native Flutter. |
+| Workspaces / worktrees | Rhythm sessions are keyed to a single cwd per session; worktree management is a power-developer feature with no church-staff use case. Fork (M4-2) covers the "try a variant" need. |
 
-### Cluster C — OpenRouter catalog overhaul (medium, scoped sprint)
+## Validation plan
 
-| Issue file | What |
-|---|---|
-| `fix-openrouter-curation-overhaul.md` | #609 — dedup aggregator routes against authed-direct routes; surface ALL curated models in the picker (currently filters to ~6); add bulk-action UI + price/free filter + sane default visibility; fix duplicate `anthropic/claude-sonnet-4.6` row |
-
-### Cluster D — UX / cosmetic (low, batch with Cluster B/C)
-
-| Issue file | What |
-|---|---|
-| `fix-archived-section-not-updating-live.md` | Insert into archived list cache on `session.updated` WS event when `archivedAt` flips |
-| `fix-agent-chat-auto-scroll-steals-focus.md` | Scroll-to-bottom should only fire when user is already pinned near the bottom |
-| `fix-agent-kind-mislabels-non-anthropic-openrouter-models.md` | Pill label for DeepSeek / Mistral / Llama OpenRouter routes |
-| `fix-google-oauth-paste-back-ui.md` | Render paste input in the Google sign-in dialog instead of "auto-close" placeholder |
-| `tweak-default-model-sonnet-over-opus.md` | Reorder `ROUTE_FALLBACKS_BY_AGENT['claude-code']` to put Sonnet first |
-
-### Skipped (environment-dependent)
-
-- Lifecycle 4 (ABI-matched Node fallback). Requires a v24-only test machine. Park for now.
-
-## Validation plan (revised — stricter than the round that failed)
-
-1. `ai-workflow checks --level pr` exit 0 after each issue.
-2. **Each fix MUST add a test that would have caught the bug.** No skipping this step. If the bug is "function does X in production but mock doesn't reveal it," fix the mock too — use real implementations in tests where feasible.
-3. **Packaged-build smoke is the source of truth.** `vbeta.18.NN+1` rebuild + install over `/Applications/` + manually exercise the specific item before marking a fix complete. `flutter run -d macos` does NOT count for this batch — its PATH and lifecycle differ from the `.app` bundle.
-4. After each cluster (A, B, C, D), re-run the entire 20-item smoke checklist. We're targeting ≥80% pass to merge.
-5. `dart format --set-exit-if-changed` + `flutter analyze --no-fatal-infos` stay clean.
-
-## Process retrospective notes (for `workflow-retrospective` next time)
-
-Items the workflow should have flagged before any "Closes #608" claim was committed:
-
-- **Mock parity check.** Arrow-function mocks of class methods are a banned pattern when the production method uses `this`. Tests should bind their mocks the same way the production code does.
-- **End-to-end coverage matrix.** Every "Closes #XXX" claim needs at minimum one test that exercises the user-visible path (UI → WS → server → SDK and back), not just unit tests of the parts in isolation.
-- **Packaged-build smoke before commit, not just before merge.** The PATH-stripping bug + the `server.close()` miss + the binding bug all only manifested in the `.app` bundle. A bot-or-script DMG-build-and-curl loop in the CI would have caught all three.
-- **No "all green" claim without a smoke checklist run.** Even a five-item smoke is worth doing before pushing a 13-issue PR.
+1. Every issue gets a contract (`docs/ai/contracts/issue-N.json` per `docs/contract-schema.md`)
+   via `acceptance-contract` before coding; red-proven before implementation, green after.
+2. **Real-shape rule (root cause 3):** contract tests must use SDK event/response shapes
+   captured from v1.14.49 (real provider ids like `anthropic`/`openai`, real part-type unions),
+   never invented values. Mocks of class methods must preserve `this`-binding semantics.
+3. `ai-workflow checks --level pr` exits 0 per issue (flutter analyze, dart format, tsc, vitest);
+   full `flutter test` green.
+4. Server↔SDK plumbing: at least one vitest asserting the SDK spy is invoked with the expected
+   shape (`spy.mock.calls` inspection). Flutter UI: at least one widget test exercising the
+   user-visible path.
+5. Milestone-end manual smoke against `flutter run -d macos` (packaged-DMG smoke at M2 and M4
+   boundaries, since reconnect/restart behavior — the M1 deliverable — only fully manifests
+   across real app restarts).
+6. Manual merge only; PR per milestone-cluster or per issue at orchestrator's discretion.
 
 ## Branch / PR strategy
 
-- Stay on `follow-up`. Push fix commits there. Each cluster ships as its own DMG (vbeta.18.37, 38, 39, …) for incremental smoke.
-- When the entire 20-item checklist passes ≥16/20 (excluding skipped Lifecycle 4): commit a final "Ready for merge" doc update + push, then merge PR #617 to `main` manually.
-- Branch `follow-up` is intentionally not auto-rebased onto `main` during this fix sprint — keep the commit history readable for the retrospective.
+- One branch per issue (`opc-m1-1-typed-sdk-wrappers`, …) off `main`; PR per issue, sequenced.
+- M1 must fully merge before M2 starts — every M2+ issue assumes the single transcript path.
+- M3 issues 10/12/13 and M4 issues 16/18/19 are parallelizable once their deps merge.
 
 ## Estimated effort
 
-Per cluster, assuming each fix is the small targeted patch the issue docs suggest:
+- M1: 5 issues, the heart of the work — **4-6 sessions** (M1-2/M1-3 are the big ones).
+- M2: 4 issues — **3-4 sessions** (tool renderers are the most UI work).
+- M3: 6 issues — **4-5 sessions**.
+- M4: 4 issues — **3-4 sessions**.
+- Total: **~14-19 focused sessions**, re-smoke baked in at milestone boundaries.
 
-- Cluster A (3 issues, high severity): **2-3 sessions** — permission pipeline is the unknown; VCS likely a one-day fix.
-- Cluster B (4 issues, medium): **2-3 sessions** — file-attach + slash popover are the most UI work.
-- Cluster C (1 large issue, OpenRouter overhaul): **2-3 sessions** — bulk-action UI is meaningful work.
-- Cluster D (5 issues, low): **1 session, batched** with Cluster B/C.
+## Open questions (flagged for orchestrator/user before M1 starts)
 
-Total: **roughly 7-10 focused sessions** to get #617 to mergeable state. With re-smoking baked in.
+1. **Parts storage shape (M1-2):** proposal is a `parts_json TEXT` column on
+   `agent_session_messages` (one row per message, parts as a JSON array) over a normalized
+   `agent_session_parts` table — simpler migration, the client always consumes whole messages.
+   Confirm, or require normalized rows for future querying.
+2. **Markdown package (M2-1):** `flutter_markdown` is deprecated by the Flutter team (handed to
+   community as `flutter_markdown_plus`); `gpt_markdown` handles streaming/LaTeX better.
+   Needs a pick before M2-1; acceptance criteria are written package-agnostic.
+3. **Mini-bubble scope (M1-3):** plan assumes the mini-bubble is **kept** and moved to the
+   parts path. If the user would rather delete the mini-bubble overlay entirely, M1-3 shrinks.
+4. **Cost display (M2-4):** OpenCode reports cost in USD per assistant message. Show dollars to
+   church staff, or tokens only? Plan defaults to both (cost primary, tokens in tooltip).
+5. **Custom agents (M4-4):** v1.14.49 custom agents come from opencode config files in the cwd.
+   Rhythm doesn't manage per-cwd opencode config; the issue scopes to "render what the SDK
+   reports" with no config-authoring UI. Confirm that's the realistic version wanted.
+6. **Vague-criteria flags:** "terminal-style output" (M2-3) and "renders as markdown" (M2-1)
+   were vague in the request; issue files pin them to concrete testable assertions (monospace
+   font + preserved whitespace + ANSI stripped; specific markdown elements present as widgets).
+   Review those pins.

--- a/docs/ai/current-plan.md
+++ b/docs/ai/current-plan.md
@@ -46,7 +46,7 @@ dependencies are merged. M1 is strictly serial after the first two (which can pa
 |---|---|---|---|---|---|---|
 | 1 | `opencode-m1-1-typed-sdk-wrappers.md` | Typed SDK wrappers replace all duck-typing | Every SDK call goes through a typed `OpencodeClientService` method that throws loudly on missing SDK surface; fixes the `diffSession` bug class and the silent permission no-op | `apps/api_server/src/services/opencode_client_service.ts`, `@types/opencode-ai-sdk.d.ts`, `controllers/agent_sessions_controller.ts` | vitest | — |
 | 2 | `opencode-m1-2-structured-parts-persistence.md` | Persist structured messages/parts server-side | Single durable source of truth: stream bridge writes full part-typed message rows; REST returns them | `apps/api_server/src/database/migrations.ts`, `repositories/agent_session_messages_repository.ts`, `services/opencode_stream_bridge.ts`, `controllers/agent_sessions_controller.ts` | vitest | — |
-| 3 | `opencode-m1-3-flutter-rehydration-single-path.md` | Flutter rehydrates parts from REST; legacy plain-text path deleted | One render path everywhere (main view + mini-bubble); reconnect/restart no longer downgrades; stuck-detection uses parts state | `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`, `views/agents_view.dart`, `app/core/agents/agent_bubble_overlay.dart`, `features/agents/data/*` | flutter test | M1-2 |
+| 3 | `opencode-m1-3-flutter-rehydration-single-path.md` | Flutter rehydrates parts from REST; legacy plain-text path deleted; **mini-bubble overlay deleted** | One render path (main view only — bubble removed per user decision 2026-06-12); reconnect/restart no longer downgrades; stuck-detection uses parts state; trigger flow surfaces via Agents tab + notification | `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`, `views/agents_view.dart`, `app/core/agents/agent_bubble_overlay.dart` (delete), `overlay_controller.dart`, `agent_trigger_watcher.dart`, `features/agents/data/*` | flutter test | M1-2 |
 | 4 | `opencode-m1-4-stream-sentinel-cleanup.md` | Stream lifecycle + sentinel cleanup, dead code removal | Real `stopStream`, no time-based sentinels, `pty_runner.ts` deleted | `apps/api_server/src/services/opencode_stream_bridge.ts`, `controllers/agent_sessions_controller.ts`, `services/pty_runner.ts` (delete), `agents_controller.dart` | vitest + flutter test | M1-3 |
 | 5 | `opencode-m1-5-resume-continuity.md` | Resume with real conversation continuity | `resume()` re-attaches to the persisted SDK session id and rehydrates; no more fresh-session amnesia | `apps/api_server/src/controllers/agent_sessions_controller.ts`, `services/opencode_engine.ts`, `migrations.ts` (persist sdk session id), `agents_controller.dart` | vitest + flutter test | M1-2, M1-3 |
 
@@ -121,23 +121,18 @@ dependencies are merged. M1 is strictly serial after the first two (which can pa
 - M4: 4 issues — **3-4 sessions**.
 - Total: **~14-19 focused sessions**, re-smoke baked in at milestone boundaries.
 
-## Open questions (flagged for orchestrator/user before M1 starts)
+## Open questions — resolutions (user, 2026-06-12)
 
-1. **Parts storage shape (M1-2):** proposal is a `parts_json TEXT` column on
-   `agent_session_messages` (one row per message, parts as a JSON array) over a normalized
-   `agent_session_parts` table — simpler migration, the client always consumes whole messages.
-   Confirm, or require normalized rows for future querying.
-2. **Markdown package (M2-1):** `flutter_markdown` is deprecated by the Flutter team (handed to
-   community as `flutter_markdown_plus`); `gpt_markdown` handles streaming/LaTeX better.
-   Needs a pick before M2-1; acceptance criteria are written package-agnostic.
-3. **Mini-bubble scope (M1-3):** plan assumes the mini-bubble is **kept** and moved to the
-   parts path. If the user would rather delete the mini-bubble overlay entirely, M1-3 shrinks.
-4. **Cost display (M2-4):** OpenCode reports cost in USD per assistant message. Show dollars to
-   church staff, or tokens only? Plan defaults to both (cost primary, tokens in tooltip).
-5. **Custom agents (M4-4):** v1.14.49 custom agents come from opencode config files in the cwd.
-   Rhythm doesn't manage per-cwd opencode config; the issue scopes to "render what the SDK
-   reports" with no config-authoring UI. Confirm that's the realistic version wanted.
+1. **Parts storage shape (M1-2): RESOLVED** — `parts_json TEXT` column on
+   `agent_session_messages` (one row per message, parts as a JSON array). No normalized table.
+2. **Markdown package (M2-1): RESOLVED** — `gpt_markdown` (streaming-delta-friendly).
+3. **Mini-bubble scope (M1-3): RESOLVED** — **delete the mini-bubble overlay entirely**
+   ("good idea, but doesn't really seem that helpful"). M1-3 deletes `agent_bubble_overlay.dart`
+   + wiring; the trigger flow surfaces via the Agents tab list + existing desktop notification.
+   No replacement surface designed in M1-3 — follow-up issue if it feels under-surfaced.
+4. **Cost display (M2-4): RESOLVED** — keep dollars on (cost primary, token breakdown in
+   tooltip), as planned.
+5. **Custom agents (M4-4): OPEN** — awaiting user decision after explanation of what OpenCode
+   custom agents are and what the no-authoring-UI scope means.
 6. **Vague-criteria flags:** "terminal-style output" (M2-3) and "renders as markdown" (M2-1)
-   were vague in the request; issue files pin them to concrete testable assertions (monospace
-   font + preserved whitespace + ANSI stripped; specific markdown elements present as widgets).
-   Review those pins.
+   were pinned to concrete testable assertions in the issue files; review during PR/issue read.

--- a/docs/ai/decisions.md
+++ b/docs/ai/decisions.md
@@ -185,3 +185,25 @@
 - + `context.watch` keeps the pill live on config refreshes.
 - - The Flutter map duplicates the server `PROVIDER_TO_AGENT`; if the server adds a provider, both must change. Acceptable for now (two small maps); a shared source could be considered later.
 - Landed on branch `fix/issue-643-645-agents-ui`, PR pending.
+
+## 2026-06-12 — OpenCode parity: keep the embedded-SDK architecture (plan #685–#703)
+
+**Context:** Request to port OpenCode's full feature set/UI into the Agents tab, after a prior partial attempt. Options weighed: (a) PTY-wrap the opencode TUI, (b) consume opencode's server API, (c) reimplement client logic natively, (d) hybrid. Audits showed the current code is already (b)+(c): `@opencode-ai/sdk` v1.14.49 in-process (server on :4096), SSE→WS bridge, native Flutter UI — and that the SDK already exposes every endpoint the missing features need (`diff`, `revert`, `unrevert`, `summarize`, `todo`, `fork`, `command`, `message` list, `children`, `mcp`).
+
+**Decision:** Keep (b)+(c). The parity gap is wiring + UI, not architecture. PTY-wrapping the TUI was rejected (regression to the pre-#574 world: ANSI scraping, no structured parts, no permission cards); a webview of opencode's web/desktop client was rejected (foreign design system, Electron/Solid stack inside Flutter). The plan's M1 fixes the structural defects that made the prior attempt rot — dual transcript stores, duck-typed SDK access, in-memory sentinels — before any new features land.
+
+**Consequences:**
+- + Each parity feature maps to a typed SDK call + a Flutter widget; per-issue contracts can use recorded v1.14.49 fixtures.
+- + Out-of-scope list is explicit (share/themes/keybinds/LSP/TUI-remote/worktrees) with church-context justifications.
+- - SDK version pinning matters: parity claims are against v1.14.49; SDK upgrades need a re-audit of the event/part union.
+- Landed: plan + issue specs on `workflow/run-2026-06-12-opencode-parity-plan` (PR #704); issues #685–#703.
+
+## 2026-06-12 — AgentFlow CLI resume requires AGENTFLOW_WORKFLOWS_DIR (process note)
+
+**Context:** A `plan_and_issues` run died mid-flight when the agentflow MCP server restarted (its in-memory registry is lost on restart; phase outputs/state survive on disk). The documented recovery is CLI `agentflow resume <aflow> --instance <uuid>` — but the first attempt silently resolved model tiers from the built-in fallback (ollama `qwen2.5:14b`) and failed with `fetch failed`, because the model-resolver only reads `agentflow.config.json` from CWD or `$AGENTFLOW_WORKFLOWS_DIR`, and neither was set.
+
+**Decision:** Always run CLI resumes as `AGENTFLOW_WORKFLOWS_DIR="$HOME/.config/agentflow/workflows" agentflow resume …` (that dir holds the canonical tier→model config: tier1=claude-fable-5, tier2=sonnet, tier3=haiku). With it set, the resume completed plan+write_issues correctly on tier1.
+
+**Consequences:**
+- + Stalled AgentFlow runs are recoverable without re-running completed phases.
+- - The fallback-to-ollama behavior is silent until an agent executes; check the `📦 [agent] model:` line in resume output before trusting a resumed run.

--- a/docs/ai/generated-issues/opencode-future-agent-builder-ui.md
+++ b/docs/ai/generated-issues/opencode-future-agent-builder-ui.md
@@ -1,0 +1,64 @@
+# OPC-FUTURE — Custom assistant builder UI (define personas inside Rhythm)
+
+**Milestone:** none — future feature, deliberately unscheduled (post-M4 at the earliest)
+**Depends on:** OPC-M4-4 (#703) — the agent *selector* must exist before authoring does
+
+## Summary
+
+A Settings surface where staff define custom AI assistant personas inside Rhythm — name,
+instructions (system prompt), default model, permission defaults (e.g. read-only), color/icon —
+which Rhythm persists into OpenCode's **global** config (`~/.config/opencode/opencode.json`
+`agent` map, or the SDK config-PATCH endpoint if it proves writable) so they appear in the
+per-session agent selector shipped by OPC-M4-4.
+
+Example target user story: a "Bulletin Writer" persona with church-specific instructions that
+any staff member can pick for a session, without anyone hand-editing JSON config files.
+
+## Why this is split out (decision 2026-06-12)
+
+OPC-M4-4 ships the realistic parity version: render whatever agents the SDK reports, no
+authoring. Authoring is a real product feature — persona design, permission UX for
+non-technical staff, where definitions live (per-machine global config vs synced), name
+collisions with built-ins — and deserves its own design pass rather than riding on a parity
+issue. User confirmed: keep #703 as-is, file this for the future.
+
+## Design questions to settle before implementation (not now)
+
+1. **Storage target:** global opencode config (per-machine; simplest) vs Rhythm production DB
+   with per-machine sync-down (personas shared across staff — likely the actual want, since
+   per-user/per-machine personas defeat the "Bulletin Writer for everyone" story).
+2. **Permission presets:** expose OpenCode's full permission ruleset or a 2-3 choice radio
+   ("Can edit files" / "Read-only" / "Ask every time")? Lean: the radio — staff are not
+   developers.
+3. **Prompt authoring help:** free-text instructions only, or template/starter library
+   (mirroring the starter-packs pattern from the staff guide)?
+4. **Validation:** prevent shadowing built-in agent names (build/plan/general); preview a
+   persona against a scratch session before saving.
+5. **SDK surface check at implementation time:** v1.14.49 exposes `GET/PATCH /config`; verify
+   the embedded server honors an `agent` map PATCH at runtime (or whether a restart/reload of
+   the opencode engine is required) before committing to live-apply semantics.
+
+## Sketch acceptance criteria (to be firmed when scheduled)
+
+1. Settings → "Custom assistants": list, create, edit, delete personas (name, instructions,
+   model default, permission preset).
+2. A saved persona appears in the OPC-M4-4 session agent selector without app restart (or with
+   a documented, user-visible "restart agents engine" affordance if the SDK requires it).
+3. A session run with the persona demonstrably uses its instructions (vitest spy on the prompt
+   call / SDK config fixture) and its permission preset (plan-style deny honored).
+4. Deleting a persona never deletes built-ins; name-collision with built-ins is rejected at
+   save time.
+5. Personas survive app restart; storage location documented in architecture.md.
+6. `ai-workflow checks --level pr` green; vitest + flutter test cover the above.
+
+## Likely files (sketch)
+
+- `apps/api_server/src/services/opencode_client_service.ts` (config read/patch wrapper)
+- `apps/api_server/src/routes/` (persona CRUD route, or production-API table + sync if design
+  question 1 lands on shared storage)
+- `apps/desktop_flutter/lib/features/settings/widgets/custom_assistants_section.dart` (new)
+- `apps/desktop_flutter/lib/features/agents/` (selector refresh hook)
+
+## Out of scope
+
+- Anything in the M1-M4 parity sequence. This issue must not block or expand #703.

--- a/docs/ai/generated-issues/opencode-m1-1-typed-sdk-wrappers.md
+++ b/docs/ai/generated-issues/opencode-m1-1-typed-sdk-wrappers.md
@@ -1,0 +1,58 @@
+# OPC-M1-1 — Typed SDK wrappers replace all duck-typing (diff, permission respond, command)
+
+**Milestone:** M1 — Foundation
+**Branch:** `opc-m1-1-typed-sdk-wrappers`
+**Depends on:** — (first issue; M1-2 may run in parallel)
+
+## Summary
+
+Every Opencode SDK call must go through a typed method on `OpencodeClientService` declared in
+`@types/opencode-ai-sdk.d.ts`. Remove all duck-typed probes and `as unknown as` casts. A typed
+wrapper that finds the SDK surface missing must **throw a descriptive error** (surfaced as
+AppError → WS error frame), never silently no-op.
+
+## Motivation
+
+Root cause 3 of the prior failure: duck-typed SDK access produced silent no-ops —
+`diffSession` (doesn't exist; the real method maps to `GET /session/{id}/diff`) made the
+Changes tab permanently empty, and the permission-respond probe
+(`opencode_client_service.ts:654-663`) can silently no-op, hanging the agent.
+
+## Scope
+
+Add/replace typed wrapper methods (names indicative):
+
+- `getSessionDiff(sdkId): Promise<SessionDiff[]>` — maps to `GET /session/{id}/diff`
+- `respondToPermission(sdkId, permissionId, decision, feedback?)` — maps to `POST /session/{id}/permissions/{permissionID}`; remove the 654-663 probe
+- `dispatchCommand(sdkId, command, args)` — maps to `POST /session/{id}/command`
+- `listMessages(sdkId)`, `getTodo(sdkId)`, `revert/unrevert`, `summarize`, `fork`, `listChildren`, `listMcp/connectMcp/disconnectMcp` — declared now (typed, unit-tested at the wrapper level) so M3/M4 consume them without re-touching the d.ts
+- Single exported `PROVIDER_TO_AGENT_KIND` constant in the server, consumed by `agents_capabilities_routes.ts` and exposed via `GET /agents/capabilities` so Flutter's duplicated `_kProviderToAgentKind` map can be deleted in M1-3 (root cause 4)
+
+## Likely files
+
+- `apps/api_server/src/services/opencode_client_service.ts`
+- `apps/api_server/src/@types/opencode-ai-sdk.d.ts`
+- `apps/api_server/src/controllers/agent_sessions_controller.ts` (replace `diffSession` duck-type at :362-383 call site with the typed wrapper)
+- `apps/api_server/src/routes/agents_capabilities_routes.ts`
+- `apps/api_server/src/services/ws_gateway.ts` (permission respond path)
+
+## Acceptance criteria
+
+1. Repo-wide grep: zero occurrences of `diffSession`, zero `as unknown as` casts targeting SDK objects in `opencode_client_service.ts`, `agent_sessions_controller.ts`, `ws_gateway.ts`.
+2. `getSessionDiff` invokes the SDK method that maps to `GET /session/{id}/diff` (spy.mock.calls asserts the SDK client method + sdkId argument) and returns its payload verbatim.
+3. `respondToPermission` invokes the SDK permission endpoint with `{decision, feedback}`; when the SDK object lacks the method, it **throws** an Error whose message contains the method name (asserted), instead of returning undefined.
+4. `dispatchCommand` invokes the SDK command endpoint with `{command, args}` shape.
+5. Every wrapper, when called before SDK init, throws/rejects with the existing "engine not ready" AppError (no silent resolve).
+6. `GET /agents/capabilities` response includes the provider→agent-kind mapping object.
+7. `ai-workflow checks --level pr` exits 0.
+
+## Required tests (vitest)
+
+- New `opencode_client_typed_wrappers.test.ts`: one test per wrapper asserting SDK spy call shape using **real provider/part shapes from v1.14.49** (real-shape rule); missing-method → throw; not-ready → reject.
+- Extend `agents_capabilities_routes.test.ts` for criterion 6.
+- Mocks must not use arrow-function method mocks where production uses `this` (banned pattern per #617 retrospective).
+
+## Out of scope
+
+- No Flutter changes (M1-3 deletes the duplicated Flutter map).
+- No new UI features consuming the new wrappers (M3/M4).

--- a/docs/ai/generated-issues/opencode-m1-2-structured-parts-persistence.md
+++ b/docs/ai/generated-issues/opencode-m1-2-structured-parts-persistence.md
@@ -29,7 +29,7 @@ ALTER TABLE agent_session_messages ADD COLUMN cost REAL;               -- USD | 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_asm_sdk_msg ON agent_session_messages(session_id, sdk_message_id);
 ```
 
-Decision (flagged in plan open question 1): JSON column over a normalized parts table —
+Decision (resolved 2026-06-12, plan open question 1 — user confirmed): JSON column over a normalized parts table —
 clients always consume whole messages; simpler upsert from `message.updated`. Legacy rows keep
 `parts_json = NULL` and are served as a single synthetic text part (back-compat read shim).
 

--- a/docs/ai/generated-issues/opencode-m1-2-structured-parts-persistence.md
+++ b/docs/ai/generated-issues/opencode-m1-2-structured-parts-persistence.md
@@ -1,0 +1,69 @@
+# OPC-M1-2 — Persist structured messages/parts server-side (single source of truth)
+
+**Milestone:** M1 — Foundation
+**Branch:** `opc-m1-2-structured-parts-persistence`
+**Depends on:** — (parallel with M1-1)
+
+## Summary
+
+Extend `agent_session_messages` so each row stores the full structured message — SDK message id,
+role, and a `parts_json TEXT` column holding the ordered part array (the 12-type union: text,
+reasoning, file, tool, step-start, step-finish, snapshot, patch, agent, subtask, retry,
+compaction) plus token/cost metadata for assistant messages. The stream bridge upserts rows as
+SSE events arrive; `GET /agent-sessions/:id/messages` returns the structured form.
+
+## Motivation
+
+Root cause 1: the prior implementation kept parts in Flutter memory only and persisted lossy
+role+text rows. Every reconnect/restart silently downgraded to the legacy plain-text render
+path, and every new feature had to be wired twice. This issue makes the server DB the single
+durable transcript store; M1-3 makes Flutter rehydrate from it.
+
+## Schema (idempotent migration)
+
+```sql
+ALTER TABLE agent_session_messages ADD COLUMN sdk_message_id TEXT;     -- PRAGMA-guarded
+ALTER TABLE agent_session_messages ADD COLUMN parts_json TEXT;         -- JSON array of parts
+ALTER TABLE agent_session_messages ADD COLUMN tokens_json TEXT;        -- {input,output,reasoning,cache} | NULL
+ALTER TABLE agent_session_messages ADD COLUMN cost REAL;               -- USD | NULL
+CREATE UNIQUE INDEX IF NOT EXISTS idx_asm_sdk_msg ON agent_session_messages(session_id, sdk_message_id);
+```
+
+Decision (flagged in plan open question 1): JSON column over a normalized parts table —
+clients always consume whole messages; simpler upsert from `message.updated`. Legacy rows keep
+`parts_json = NULL` and are served as a single synthetic text part (back-compat read shim).
+
+## Stream bridge persistence
+
+- `message.updated` → upsert full row (role, parts_json, tokens_json, cost) keyed by (session_id, sdk_message_id).
+- `message.part.updated` / `message.part.delta` → update the in-flight row's parts_json (write-through on part.updated; deltas may batch — final state must match the SDK's message on `session.idle`).
+- `message.removed` / `message.part.removed` → delete/patch accordingly.
+- Because the SDK has no SSE replay, the row store is the replay.
+
+## Likely files
+
+- `apps/api_server/src/database/migrations.ts`
+- `apps/api_server/src/repositories/agent_session_messages_repository.ts` (or current messages repo)
+- `apps/api_server/src/services/opencode_stream_bridge.ts`
+- `apps/api_server/src/controllers/agent_sessions_controller.ts` (messages GET)
+- `apps/api_server/src/models/agent_session_message.ts`
+
+## Acceptance criteria
+
+1. Migration is idempotent (runs twice cleanly) and preserves existing rows (`parts_json IS NULL`).
+2. Feeding the bridge a recorded v1.14.49 `message.updated` event (assistant message with text + tool + reasoning parts, tokens, cost) results in one row whose `parts_json` round-trips the part array and whose `tokens_json`/`cost` match the event.
+3. A second `message.updated` for the same sdk_message_id updates the same row (no duplicates; unique index holds).
+4. `GET /agent-sessions/:id/messages` returns messages ordered by creation with `parts` as a parsed array, `tokens`, `cost`; legacy NULL-parts rows come back as `[{type:'text', text:<row text>}]`.
+5. `message.removed` deletes the row; `message.part.removed` removes only that part.
+6. After simulating bridge restart (new bridge instance, same DB), GET still returns the full structured transcript (persistence, not memory).
+7. `ai-workflow checks --level pr` exits 0.
+
+## Required tests (vitest)
+
+- New `opencode_parts_persistence.test.ts` over in-memory SQLite + the bridge with **recorded real SDK event fixtures** (check fixtures into `src/__tests__/fixtures/opencode_v1_14_49/`). Cover criteria 1-6.
+
+## Out of scope
+
+- No Flutter changes (M1-3).
+- No WS protocol changes — the live WS stream is unchanged; this adds the durable store beside it.
+- No backfill of legacy rows into parts (read shim only).

--- a/docs/ai/generated-issues/opencode-m1-3-flutter-rehydration-single-path.md
+++ b/docs/ai/generated-issues/opencode-m1-3-flutter-rehydration-single-path.md
@@ -9,8 +9,10 @@
 `_chatMessagesBySession` becomes a cache of the server's structured transcript: on session
 select, reconnect, and app restart, Flutter fetches `GET /agent-sessions/:id/messages` and
 rebuilds parts-based chat state. The legacy plain-text transcript render branch is **deleted**
-everywhere — main transcript body, mini-bubble overlay, and stuck-detection — leaving exactly
-one render path.
+everywhere — main transcript body and stuck-detection — leaving exactly one render path.
+
+**Scope change (user decision 2026-06-12, plan open question 3):** the floating mini-bubble
+overlay is **deleted entirely**, not migrated. Sessions surface only in the Agents tab.
 
 ## Motivation
 
@@ -22,7 +24,8 @@ falsely flagged "stuck".
 ## Scope
 
 - Rehydration: `selectSession()` / WS reconnect / `initialize()` for resumable sessions fetch structured messages and populate `_chatMessagesBySession` + `_chatPartsByMessage`. Optimistic local rows (user input) reconcile by sdk message id on next hydrate.
-- Delete: `_transcriptsBySession`-driven rendering in `agents_view.dart` `_buildTranscriptBody` (the hasChat=false branch), the mini-bubble's legacy transcript read, `_liveOutputBuffer`. System/error WS frames become synthetic system-role chat messages (preserving the #638 behavior) instead of legacy transcript rows.
+- Delete: `_transcriptsBySession`-driven rendering in `agents_view.dart` `_buildTranscriptBody` (the hasChat=false branch), `_liveOutputBuffer`. System/error WS frames become synthetic system-role chat messages (preserving the #638 behavior) instead of legacy transcript rows.
+- Delete the mini-bubble overlay: `agent_bubble_overlay.dart`, its `overlay_controller.dart` wiring, and every call site. The trigger-fired flow (AgentTriggerWatcher → task-collaboration session) must still work without it: the existing desktop notification path stays, and the session appears in the Agents tab list. If trigger handling currently *requires* a bubble API, replace with a no-op surface + follow-up issue rather than expanding scope here.
 - Stuck-detection: `_recomputeStuck` keys off parts state (last part activity timestamp / session status) instead of `_liveOutputBuffer`.
 - Delete Flutter's `_kProviderToAgentKind` duplicate; consume the mapping from `GET /agents/capabilities` (M1-1 criterion 6), with the current map as offline fallback.
 
@@ -30,7 +33,9 @@ falsely flagged "stuck".
 
 - `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`
 - `apps/desktop_flutter/lib/features/agents/views/agents_view.dart`
-- `apps/desktop_flutter/lib/app/core/agents/agent_bubble_overlay.dart`
+- `apps/desktop_flutter/lib/app/core/agents/agent_bubble_overlay.dart` (DELETE)
+- `apps/desktop_flutter/lib/app/core/agents/overlay_controller.dart` (DELETE or trim to non-bubble duties)
+- `apps/desktop_flutter/lib/app/core/agents/agent_trigger_watcher.dart` (decouple from bubble surface)
 - `apps/desktop_flutter/lib/features/agents/data/agent_sessions_data_source.dart` (structured messages fetch)
 - `apps/desktop_flutter/lib/features/agents/models/*` (ChatMessage/ChatPart fromJson for the REST shape)
 
@@ -39,7 +44,7 @@ falsely flagged "stuck".
 1. Selecting a session with an existing server transcript (controller test with fake data source returning a structured payload incl. text+tool+reasoning parts) populates `_chatMessagesBySession` with the same message/part structure — no plain-text fallback.
 2. After simulated WS reconnect, the transcript renders from rehydrated parts: widget test asserts a tool part renders the tool card (not raw text) post-reconnect.
 3. Repo-wide grep: `_liveOutputBuffer` has zero references; `_buildTranscriptBody` has a single render branch (no hasChat conditional on transcript store).
-4. Mini-bubble renders from `_chatMessagesBySession` (widget test: bubble shows the latest assistant text part for a non-selected session).
+4. Mini-bubble overlay fully removed: `agent_bubble_overlay.dart` deleted, repo-wide grep shows zero references to it (and to `AgentBubbleEntry`); a fired trigger still produces a visible session row in the Agents tab and the existing desktop notification (controller test).
 5. A streaming parts-based session is not flagged stuck while parts are arriving; a session with no part activity for the stuck threshold in `starting` status is flagged (unit tests on the extracted pure stuck predicate).
 6. WS error frames appear as system-role chat messages in the (single) transcript path.
 7. Flutter's provider→agent-kind map is fetched from capabilities; badge tests from issue #645 still pass.
@@ -48,11 +53,12 @@ falsely flagged "stuck".
 ## Required tests (flutter test)
 
 - New `test/features/agents/opc_m1_3_rehydration_test.dart` (criteria 1, 2, 5, 6).
-- New/updated bubble test for criterion 4.
-- Update existing agents suite tests that referenced the legacy path (expected churn; do not weaken assertions — port them to the parts path).
+- Trigger-flow test for criterion 4 (no bubble; session row + notification still fire).
+- Delete bubble-specific tests; update existing agents suite tests that referenced the legacy path (expected churn; do not weaken assertions — port them to the parts path).
 
 ## Out of scope
 
 - No new part-type renderers (M2) — unknown part types render via the existing generic card.
 - No resume/continuity change (M1-5).
-- Mini-bubble is kept, not redesigned (plan open question 3).
+- No replacement surface for the bubble (nav badge, dock bounce, etc.) — if the trigger flow
+  feels under-surfaced without it, file a follow-up issue rather than designing one here.

--- a/docs/ai/generated-issues/opencode-m1-3-flutter-rehydration-single-path.md
+++ b/docs/ai/generated-issues/opencode-m1-3-flutter-rehydration-single-path.md
@@ -1,0 +1,58 @@
+# OPC-M1-3 — Flutter rehydrates parts from REST; delete the legacy dual render path
+
+**Milestone:** M1 — Foundation
+**Branch:** `opc-m1-3-flutter-rehydration-single-path`
+**Depends on:** OPC-M1-2
+
+## Summary
+
+`_chatMessagesBySession` becomes a cache of the server's structured transcript: on session
+select, reconnect, and app restart, Flutter fetches `GET /agent-sessions/:id/messages` and
+rebuilds parts-based chat state. The legacy plain-text transcript render branch is **deleted**
+everywhere — main transcript body, mini-bubble overlay, and stuck-detection — leaving exactly
+one render path.
+
+## Motivation
+
+Root cause 1 (client half): reconnected sessions always fall back to the legacy plain-text path
+because `_chatMessagesBySession` was in-memory only; the mini-bubble always used the legacy
+path; `_recomputeStuck` reads the legacy `_liveOutputBuffer` so parts-based sessions are
+falsely flagged "stuck".
+
+## Scope
+
+- Rehydration: `selectSession()` / WS reconnect / `initialize()` for resumable sessions fetch structured messages and populate `_chatMessagesBySession` + `_chatPartsByMessage`. Optimistic local rows (user input) reconcile by sdk message id on next hydrate.
+- Delete: `_transcriptsBySession`-driven rendering in `agents_view.dart` `_buildTranscriptBody` (the hasChat=false branch), the mini-bubble's legacy transcript read, `_liveOutputBuffer`. System/error WS frames become synthetic system-role chat messages (preserving the #638 behavior) instead of legacy transcript rows.
+- Stuck-detection: `_recomputeStuck` keys off parts state (last part activity timestamp / session status) instead of `_liveOutputBuffer`.
+- Delete Flutter's `_kProviderToAgentKind` duplicate; consume the mapping from `GET /agents/capabilities` (M1-1 criterion 6), with the current map as offline fallback.
+
+## Likely files
+
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart`
+- `apps/desktop_flutter/lib/app/core/agents/agent_bubble_overlay.dart`
+- `apps/desktop_flutter/lib/features/agents/data/agent_sessions_data_source.dart` (structured messages fetch)
+- `apps/desktop_flutter/lib/features/agents/models/*` (ChatMessage/ChatPart fromJson for the REST shape)
+
+## Acceptance criteria
+
+1. Selecting a session with an existing server transcript (controller test with fake data source returning a structured payload incl. text+tool+reasoning parts) populates `_chatMessagesBySession` with the same message/part structure — no plain-text fallback.
+2. After simulated WS reconnect, the transcript renders from rehydrated parts: widget test asserts a tool part renders the tool card (not raw text) post-reconnect.
+3. Repo-wide grep: `_liveOutputBuffer` has zero references; `_buildTranscriptBody` has a single render branch (no hasChat conditional on transcript store).
+4. Mini-bubble renders from `_chatMessagesBySession` (widget test: bubble shows the latest assistant text part for a non-selected session).
+5. A streaming parts-based session is not flagged stuck while parts are arriving; a session with no part activity for the stuck threshold in `starting` status is flagged (unit tests on the extracted pure stuck predicate).
+6. WS error frames appear as system-role chat messages in the (single) transcript path.
+7. Flutter's provider→agent-kind map is fetched from capabilities; badge tests from issue #645 still pass.
+8. `flutter test` full suite green; `ai-workflow checks --level pr` exits 0.
+
+## Required tests (flutter test)
+
+- New `test/features/agents/opc_m1_3_rehydration_test.dart` (criteria 1, 2, 5, 6).
+- New/updated bubble test for criterion 4.
+- Update existing agents suite tests that referenced the legacy path (expected churn; do not weaken assertions — port them to the parts path).
+
+## Out of scope
+
+- No new part-type renderers (M2) — unknown part types render via the existing generic card.
+- No resume/continuity change (M1-5).
+- Mini-bubble is kept, not redesigned (plan open question 3).

--- a/docs/ai/generated-issues/opencode-m1-4-stream-sentinel-cleanup.md
+++ b/docs/ai/generated-issues/opencode-m1-4-stream-sentinel-cleanup.md
@@ -1,0 +1,54 @@
+# OPC-M1-4 — Stream lifecycle + sentinel cleanup; dead code removal
+
+**Milestone:** M1 — Foundation
+**Branch:** `opc-m1-4-stream-sentinel-cleanup`
+**Depends on:** OPC-M1-3
+
+## Summary
+
+Make session teardown real and remove time-based in-memory sentinels: implement
+`stopStream()` (currently a no-op at `opencode_stream_bridge.ts:580`), replace the
+`erroredSessions` 5s `setTimeout` sentinel with persisted session status, and remove the
+`__pending__` sentinel leakage paths. Delete `pty_runner.ts` (dead since PR #574).
+
+## Motivation
+
+Root cause 5: in-memory sentinels leak across turns — an errored session "un-errors" itself
+after 5 seconds regardless of reality; `__pending__` rows surfaced raw in UI (#651/#652
+band-aids). The no-op `stopStream` means closed sessions keep consuming bridge filtering work
+and can emit ghost events for deleted local ids.
+
+## Scope
+
+- `stopStream(localId)`: unregister the session from the shared stream's routing/filter map so events for that sdk session are no longer relayed or persisted after DELETE/close; shared SSE subscription itself stays alive (current architecture).
+- `erroredSessions`: persist error state on the session row (`status='error'`, `statusMessage`) via the existing repo; remove the setTimeout. Clearing happens on explicit user action (new prompt / resume), not on a timer.
+- `__pending__`: confine the sentinel to the composer layer; it must never be persisted or broadcast (assert at the WS/REST boundary).
+- Delete `apps/api_server/src/services/pty_runner.ts` + any test-only imports; update `docs/ai/architecture.md` "Known dead code".
+
+## Likely files
+
+- `apps/api_server/src/services/opencode_stream_bridge.ts` (:580)
+- `apps/api_server/src/controllers/agent_sessions_controller.ts`
+- `apps/api_server/src/repositories/agent_sessions_repository.ts` (status persistence if missing)
+- `apps/api_server/src/services/pty_runner.ts` (DELETE)
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart` (error-state consumption)
+
+## Acceptance criteria
+
+1. After `DELETE /agent-sessions/:id`, feeding the bridge a subsequent SSE event for that session's sdk id produces no WS broadcast and no DB write (vitest with spies).
+2. `stopStream` for one session does not affect event relay for a second live session sharing the stream.
+3. An error event sets the session row `status='error'` with message; restarting the server (re-reading the DB) still reports `error` — no time-based reset (assert after fake-timer advance of >5s).
+4. Sending a new prompt to an errored session clears the error status via an explicit transition.
+5. Repo-wide grep: zero references to `pty_runner`; no `setTimeout` in the errored-session path.
+6. `__pending__` never appears in any WS frame or REST response (boundary test).
+7. `ai-workflow checks --level pr` exits 0; full vitest + flutter test green.
+
+## Required tests
+
+- vitest: new `opc_m1_4_stream_lifecycle.test.ts` (criteria 1-4, 6) with fake timers.
+- flutter test: errored session renders persisted error state and clears on resend.
+
+## Out of scope
+
+- No resume implementation (M1-5).
+- No retry-status surfacing (M2-4).

--- a/docs/ai/generated-issues/opencode-m1-5-resume-continuity.md
+++ b/docs/ai/generated-issues/opencode-m1-5-resume-continuity.md
@@ -1,0 +1,54 @@
+# OPC-M1-5 — Resume with real conversation continuity
+
+**Milestone:** M1 — Foundation
+**Branch:** `opc-m1-5-resume-continuity`
+**Depends on:** OPC-M1-2, OPC-M1-3
+
+## Summary
+
+Persist the SDK session id on the local session row at create time and make
+`resume()` re-attach to it: re-populate `opencodeSessionMap`, re-register the stream filter,
+and let the next prompt continue the same SDK conversation. The Flutter side rehydrates the
+transcript (already built in M1-3), so a resumed session shows its full history and the model
+keeps its context.
+
+## Motivation
+
+Audit B: `resume()` creates a fresh SDK session — no conversation continuity; the
+`sessionToken` DB field is unused; `session.messages` is never called. Architecture doc lists
+resume as a known stub. Opencode sessions are durable server-side (the embedded server stores
+them under its data dir), so re-attach is the correct semantic.
+
+## Scope
+
+- Migration: `ALTER TABLE agent_sessions ADD COLUMN sdk_session_id TEXT` (PRAGMA-guarded); populate on create. (Repurpose/retire the unused `sessionToken` field — prefer the new explicitly-named column; mark old field deprecated.)
+- `resume()`: look up `sdk_session_id` → verify the SDK session still exists (typed `getSession`/list wrapper from M1-1) → `opencodeSessionMap.set(localId, sdkId)` → register stream filter → status `running`/`idle` per SDK status. If the SDK session is gone, return 410 with a clear message (client offers "start fresh").
+- Server boot: do NOT auto-resume all sessions; sessions remain `resumable` until user action (matches current UX).
+- Flutter: resume action calls REST resume, then rehydrates messages (M1-3 path); composer enabled on success; 410 → dialog offering new session seeded with same name/cwd.
+
+## Likely files
+
+- `apps/api_server/src/database/migrations.ts`
+- `apps/api_server/src/controllers/agent_sessions_controller.ts` (resume())
+- `apps/api_server/src/services/opencode_engine.ts`
+- `apps/api_server/src/services/opencode_stream_bridge.ts`
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`
+
+## Acceptance criteria
+
+1. POST create persists `sdk_session_id`; vitest asserts the row value equals the mocked SDK session id.
+2. `resume()` on a session with a live SDK session re-maps `opencodeSessionMap` and does NOT call `createSession` (spy assert: zero create calls).
+3. After resume, a WS `session.input` routes the prompt to the original sdk id.
+4. `resume()` when the SDK reports the session missing returns HTTP 410 with a message naming the session; no map entry is created.
+5. Flutter: resuming a session triggers exactly one messages rehydrate fetch and renders prior parts (controller test with fakes).
+6. Flutter: 410 surfaces the "start fresh" affordance (widget/controller test).
+7. `ai-workflow checks --level pr` exits 0.
+
+## Required tests
+
+- vitest: extend `agent_sessions.test.ts` + new `opc_m1_5_resume_contract.test.ts` (criteria 1-4).
+- flutter test: `opc_m1_5_resume_test.dart` (criteria 5-6).
+
+## Out of scope
+
+- Fork (M4-2). Compaction (M3-3). Auto-resume on app launch.

--- a/docs/ai/generated-issues/opencode-m2-1-markdown-rendering.md
+++ b/docs/ai/generated-issues/opencode-m2-1-markdown-rendering.md
@@ -1,0 +1,47 @@
+# OPC-M2-1 — Markdown rendering in chat bubbles
+
+**Milestone:** M2 — Rendering parity
+**Branch:** `opc-m2-1-markdown-rendering`
+**Depends on:** OPC-M1-3
+
+## Summary
+
+Assistant text parts render as markdown instead of raw `SelectableText` characters: headings,
+bold/italic, inline code, fenced code blocks (monospace, surface-muted background, copy
+button), ordered/unordered lists, and links (open via `url_launcher`). Text stays selectable.
+Streaming deltas continue to append without re-rendering sibling bubbles.
+
+## Motivation
+
+Audit B BROKEN list: "markdown not rendered (SelectableText raw chars)". Every OpenCode client
+renders assistant markdown; raw `**bold**` and ``` fences read as garbage to church staff.
+
+## Decision needed (plan open question 2)
+
+Package: `flutter_markdown_plus` (community continuation of deprecated `flutter_markdown`) vs
+`gpt_markdown` (streaming-friendly). Criteria below are package-agnostic.
+
+## Likely files
+
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (`_ChatBubble` text branch)
+- `apps/desktop_flutter/lib/features/agents/views/_markdown_message_body.dart` (new)
+- `apps/desktop_flutter/pubspec.yaml`
+- `apps/desktop_flutter/lib/app/core/agents/agent_bubble_overlay.dart` (same widget reused)
+
+## Acceptance criteria
+
+1. A text part containing `# h`, `**bold**`, `` `code` ``, a fenced block, a list, and a link renders: no literal `**`/backtick/`#` characters findable as raw text; code block uses a monospace TextStyle; link tap invokes the (injected/mocked) launcher with the URL.
+2. Fenced code block shows a copy affordance; tapping copies the block content to the clipboard (widget test via `Clipboard` mock).
+3. User-role messages render as plain text (no markdown interpretation of user input).
+4. Streaming: appending a delta to the last text part updates the rendered output without throwing and preserves earlier bubbles' widgets (no full-list rebuild assertion via keys).
+5. All colors/typography come from `RhythmColorRoles` tokens (review check; widget test asserts code-block background == `context.rhythm.surfaceMuted`).
+6. Mini-bubble uses the same markdown body widget.
+7. `flutter analyze`, `dart format`, full `flutter test` green; `ai-workflow checks --level pr` exits 0.
+
+## Required tests (flutter test)
+
+- New `test/features/agents/opc_m2_1_markdown_test.dart` covering criteria 1-4 (+5 token assert).
+
+## Out of scope
+
+- Reasoning parts (M2-2). Diff rendering (M2-3). LaTeX/math support.

--- a/docs/ai/generated-issues/opencode-m2-1-markdown-rendering.md
+++ b/docs/ai/generated-issues/opencode-m2-1-markdown-rendering.md
@@ -16,17 +16,18 @@ Streaming deltas continue to append without re-rendering sibling bubbles.
 Audit B BROKEN list: "markdown not rendered (SelectableText raw chars)". Every OpenCode client
 renders assistant markdown; raw `**bold**` and ``` fences read as garbage to church staff.
 
-## Decision needed (plan open question 2)
+## Decision (resolved 2026-06-12, plan open question 2)
 
-Package: `flutter_markdown_plus` (community continuation of deprecated `flutter_markdown`) vs
-`gpt_markdown` (streaming-friendly). Criteria below are package-agnostic.
+Package: **`gpt_markdown`** — chosen for streaming-delta-friendly rendering (assistant text
+arrives as `message.part.delta` appends). Criteria below remain package-agnostic; if
+`gpt_markdown` cannot satisfy a criterion (e.g. selectability), surface that before swapping
+packages rather than weakening the criterion.
 
 ## Likely files
 
 - `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (`_ChatBubble` text branch)
 - `apps/desktop_flutter/lib/features/agents/views/_markdown_message_body.dart` (new)
-- `apps/desktop_flutter/pubspec.yaml`
-- `apps/desktop_flutter/lib/app/core/agents/agent_bubble_overlay.dart` (same widget reused)
+- `apps/desktop_flutter/pubspec.yaml` (add `gpt_markdown`)
 
 ## Acceptance criteria
 
@@ -35,8 +36,8 @@ Package: `flutter_markdown_plus` (community continuation of deprecated `flutter_
 3. User-role messages render as plain text (no markdown interpretation of user input).
 4. Streaming: appending a delta to the last text part updates the rendered output without throwing and preserves earlier bubbles' widgets (no full-list rebuild assertion via keys).
 5. All colors/typography come from `RhythmColorRoles` tokens (review check; widget test asserts code-block background == `context.rhythm.surfaceMuted`).
-6. Mini-bubble uses the same markdown body widget.
-7. `flutter analyze`, `dart format`, full `flutter test` green; `ai-workflow checks --level pr` exits 0.
+6. `flutter analyze`, `dart format`, full `flutter test` green; `ai-workflow checks --level pr` exits 0.
+   _(Former criterion 6 — mini-bubble reuse — removed: the bubble overlay is deleted in OPC-M1-3.)_
 
 ## Required tests (flutter test)
 

--- a/docs/ai/generated-issues/opencode-m2-2-reasoning-block-and-delta-fix.md
+++ b/docs/ai/generated-issues/opencode-m2-2-reasoning-block-and-delta-fix.md
@@ -1,0 +1,42 @@
+# OPC-M2-2 — Reasoning collapsible block + non-text delta routing fix
+
+**Milestone:** M2 — Rendering parity
+**Branch:** `opc-m2-2-reasoning-block-and-delta-fix`
+**Depends on:** OPC-M1-3 (M2-1 recommended first for shared body widget)
+
+## Summary
+
+Two halves of one feature: (a) fix `_appendChatDelta` (agents_controller.dart:1322) so
+`message.part.delta` frames are routed by part type/field — reasoning deltas append to the
+reasoning part, not dropped; (b) render reasoning parts as a collapsed "Thinking…" block
+(expandable, secondary text color, duration label when step-finish provides it) instead of
+plain prose inline with the answer.
+
+## Motivation
+
+Audit B: `_appendChatDelta` drops non-text field deltas; reasoning parts render as plain prose
+(`_ChatBubble` has no reasoning branch — agents_view.dart:1881). Extended-thinking models
+currently interleave chain-of-thought with the real answer, which is confusing and verbose.
+
+## Likely files
+
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart` (≈:1322)
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (≈:1881)
+- `apps/desktop_flutter/lib/features/agents/views/_reasoning_block.dart` (new)
+
+## Acceptance criteria
+
+1. A `message.part.delta` for a reasoning-type part appends to that part's text (controller unit test with a real-shape delta frame); a text delta still appends to the text part; an unknown-field delta is retained (logged), not silently dropped.
+2. Reasoning part renders as a collapsed block labeled "Thinking…" (or "Thought for Ns" once finished); the reasoning text is NOT visible until expanded (widget test: find.text on reasoning content fails collapsed, succeeds after tap).
+3. Expand/collapse state is per-block and survives a delta append (no auto-collapse on rebuild).
+4. The final answer text part renders outside the reasoning block (both findable when expanded).
+5. Rehydrated reasoning parts (REST, M1-3) render identically to streamed ones (same widget test fixture through the rehydrate path).
+6. `flutter test` green; `ai-workflow checks --level pr` exits 0.
+
+## Required tests (flutter test)
+
+- New `opc_m2_2_reasoning_test.dart`: controller delta-routing units (c1) + widget tests (c2-c5) using recorded v1.14.49 part shapes.
+
+## Out of scope
+
+- Token/cost display (M2-4). Reasoning-budget composer controls (already shipped).

--- a/docs/ai/generated-issues/opencode-m2-3-tool-specific-renderers.md
+++ b/docs/ai/generated-issues/opencode-m2-3-tool-specific-renderers.md
@@ -1,0 +1,42 @@
+# OPC-M2-3 — Tool-specific renderers (diff, terminal, checklist, child-session chip)
+
+**Milestone:** M2 — Rendering parity
+**Branch:** `opc-m2-3-tool-specific-renderers`
+**Depends on:** OPC-M2-1
+
+## Summary
+
+Replace the one-size generic tool card with per-tool renderers matching OpenCode conventions,
+dispatched by tool name with the generic args+output card as fallback:
+
+- `edit` / `write` / `apply_patch` → unified diff widget (new `_UnifiedDiffView`: per-line +/- coloring via tokens — success-tinted additions, danger-tinted deletions, monospace, file path header, collapsed beyond 20 lines with "Show all")
+- `bash` → terminal-style output: monospace, preserved whitespace, ANSI escape sequences stripped, command shown as header, exit-code badge on error state
+- `todowrite` → checklist (checked/unchecked per item status)
+- `task` → child-session chip showing the subagent description + status (navigation wired in M3-6; chip is inert here)
+- `read`/`glob`/`grep`/`webfetch`/`websearch`/`skill`/`plan`/`lsp` → keep generic card (explicitly listed as fallback)
+
+ToolState (pending/running/completed/error) drives a leading status indicator on every renderer.
+
+## Likely files
+
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (dispatch)
+- `apps/desktop_flutter/lib/features/agents/views/_tool_renderers/` (new: `_unified_diff_view.dart`, `_terminal_output_view.dart`, `_todo_checklist_view.dart`, `_task_chip.dart`)
+
+## Acceptance criteria
+
+1. An `edit` tool part (real-shape fixture with old/new content or patch) renders the diff view: added lines styled with the success role, removed with danger, monospace family; file path visible.
+2. A diff longer than 20 lines renders collapsed with a "Show all (N lines)" affordance that expands on tap.
+3. A `bash` tool part renders the command header + output with preserved whitespace (multi-space run intact in the rendered string) and ANSI codes stripped (fixture contains `\x1b[31m`; rendered text does not); error state shows the exit code.
+4. A `todowrite` part renders one checklist row per todo with correct checked state.
+5. A `task` part renders a chip with the subagent description and live ToolState indicator.
+6. An unrecognized tool name renders the existing generic card (regression test).
+7. ToolState pending/running/completed/error each render a distinct indicator (golden-free: assert by icon/semantics).
+8. All colors via `RhythmColorRoles`; `flutter test` green; `ai-workflow checks --level pr` exits 0.
+
+## Required tests (flutter test)
+
+- New `opc_m2_3_tool_renderers_test.dart` covering criteria 1-7 with recorded v1.14.49 tool-part fixtures (one per tool).
+
+## Out of scope
+
+- Child-session navigation (M3-6). Changes-tab session diff (M3-1 — reuses `_UnifiedDiffView`). Todo side panel (M3-5 — reuses checklist widget). Real terminal/PTY (out of scope permanently).

--- a/docs/ai/generated-issues/opencode-m2-4-retry-status-tokens-cost.md
+++ b/docs/ai/generated-issues/opencode-m2-4-retry-status-tokens-cost.md
@@ -1,0 +1,46 @@
+# OPC-M2-4 — Retry status surfacing + token/cost display
+
+**Milestone:** M2 — Rendering parity
+**Branch:** `opc-m2-4-retry-status-tokens-cost`
+**Depends on:** OPC-M1-2, OPC-M1-3
+
+## Summary
+
+(a) The bridge stops collapsing every non-busy SDK status to `idle`: retry states/parts are
+relayed as a distinct WS status and rendered inline ("Retrying (attempt N)…" with reason).
+(b) Assistant messages display token+cost metadata (already persisted by M1-2): per-message
+cost (USD, 2-4 decimals) with token breakdown (input/output/reasoning/cache) in a tooltip, and
+a session running total in the transcript header.
+
+## Motivation
+
+Audit B: "retry status dropped (bridge treats non-busy as idle)" — users see a frozen session
+during provider retries; "token/cost display: ABSENT" — OpenCode's sidebar shows cost/tokens,
+and per-user-API-key billing makes cost visibility genuinely useful to staff.
+
+## Likely files
+
+- `apps/api_server/src/services/opencode_stream_bridge.ts` (status mapping)
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (bubble footer + header total)
+- `apps/desktop_flutter/lib/features/agents/models/agent_session_message.dart` (tokens/cost fields)
+
+## Acceptance criteria
+
+1. Bridge maps a real-shape retry status/part event to a WS frame with status `retrying` (vitest: not `idle`); idle and busy mappings unchanged (regression asserts).
+2. A retry part renders inline with attempt count and reason text (widget test).
+3. When the retry resolves (next message/part event), the retrying indicator clears.
+4. An assistant message with `cost: 0.0142` and tokens `{input: 1200, output: 350, reasoning: 0, cache: 800}` renders a footer "$0.0142"; tooltip/expanded detail contains all four token counts (widget test).
+5. Messages without cost (user, legacy rows) render no cost footer.
+6. Transcript header shows the session total = sum of persisted message costs, updating when a new message lands (controller test).
+7. Rehydrated messages (REST) show identical cost/token UI to streamed ones.
+8. `ai-workflow checks --level pr` exits 0; vitest + flutter test green.
+
+## Required tests
+
+- vitest: bridge status-mapping tests with recorded retry fixtures (c1).
+- flutter test: `opc_m2_4_retry_cost_test.dart` (c2-c7).
+
+## Out of scope
+
+- Cost budgeting/limits. Currency localization (USD only — plan open question 4).

--- a/docs/ai/generated-issues/opencode-m3-1-changes-tab-real-diff.md
+++ b/docs/ai/generated-issues/opencode-m3-1-changes-tab-real-diff.md
@@ -1,0 +1,45 @@
+# OPC-M3-1 — Changes tab via real GET /session/{id}/diff
+
+**Milestone:** M3 — Session features
+**Branch:** `opc-m3-1-changes-tab-real-diff`
+**Depends on:** OPC-M1-1, OPC-M2-3
+
+## Summary
+
+Fix the always-empty Changes tab: route it through the typed `getSessionDiff` wrapper (M1-1)
+instead of the nonexistent duck-typed `diffSession` (agent_sessions_controller.ts:362-383).
+Render per-file diffs with `_UnifiedDiffView` (M2-3), refreshing on `session.diff` /
+`session.idle` events.
+
+## Motivation
+
+Audit B BROKEN: `getDiff` always returns `[]` — the prior agent duck-typed a method name that
+doesn't exist on the SDK, and the silent fallback returned an empty array, so the Changes tab
+shipped permanently empty.
+
+## Likely files
+
+- `apps/api_server/src/controllers/agent_sessions_controller.ts` (:362-383)
+- `apps/api_server/src/services/opencode_client_service.ts` (wrapper from M1-1)
+- `apps/api_server/src/services/opencode_stream_bridge.ts` (relay `session.diff` event)
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (Changes tab)
+- `apps/desktop_flutter/lib/features/agents/data/agent_sessions_data_source.dart`
+
+## Acceptance criteria
+
+1. `GET /agent-sessions/:id/diff` calls the typed wrapper with the mapped sdk id and returns its payload (vitest spy assert with a real-shape diff fixture: file path, additions, deletions, patch text); SDK-error → AppError 502 with message, never a silent `[]`.
+2. Changes tab renders one expandable file row per diff entry (path + `+N −M` counts) using `_UnifiedDiffView` (widget test on the fixture).
+3. Empty diff renders an explicit "No file changes yet" empty state (distinct from error state).
+4. A `session.diff` WS event triggers a refetch for the affected session only (controller test).
+5. Tab badge shows the changed-file count when nonzero.
+6. `ai-workflow checks --level pr` exits 0; vitest + flutter test green.
+
+## Required tests
+
+- vitest: controller diff route contract (c1) — must fail on the current duck-typed code (red-proven).
+- flutter test: `opc_m3_1_changes_tab_test.dart` (c2-c5).
+
+## Out of scope
+
+- Revert from the diff view (M3-2). VCS branch chip (already shipped). `/file/status` polling.

--- a/docs/ai/generated-issues/opencode-m3-2-revert-unrevert.md
+++ b/docs/ai/generated-issues/opencode-m3-2-revert-unrevert.md
@@ -1,0 +1,39 @@
+# OPC-M3-2 — Undo: revert / unrevert UI
+
+**Milestone:** M3 — Session features
+**Branch:** `opc-m3-2-revert-unrevert`
+**Depends on:** OPC-M3-1
+
+## Summary
+
+Expose OpenCode's undo: a "Revert to here" action on assistant messages calls
+`POST /session/{id}/revert` (typed wrapper) with the message id; a session-level "Restore
+reverted changes" banner calls `/unrevert`. Reverted messages render dimmed with a "reverted"
+badge; the Changes tab refreshes after either action. Revert requires a confirmation dialog
+(it rewrites files in the user's cwd).
+
+## Likely files
+
+- `apps/api_server/src/services/opencode_client_service.ts` (revert/unrevert wrappers, M1-1 stubs)
+- `apps/api_server/src/controllers/agent_sessions_controller.ts` (new POST routes)
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (+ `_message_actions_row.dart`)
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`
+- `apps/desktop_flutter/lib/features/agents/data/agent_sessions_data_source.dart`
+
+## Acceptance criteria
+
+1. `POST /agent-sessions/:id/revert` body `{messageId}` invokes the SDK revert wrapper with (sdkId, messageId) — vitest spy assert; `POST /agent-sessions/:id/unrevert` likewise; SDK errors → AppError with message.
+2. Message action row on assistant messages includes "Revert to here"; tapping shows a confirmation dialog naming the consequence ("Undo file changes after this point"); confirm dispatches the call; cancel does not (widget tests, mocked data source).
+3. After a successful revert, messages after the revert point render with the reverted treatment (dimmed + badge) based on the session's revert state from the SDK/refetched messages, and a "Restore reverted changes" banner is visible.
+4. Tapping the banner dispatches unrevert and clears the reverted treatment on success.
+5. Both actions trigger a Changes-tab diff refetch (controller test).
+6. `ai-workflow checks --level pr` exits 0; vitest + flutter test green.
+
+## Required tests
+
+- vitest: revert/unrevert route contracts (c1).
+- flutter test: `opc_m3_2_revert_test.dart` (c2-c5).
+
+## Out of scope
+
+- Fork/timeline browsing (M4-2). Snapshot part rendering beyond the existing generic card.

--- a/docs/ai/generated-issues/opencode-m3-3-compaction-summarize.md
+++ b/docs/ai/generated-issues/opencode-m3-3-compaction-summarize.md
@@ -1,0 +1,43 @@
+# OPC-M3-3 — Compaction (summarize) with UI affordance
+
+**Milestone:** M3 — Session features
+**Branch:** `opc-m3-3-compaction-summarize`
+**Depends on:** OPC-M1-1, OPC-M1-3
+
+## Summary
+
+Add a "Compact session" action (session header overflow menu) that calls
+`POST /session/{id}/summarize` via the typed wrapper, plus first-class rendering of
+`compaction` parts (a horizontal "Conversation compacted" divider with the summary expandable
+beneath). Show a context-usage hint near the composer when the session's input tokens approach
+the model's limit, suggesting compaction.
+
+## Motivation
+
+Audit A ranks compaction in the TUI top-15; long-running church-task sessions will hit context
+limits, and today the only recovery is abandoning the session.
+
+## Likely files
+
+- `apps/api_server/src/services/opencode_client_service.ts` (summarize wrapper)
+- `apps/api_server/src/controllers/agent_sessions_controller.ts` (POST route)
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (menu + compaction divider)
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`
+
+## Acceptance criteria
+
+1. `POST /agent-sessions/:id/summarize` invokes the SDK summarize wrapper with the mapped sdk id (vitest spy); errors surface as AppError, not silence.
+2. Session header menu contains "Compact session"; tapping dispatches the call and shows a working indicator until the resulting compaction part/message arrives (widget test, mocked source).
+3. A `compaction` part (real-shape fixture) renders as a divider row labeled "Conversation compacted", with the summary text hidden until expanded.
+4. Compaction parts arriving via stream and via rehydration render identically.
+5. When the last assistant message's input-token count exceeds a configurable threshold fraction of the model's context (default 0.8, constant), a hint chip appears near the composer; below threshold it does not (widget test both sides).
+6. `ai-workflow checks --level pr` exits 0; vitest + flutter test green.
+
+## Required tests
+
+- vitest: summarize route contract (c1).
+- flutter test: `opc_m3_3_compaction_test.dart` (c2-c5).
+
+## Out of scope
+
+- Automatic compaction. Per-model context-limit catalog beyond what the provider list already exposes (if absent, criterion 5's threshold uses a fixed 150k-token default and says so in code comment).

--- a/docs/ai/generated-issues/opencode-m3-4-structured-command-dispatch.md
+++ b/docs/ai/generated-issues/opencode-m3-4-structured-command-dispatch.md
@@ -1,0 +1,44 @@
+# OPC-M3-4 — Slash commands dispatched via POST /session/{id}/command
+
+**Milestone:** M3 — Session features
+**Branch:** `opc-m3-4-structured-command-dispatch`
+**Depends on:** OPC-M1-1
+
+## Summary
+
+When the user selects a slash command from the popover, dispatch it through the structured
+endpoint (`dispatchCommand` wrapper from M1-1) with `{command, arguments}` instead of
+submitting `/name args` as plain prompt text. Free-typed text that happens to start with `/`
+but doesn't match a listed command still goes as plain text.
+
+## Motivation
+
+Audit B PARTIAL: "slash commands not dispatched via POST /session/:id/command" — text-prefix
+injection relies on the model/server parsing the prefix and bypasses opencode's command
+templating (agent/model overrides per command), so commands behave differently than in
+OpenCode proper.
+
+## Likely files
+
+- `apps/api_server/src/services/ws_gateway.ts` (new `session.command` WS message) or a REST route in `agent_sessions_controller.ts`
+- `apps/api_server/src/services/opencode_client_service.ts`
+- `apps/desktop_flutter/lib/features/agents/views/_slash_command_popover.dart`
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`
+
+## Acceptance criteria
+
+1. A `session.command` WS frame (or POST route — implementer picks one and documents it) `{id, command, arguments}` invokes the SDK command wrapper with (sdkId, command, arguments) — vitest spy assert; unknown local id → error frame.
+2. Selecting a command in the popover and submitting sends the structured frame, NOT a `session.input` with text prefix (controller test asserts message type and absence of `/cmd` text send).
+3. The user's command invocation renders in the transcript as a distinct command row (`/name args`), and the streamed response parts render normally.
+4. Typing `/notacommand foo` (not in `command.list`) and submitting sends plain `session.input` text (regression).
+5. Command failure (SDK error) surfaces as a system error message in the transcript.
+6. `ai-workflow checks --level pr` exits 0; vitest + flutter test green.
+
+## Required tests
+
+- vitest: gateway/route command contract (c1).
+- flutter test: `opc_m3_4_command_dispatch_test.dart` (c2-c4).
+
+## Out of scope
+
+- Command palette (global Cmd+K). Custom user-defined command authoring UI.

--- a/docs/ai/generated-issues/opencode-m3-5-todo-panel.md
+++ b/docs/ai/generated-issues/opencode-m3-5-todo-panel.md
@@ -1,0 +1,44 @@
+# OPC-M3-5 — Session todo panel
+
+**Milestone:** M3 — Session features
+**Branch:** `opc-m3-5-todo-panel`
+**Depends on:** OPC-M1-2, OPC-M2-3
+
+## Summary
+
+Live, collapsible todo panel for the selected session: hydrate from
+`GET /session/{id}/todo` (typed wrapper, proxied at `GET /agent-sessions/:id/todo`), update on
+`todo.updated` SSE→WS events, render with the M2-3 checklist widget plus a progress count
+("3/7") on the panel header. Panel hidden when the session has no todos.
+
+## Motivation
+
+Audit B ABSENT: "todo panel". OpenCode's sidebar todo list is how users track multi-step agent
+work; todowrite parts scroll away in the transcript, losing the at-a-glance state.
+
+## Likely files
+
+- `apps/api_server/src/services/opencode_stream_bridge.ts` (relay `todo.updated`)
+- `apps/api_server/src/controllers/agent_sessions_controller.ts` (GET todo route)
+- `apps/api_server/src/services/opencode_client_service.ts`
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart` (`_todosBySession`)
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (panel)
+
+## Acceptance criteria
+
+1. `GET /agent-sessions/:id/todo` invokes the SDK todo wrapper and returns the list (vitest spy + real-shape fixture).
+2. The bridge relays a `todo.updated` SSE event as a WS frame carrying session id + todo list (vitest).
+3. Selecting a session fetches todos once and renders the panel when nonempty; empty list → no panel (widget tests).
+4. A `todo.updated` WS frame replaces the session's todo state and the panel re-renders (controller test: state keyed per session — an update for session B does not touch session A).
+5. Panel header shows completed/total count; rows reuse the M2-3 checklist styling with status-driven check state.
+6. Panel collapse state persists while switching between sessions in the same app run.
+7. `ai-workflow checks --level pr` exits 0; vitest + flutter test green.
+
+## Required tests
+
+- vitest: todo route + bridge relay (c1-c2).
+- flutter test: `opc_m3_5_todo_panel_test.dart` (c3-c6).
+
+## Out of scope
+
+- User-editable todos (read-only mirror of agent state). Cross-session todo aggregation.

--- a/docs/ai/generated-issues/opencode-m3-6-subagent-child-sessions.md
+++ b/docs/ai/generated-issues/opencode-m3-6-subagent-child-sessions.md
@@ -1,0 +1,45 @@
+# OPC-M3-6 — Subagent child-session navigation
+
+**Milestone:** M3 — Session features
+**Branch:** `opc-m3-6-subagent-child-sessions`
+**Depends on:** OPC-M2-3
+
+## Summary
+
+Make the `task` tool chip (M2-3) navigable: tapping opens the child session's transcript
+read-only in the main transcript area, with a breadcrumb back to the parent. Children are
+discovered via `GET /session/{id}/children` (typed wrapper) and their messages fetched via the
+SDK message-list; child sessions do NOT appear in the main session list (they're owned by the
+parent) and accept no user input.
+
+## Motivation
+
+Audit B ABSENT: "subagent child-session navigation". OpenCode's task tool spawns child
+sessions; today their work is invisible beyond the generic tool card, making subagent runs a
+black box.
+
+## Likely files
+
+- `apps/api_server/src/controllers/agent_sessions_controller.ts` (children + child-messages routes)
+- `apps/api_server/src/services/opencode_client_service.ts` (listChildren wrapper from M1-1)
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (+ `_tool_renderers/_task_chip.dart`)
+
+## Acceptance criteria
+
+1. `GET /agent-sessions/:id/children` invokes the SDK children wrapper with the mapped sdk id and returns child session summaries (vitest spy + fixture); `GET /agent-sessions/:id/children/:childSdkId/messages` returns the child's structured messages (parts shape identical to M1-2's REST shape).
+2. Tapping a `task` chip pushes a child transcript view showing the child's parts via the standard renderers (widget test with fixture).
+3. The child view shows a breadcrumb "‹ parent-session-name"; tapping returns to the parent transcript at its prior scroll context (no rehydrate refetch of the parent).
+4. The child view has no composer (read-only assert: composer widget absent).
+5. Child sessions never appear in the sidebar session lists (controller test: children excluded from active/resumable lists).
+6. While the child is streaming (subtask parts updating), the chip's status indicator updates in the parent transcript (existing ToolState path — regression assert).
+7. `ai-workflow checks --level pr` exits 0; vitest + flutter test green.
+
+## Required tests
+
+- vitest: children routes (c1).
+- flutter test: `opc_m3_6_child_sessions_test.dart` (c2-c6).
+
+## Out of scope
+
+- Live WS subscription to child sessions (fetch-on-open + refetch on parent task-part updates is sufficient); promoting a child to a full session.

--- a/docs/ai/generated-issues/opencode-m4-1-real-file-attachments.md
+++ b/docs/ai/generated-issues/opencode-m4-1-real-file-attachments.md
@@ -1,0 +1,42 @@
+# OPC-M4-1 — Real image/file attachments (FilePart with data URI)
+
+**Milestone:** M4 — Input & config
+**Branch:** `opc-m4-1-real-file-attachments`
+**Depends on:** OPC-M1-3
+
+## Summary
+
+The paperclip attaches real content: selected files are read as bytes and sent as an OpenCode
+`FilePart` (`{type:'file', mime, filename, url: 'data:<mime>;base64,...'}`) alongside the text
+part in the prompt's parts array. Attached images render as thumbnails in the user's transcript
+bubble; non-image files as a filename chip. Pasting an image into the composer attaches it.
+
+## Motivation
+
+Audit B PARTIAL: "image attachments send `[image] /path` text not bytes" — the model never sees
+the image, it sees a useless path string. Vision-capable models are already in the picker.
+
+## Likely files
+
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart` (build parts array)
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (composer chips + bubble thumbnails)
+- `apps/api_server/src/services/ws_gateway.ts` (accept parts incl. FilePart in `session.input`)
+- `apps/api_server/src/services/opencode_client_service.ts` (prompt forwards parts verbatim)
+
+## Acceptance criteria
+
+1. WS `session.input` with a parts array containing a FilePart forwards that part to the SDK prompt unmodified (vitest spy: parts array deep-equals, data URI intact); oversized payloads respect/raise the WS+express body limits with a clear error frame, not a silent drop (test at limit boundary).
+2. Attaching an image file produces a FilePart whose url is `data:image/<ext>;base64,<payload>` matching the file bytes (controller unit test on a small fixture PNG) — and the prompt no longer contains any `[image]` text token (grep-level regression: the legacy formatter is deleted).
+3. Composer shows a removable chip per pending attachment; removing it excludes the part from the send.
+4. Sent images render as a bounded thumbnail in the user bubble; non-image files render a filename chip (widget tests).
+5. Rehydrated file parts (M1-2 persistence) render the same as streamed ones.
+6. `ai-workflow checks --level pr` exits 0; vitest + flutter test green.
+
+## Required tests
+
+- vitest: gateway parts-forwarding contract (c1).
+- flutter test: `opc_m4_1_attachments_test.dart` (c2-c5).
+
+## Out of scope
+
+- Drag-and-drop (follow-up if the osascript picker UX proves clunky). Attachment size compression. Non-data-URI file references via opencode's file API.

--- a/docs/ai/generated-issues/opencode-m4-2-session-fork.md
+++ b/docs/ai/generated-issues/opencode-m4-2-session-fork.md
@@ -1,0 +1,44 @@
+# OPC-M4-2 — Session fork
+
+**Milestone:** M4 — Input & config
+**Branch:** `opc-m4-2-session-fork`
+**Depends on:** OPC-M1-5
+
+## Summary
+
+"Fork from here" on an assistant message calls `POST /session/{id}/fork` (typed wrapper) with
+the message id, then creates a local session row mapped to the new SDK session id (name
+"`<parent> (fork)`", same cwd), registers its stream, and persists/copies the transcript up to
+the fork point so the new session hydrates correctly. The forked session appears in the active
+list and is immediately promptable.
+
+## Motivation
+
+Audit B ABSENT: "fork". Lets users branch an exploration ("try a different approach from step
+3") without destroying the original — the safe sibling of revert (M3-2).
+
+## Likely files
+
+- `apps/api_server/src/services/opencode_client_service.ts` (fork wrapper)
+- `apps/api_server/src/controllers/agent_sessions_controller.ts` (fork route: SDK fork + local row + map + stream + message copy)
+- `apps/api_server/src/repositories/agent_sessions_repository.ts` / messages repo
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (action row + optimistic list insert)
+
+## Acceptance criteria
+
+1. `POST /agent-sessions/:id/fork` body `{messageId}` invokes the SDK fork wrapper with (sdkId, messageId), inserts a local row with the new `sdk_session_id`, populates `opencodeSessionMap`, and returns 201 with the new session (vitest, spy + DB asserts).
+2. The new session's persisted messages equal the parent's messages up to and including the fork message (DB assert on copied rows; parts_json intact).
+3. SDK fork failure → AppError; no local row is left behind (rollback assert).
+4. "Fork from here" in the message action row dispatches the call; the new session appears in the active list (optimistic, reconciled by REST response) and selecting it shows the copied transcript (controller/widget tests with fakes).
+5. Prompting the fork routes input to the fork's sdk id, not the parent's (vitest via map).
+6. `ai-workflow checks --level pr` exits 0; vitest + flutter test green.
+
+## Required tests
+
+- vitest: fork route contract (c1-c3, c5).
+- flutter test: `opc_m4_2_fork_test.dart` (c4).
+
+## Out of scope
+
+- Visual timeline/branch graph. Forking forked sessions is allowed but gets no special UI.

--- a/docs/ai/generated-issues/opencode-m4-3-mcp-config-ui.md
+++ b/docs/ai/generated-issues/opencode-m4-3-mcp-config-ui.md
@@ -1,0 +1,46 @@
+# OPC-M4-3 — MCP server management UI
+
+**Milestone:** M4 — Input & config
+**Branch:** `opc-m4-3-mcp-config-ui`
+**Depends on:** OPC-M1-1
+
+## Summary
+
+Settings → new "MCP Servers" section (sibling of `ai_account_section.dart`): list configured
+MCP servers with connection status, add a server (name + command/url form for local/remote
+types), connect/disconnect, and remove — all proxied through typed wrappers over the SDK's
+`/mcp` API via new `routes/opencode_mcp_routes.ts`. Follows the feature-layer pattern
+(data source → repository → ChangeNotifier controller → view) and theme tokens.
+
+## Motivation
+
+Audit B ABSENT: "MCP config UI". MCP is how Rhythm's own tooling (e.g. the Rhythm MCP server)
+gets attached to agent sessions; today it requires hand-editing opencode config files, which
+church staff cannot do.
+
+## Likely files
+
+- `apps/api_server/src/routes/opencode_mcp_routes.ts` (new)
+- `apps/api_server/src/services/opencode_client_service.ts` (listMcp/addMcp/connectMcp/disconnectMcp/removeMcp wrappers)
+- `apps/desktop_flutter/lib/features/settings/widgets/mcp_section.dart` (new)
+- `apps/desktop_flutter/lib/features/settings/controllers/mcp_controller.dart` (new)
+- `apps/desktop_flutter/lib/features/settings/data/mcp_data_source.dart` (new, baseUrl = `AppConstants.agentLocalBaseUrl`)
+- `apps/desktop_flutter/lib/main.dart` (provider wiring)
+
+## Acceptance criteria
+
+1. `GET /opencode/mcp` returns the SDK's MCP server list (vitest spy + real-shape fixture: name, type, connection status); `POST /opencode/mcp` (add), `POST /opencode/mcp/:name/connect`, `POST /opencode/mcp/:name/disconnect`, `DELETE /opencode/mcp/:name` each invoke the corresponding typed wrapper; SDK errors → AppError with message.
+2. The section lists each server with name + status badge (connected/disconnected/error using success/textMuted/danger roles); empty state shows guidance text (widget test).
+3. Add-server dialog validates required fields (name + command-or-url) and dispatches the add call; the list refreshes on success (controller test with fake data source).
+4. Connect/disconnect buttons dispatch their calls and update the row's status from the refetched list; failures surface inline error text, not silence.
+5. MCP data source hard-codes `AppConstants.agentLocalBaseUrl` (never `serverConfigService.url`) — unit assert mirroring issue #644's contract pattern.
+6. `ai-workflow checks --level pr` exits 0; vitest + flutter test green.
+
+## Required tests
+
+- vitest: `opc_m4_3_mcp_routes.test.ts` (c1).
+- flutter test: `opc_m4_3_mcp_section_test.dart` (c2-c5).
+
+## Out of scope
+
+- MCP OAuth flows (SDK supports them; defer to a follow-up — note in the section UI when a server reports auth-required). Per-session MCP enable/disable.

--- a/docs/ai/generated-issues/opencode-m4-4-custom-agent-selection.md
+++ b/docs/ai/generated-issues/opencode-m4-4-custom-agent-selection.md
@@ -43,4 +43,7 @@ identically to OpenCode proper.
 
 ## Out of scope
 
-- Authoring/editing custom agents inside Rhythm. Reconciling Rhythm's legacy `agentId` (claude-code/codex/gemini-cli) naming — that stays the session-creation concept; this selector is opencode's intra-session agent.
+- Authoring/editing custom agents inside Rhythm — confirmed by user 2026-06-12; the persona
+  builder UI is filed separately as the unscheduled future issue #705
+  (`opencode-future-agent-builder-ui.md`). This issue must not grow authoring scope.
+- Reconciling Rhythm's legacy `agentId` (claude-code/codex/gemini-cli) naming — that stays the session-creation concept; this selector is opencode's intra-session agent.

--- a/docs/ai/generated-issues/opencode-m4-4-custom-agent-selection.md
+++ b/docs/ai/generated-issues/opencode-m4-4-custom-agent-selection.md
@@ -1,0 +1,46 @@
+# OPC-M4-4 — Custom agent/mode selection
+
+**Milestone:** M4 — Input & config
+**Branch:** `opc-m4-4-custom-agent-selection`
+**Depends on:** OPC-M1-1
+
+## Summary
+
+Surface OpenCode's agent concept (build/plan built-ins + any custom agents the SDK config
+reports for the session cwd): a per-session agent selector next to the model picker, sent with
+prompts, with the active agent reflected in `agent`-type parts. Scoped to **render what the SDK
+reports** — no config-authoring UI (custom agents come from opencode config files in the cwd;
+Rhythm does not manage those).
+
+## Motivation
+
+Audit A top-15: "agent switching". The existing permission-mode toggle (plan mode) partially
+overlaps; this aligns the affordance with opencode's real agent model so plan/build behave
+identically to OpenCode proper.
+
+## Likely files
+
+- `apps/api_server/src/services/opencode_client_service.ts` (listAgents/config wrapper)
+- `apps/api_server/src/routes/agents_capabilities_routes.ts` or new route (expose agent list)
+- `apps/api_server/src/services/ws_gateway.ts` (forward `agent` field on prompt)
+- `apps/desktop_flutter/lib/features/agents/views/agents_view.dart` (selector)
+- `apps/desktop_flutter/lib/features/agents/controllers/agents_controller.dart`
+
+## Acceptance criteria
+
+1. `GET /agent-sessions/agents` (or capabilities extension — implementer documents choice) returns the SDK-reported agent list for a cwd (vitest spy + fixture incl. a custom agent entry).
+2. WS `session.input` carrying `agent: <name>` forwards it on the SDK prompt call (vitest spy assert).
+3. The composer shows an agent selector populated from the endpoint; default matches the SDK default; selection persists per session for the app run (controller test).
+4. An `agent`-type part in the transcript renders a labeled marker ("Switched to plan") rather than the generic card (widget test with fixture).
+5. When the SDK reports only built-ins, the selector still works with build/plan (no crash on absent custom agents).
+6. Existing permission-mode behavior (plan mode auto-deny semantics) is regression-tested — selecting the plan agent must not double-apply permission gating.
+7. `ai-workflow checks --level pr` exits 0; vitest + flutter test green.
+
+## Required tests
+
+- vitest: agent list + prompt-forwarding contracts (c1-c2).
+- flutter test: `opc_m4_4_agent_selection_test.dart` (c3-c6).
+
+## Out of scope
+
+- Authoring/editing custom agents inside Rhythm. Reconciling Rhythm's legacy `agentId` (claude-code/codex/gemini-cli) naming — that stays the session-creation concept; this selector is opencode's intra-session agent.

--- a/docs/ai/project-state.md
+++ b/docs/ai/project-state.md
@@ -6,6 +6,14 @@ _(Parked bugs from before 2026-05-27 run. #638 and #635 below are now RESOLVED �
 
 ## Recent coding-agent runs
 
+### 2026-06-12 — workflow/run-2026-06-12-opencode-parity-plan (planning only; PR #704, issues #685–#703)
+- Task: audit-driven plan for full OpenCode v1.14.49 feature/UI parity in the Agents tab. No implementation. Two parallel audits (OpenCode clone pinned at the embedded SDK version v1.14.49; Rhythm's existing integration) → gap analysis → `docs/ai/current-plan.md` (replaces the completed #617 sprint plan) → 19 issue specs in `docs/ai/generated-issues/opencode-m*.md` → GitHub issues #685–#703 (label `opencode-parity`) → PR #704.
+- Key findings recorded in the plan: the embedded SDK already exposes every endpoint the gaps need (`/session/{id}/diff`, `/revert`, `/unrevert`, `/summarize`, `/todo`, `/fork`, `/command`, `/message`, `/children`, `/mcp`) — the "Changes tab always empty" bug is a duck-typed call to a nonexistent `diffSession` method. Root causes of prior rot, each mapped to an M1 issue: dual transcript stores (in-memory parts vs SQLite plain text), duck-typed SDK access, provider-id/agent-id conflation, in-memory sentinels.
+- Sequencing: M1 foundation (#685–#689) must fully merge before M2 rendering (#690–#693) → M3 session features (#694–#699) → M4 input/config (#700–#703). Out of scope (justified in plan): share server, themes/keybinds, LSP status, TUI remote control, workspaces/worktrees.
+- Checks run: planning artifacts only — no app code touched; no CI runs triggered (docs-only branch; Actions are workflow_dispatch / paths-filtered). Verification-gate not applicable to a planning run; per-issue contracts come via acceptance-contract at implementation time.
+- Open questions flagged for the user before M1 starts (current-plan.md §Open questions): parts storage shape (JSON column vs normalized table), markdown package pick, mini-bubble keep-or-delete, cost display units, custom-agent scope.
+- Process note: the AgentFlow `plan_and_issues` run stalled mid-flight when the MCP server restarted (in-memory registry lost); recovered via CLI `agentflow resume` — which initially failed by falling back to a local ollama model because `AGENTFLOW_WORKFLOWS_DIR` was unset. See decisions.md entry for the config gotcha.
+
 ### 2026-06-12 — chore/server-shutdown-signal-contract (no issue; follow-up to PR #683 smoke)
 - Task: fix watchdog ppid===1 heuristic failing in dev mode (Flutter→npx→tsx→Node chain; api_server's direct parent is tsx runner not Flutter, so ppid never becomes 1 on Cmd+Q). Production path confirmed correct via code analysis (direct Flutter→Node spawn, ppid=1 fires). Implemented `--parent-pid` flag approach so the watchdog works in both modes.
 - Files modified:


### PR DESCRIPTION
## What this is

Planning-only PR — no app code changes. Adds:

- `docs/ai/current-plan.md` — the OpenCode-parity plan (replaces the completed PR #617 sprint plan)
- `docs/ai/generated-issues/opencode-m*.md` — 19 sequenced issue specs (source of GitHub issues #685–#703)
- `docs/failure-taxonomy.md` + `docs/contract-schema.md` — AgentFlow context docs this repo was missing

## How the plan was produced

1. Audited OpenCode v1.14.49 (pinned clone at the embedded SDK version): full server API, 12-type message part union, tool/permission/question systems, event catalog, TUI feature ranking.
2. Audited the existing Agents integration (`opencode_client_service`, stream bridge, ws_gateway, Flutter agents feature): wired / partial / broken / absent, with postmortem mining.
3. Verified the embedded SDK already exposes every missing endpoint (`diff`, `revert`, `summarize`, `todo`, `fork`, `command`, `messages`, `children`, `mcp`) — the gaps are wiring + UI, not architecture.

## Issue sequence

| Milestone | Issues | Theme |
|---|---|---|
| M1 Foundation | #685 #686 #687 #688 #689 | Root-cause fixes: typed SDK wrappers, structured parts persistence, single render path, sentinel cleanup, resume continuity |
| M2 Rendering | #690 #691 #692 #693 | Markdown, reasoning block, tool-specific renderers, retry/tokens/cost |
| M3 Session features | #694 #695 #696 #697 #698 #699 | Real diff tab, revert/unrevert, compaction, structured commands, todo panel, subagents |
| M4 Input & config | #700 #701 #702 #703 | Real attachments, fork, MCP UI, custom agents |

M1 merges fully before M2 starts. None of these issues are closed by this PR.

## Open questions before M1 starts (flagged in the plan §Open questions)

parts storage shape, markdown package, mini-bubble fate, cost display units, custom-agent scope — see `current-plan.md` lines 124-143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)