### PR TITLE
F1: Reuse sign-in Google credential for Calendar (no second OAuth)

### DIFF
--- a/apps/api_server/src/__tests__/integrations_account_status.test.ts
+++ b/apps/api_server/src/__tests__/integrations_account_status.test.ts
@@ -71,3 +71,13 @@ describe('deriveAccountStatus(google_calendar)', () => {
     });
   });
 });
+
+import { buildAccountDto } from '../controllers/integrations_controller';
+
+describe('buildAccountDto', () => {
+  it('uses derived status and exposes needsReauth', () => {
+    const dto = buildAccountDto('google_calendar', null);
+    expect(dto.status).toBe('disconnected');
+    expect(dto.needsReauth).toBe(false);
+  });
+});

--- a/apps/api_server/src/__tests__/integrations_account_status.test.ts
+++ b/apps/api_server/src/__tests__/integrations_account_status.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { deriveAccountStatus } from '../controllers/integrations_status';
+import type { IntegrationAccount } from '../models/integration_account';
+
+function account(overrides: Partial<IntegrationAccount>): IntegrationAccount {
+  return {
+    id: 'acc-1',
+    ownerId: 1,
+    provider: 'google_calendar',
+    externalAccountId: 'sub-1',
+    email: 'a@example.com',
+    displayName: 'A',
+    status: 'connected',
+    accessToken: 'at',
+    refreshToken: 'rt',
+    scope:
+      'openid email profile https://www.googleapis.com/auth/calendar.readonly',
+    tokenType: 'Bearer',
+    expiresAt: null,
+    lastSyncedAt: null,
+    errorMessage: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('deriveAccountStatus(google_calendar)', () => {
+  it('connected when calendar scope + refresh token present', () => {
+    expect(deriveAccountStatus('google_calendar', account({}))).toEqual({
+      status: 'connected',
+      needsReauth: false,
+    });
+  });
+
+  it('connected when full calendar scope present', () => {
+    const a = account({
+      scope: 'openid https://www.googleapis.com/auth/calendar',
+    });
+    expect(deriveAccountStatus('google_calendar', a).status).toBe('connected');
+  });
+
+  it('needs_reauth when calendar scope missing (legacy account)', () => {
+    const a = account({ scope: 'openid email profile' });
+    expect(deriveAccountStatus('google_calendar', a)).toEqual({
+      status: 'needs_reauth',
+      needsReauth: true,
+    });
+  });
+
+  it('needs_reauth when refresh token missing', () => {
+    const a = account({ refreshToken: null });
+    expect(deriveAccountStatus('google_calendar', a)).toEqual({
+      status: 'needs_reauth',
+      needsReauth: true,
+    });
+  });
+
+  it('error when account row is in error state', () => {
+    const a = account({ status: 'error' });
+    expect(deriveAccountStatus('google_calendar', a)).toEqual({
+      status: 'error',
+      needsReauth: false,
+    });
+  });
+
+  it('disconnected when no account', () => {
+    expect(deriveAccountStatus('google_calendar', null)).toEqual({
+      status: 'disconnected',
+      needsReauth: false,
+    });
+  });
+});

--- a/apps/api_server/src/controllers/integrations_controller.ts
+++ b/apps/api_server/src/controllers/integrations_controller.ts
@@ -6,50 +6,52 @@ import type {
 import { IntegrationAccountsRepository } from '../repositories/integration_accounts_repository';
 import { AutomationCatalogService } from '../services/automation_catalog_service';
 import { IntegrationsService } from '../services/integrations_service';
+import { deriveAccountStatus } from './integrations_status';
 
 const repo = new IntegrationAccountsRepository();
 const service = new IntegrationsService();
 const catalog = new AutomationCatalogService();
 
-function toAccountDto(
+export function buildAccountDto(
   provider: IntegrationProvider,
   account: IntegrationAccount | null,
 ) {
   const providerMeta = catalog
     .getProviders()
     .find((item) => item.source === provider);
+  const { status, needsReauth } = deriveAccountStatus(provider, account);
+  const base = {
+    providerDisplayName: providerMeta?.label ?? provider,
+    availableTriggerFamilies: providerMeta?.triggerKeys ?? [],
+    syncSupportMode: providerMeta?.syncSupport ?? 'manual',
+    status,
+    needsReauth,
+  };
   if (!account) {
     return {
+      ...base,
       id: provider,
       provider,
-      providerDisplayName: providerMeta?.label ?? provider,
       accountLabel: null,
       email: null,
       displayName: null,
-      status: 'disconnected',
       expiresAt: null,
       lastSyncedAt: null,
       errorMessage: null,
       scope: null,
-      availableTriggerFamilies: providerMeta?.triggerKeys ?? [],
-      syncSupportMode: providerMeta?.syncSupport ?? 'manual',
     };
   }
-
   return {
+    ...base,
     id: account.id,
     provider: account.provider,
-    providerDisplayName: providerMeta?.label ?? account.provider,
     accountLabel: account.displayName ?? account.email,
     email: account.email,
     displayName: account.displayName,
-    status: account.status,
     expiresAt: account.expiresAt,
     lastSyncedAt: account.lastSyncedAt,
     errorMessage: account.errorMessage,
     scope: account.scope,
-    availableTriggerFamilies: providerMeta?.triggerKeys ?? [],
-    syncSupportMode: providerMeta?.syncSupport ?? 'manual',
   };
 }
 
@@ -60,9 +62,9 @@ export class IntegrationsController {
       const byProvider = new Map(existing.map((account) => [account.provider, account]));
 
       res.json([
-        toAccountDto('google_calendar', byProvider.get('google_calendar') ?? null),
-        toAccountDto('gmail', byProvider.get('gmail') ?? null),
-        toAccountDto('planning_center', byProvider.get('planning_center') ?? null),
+        buildAccountDto('google_calendar', byProvider.get('google_calendar') ?? null),
+        buildAccountDto('gmail', byProvider.get('gmail') ?? null),
+        buildAccountDto('planning_center', byProvider.get('planning_center') ?? null),
       ]);
     } catch (err) {
       next(err);

--- a/apps/api_server/src/controllers/integrations_status.ts
+++ b/apps/api_server/src/controllers/integrations_status.ts
@@ -1,0 +1,55 @@
+import type {
+  IntegrationAccount,
+  IntegrationProvider,
+} from '../models/integration_account';
+
+export type DerivedStatus =
+  | 'connected'
+  | 'needs_reauth'
+  | 'error'
+  | 'disconnected';
+
+export interface AccountStatus {
+  status: DerivedStatus;
+  needsReauth: boolean;
+}
+
+/**
+ * Substrings that satisfy each provider's minimum capability. A stored scope
+ * string "contains" the requirement when any listed substring is present.
+ * google_calendar accepts read-only OR full calendar scope.
+ */
+const REQUIRED_SCOPE_SUBSTRINGS: Record<IntegrationProvider, string[]> = {
+  google_calendar: [
+    'https://www.googleapis.com/auth/calendar.readonly',
+    'https://www.googleapis.com/auth/calendar',
+  ],
+  gmail: [
+    'https://www.googleapis.com/auth/gmail.metadata',
+    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/gmail.modify',
+  ],
+  planning_center: ['services'],
+};
+
+function hasRequiredScope(
+  provider: IntegrationProvider,
+  scope: string | null,
+): boolean {
+  if (!scope) return false;
+  return REQUIRED_SCOPE_SUBSTRINGS[provider].some((needle) =>
+    scope.includes(needle),
+  );
+}
+
+export function deriveAccountStatus(
+  provider: IntegrationProvider,
+  account: IntegrationAccount | null,
+): AccountStatus {
+  if (!account) return { status: 'disconnected', needsReauth: false };
+  if (account.status === 'error') return { status: 'error', needsReauth: false };
+  if (!account.refreshToken || !hasRequiredScope(provider, account.scope)) {
+    return { status: 'needs_reauth', needsReauth: true };
+  }
+  return { status: 'connected', needsReauth: false };
+}

--- a/apps/desktop_flutter/lib/features/integrations/controllers/integrations_controller.dart
+++ b/apps/desktop_flutter/lib/features/integrations/controllers/integrations_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import '../models/gmail_signal.dart';
 import '../models/google_calendar_settings.dart';
@@ -31,6 +33,7 @@ class IntegrationsController extends ChangeNotifier {
   bool _syncingPlanningCenter = false;
   bool _savingPlanningCenterTaskFilters = false;
   bool _syncingAll = false;
+  bool _autoSyncedCalendar = false;
 
   List<IntegrationAccount> get accounts => _accounts;
   GoogleCalendarSettings get googleCalendarSettings => _googleCalendarSettings;
@@ -90,6 +93,20 @@ class IntegrationsController extends ChangeNotifier {
       _errorMessage = e.toString();
     }
     notifyListeners();
+    unawaited(maybeAutoSyncCalendar());
+  }
+
+  /// Kick a one-time silent calendar sync when the credential captured at
+  /// sign-in is connected and has never synced. No-op otherwise (idempotent
+  /// within a session).
+  Future<void> maybeAutoSyncCalendar() async {
+    if (_autoSyncedCalendar) return;
+    final matches = _accounts.where((a) => a.provider == 'google_calendar');
+    if (matches.isEmpty) return;
+    final account = matches.first;
+    if (account.status != 'connected' || account.lastSyncedAt != null) return;
+    _autoSyncedCalendar = true;
+    await syncGoogleCalendar();
   }
 
   Uri googleBeginUri() => _repository.googleBeginUri();

--- a/apps/desktop_flutter/lib/features/integrations/models/integration_account.dart
+++ b/apps/desktop_flutter/lib/features/integrations/models/integration_account.dart
@@ -13,6 +13,7 @@ class IntegrationAccount {
     this.scope,
     this.availableTriggerFamilies = const [],
     this.syncSupportMode,
+    this.needsReauth = false,
   });
 
   factory IntegrationAccount.fromJson(Map<String, dynamic> json) {
@@ -34,6 +35,7 @@ class IntegrationAccount {
               .map((item) => item.toString())
               .toList(),
       syncSupportMode: json['syncSupportMode'] as String?,
+      needsReauth: json['needsReauth'] as bool? ?? false,
     );
   }
 
@@ -50,4 +52,5 @@ class IntegrationAccount {
   final String? scope;
   final List<String> availableTriggerFamilies;
   final String? syncSupportMode;
+  final bool needsReauth;
 }

--- a/apps/desktop_flutter/lib/features/integrations/views/integrations_view.dart
+++ b/apps/desktop_flutter/lib/features/integrations/views/integrations_view.dart
@@ -86,6 +86,7 @@ class _IntegrationsViewState extends State<IntegrationsView> {
                                 title: 'Google Calendar',
                                 description:
                                     'Read-only calendar timing for shadow events in the planner.',
+                                keyProvider: 'google_calendar',
                                 onConnect: () =>
                                     _openExternal(controller.googleBeginUri()),
                                 onSync: controller.syncGoogleCalendar,
@@ -198,6 +199,7 @@ class _IntegrationCard extends StatelessWidget {
     this.onSync,
     this.syncing = false,
     this.child,
+    this.keyProvider,
   });
 
   final String title;
@@ -207,6 +209,11 @@ class _IntegrationCard extends StatelessWidget {
   final Future<void> Function()? onSync;
   final bool syncing;
   final Widget? child;
+
+  /// When set, the connect/sync affordances are branched on
+  /// [IntegrationAccount.status] and tagged with stable ValueKeys
+  /// (`integration-$keyProvider-sync` / `integration-$keyProvider-reconnect`).
+  final String? keyProvider;
 
   @override
   Widget build(BuildContext context) {
@@ -324,41 +331,7 @@ class _IntegrationCard extends StatelessWidget {
               spacing: 10,
               runSpacing: 10,
               crossAxisAlignment: WrapCrossAlignment.center,
-              children: [
-                FilledButton.icon(
-                  onPressed: onConnect,
-                  icon: Icon(connected ? Icons.sync : Icons.link, size: 16),
-                  label: Text(connected ? 'Reconnect' : 'Connect'),
-                ),
-                if (connected && onSync != null)
-                  OutlinedButton.icon(
-                    onPressed: syncing ? null : () => onSync!.call(),
-                    icon: syncing
-                        ? const SizedBox(
-                            width: 14,
-                            height: 14,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Icon(Icons.download, size: 16),
-                    label: Text(
-                      title == 'Gmail'
-                          ? 'Sync Gmail'
-                          : title == 'Planning Center'
-                              ? 'Sync Planning Center'
-                              : 'Sync Calendar',
-                    ),
-                  ),
-                if (!connected && onConnect == null)
-                  Text(
-                    'Coming next',
-                    style: Theme.of(
-                      context,
-                    )
-                        .textTheme
-                        .bodySmall
-                        ?.copyWith(color: context.rhythm.textMuted),
-                  ),
-              ],
+              children: _buildActions(context, connected),
             ),
             if (child != null) ...[
               const SizedBox(height: 18),
@@ -377,6 +350,69 @@ class _IntegrationCard extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Widget _syncButton(BuildContext context, {Key? key}) {
+    return OutlinedButton.icon(
+      key: key,
+      onPressed: syncing ? null : () => onSync?.call(),
+      icon: syncing
+          ? const SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Icon(Icons.download, size: 16),
+      label: Text(
+        title == 'Gmail'
+            ? 'Sync Gmail'
+            : title == 'Planning Center'
+                ? 'Sync Planning Center'
+                : 'Sync Calendar',
+      ),
+    );
+  }
+
+  List<Widget> _buildActions(BuildContext context, bool connected) {
+    // Status-driven affordances for cards that opt in via [keyProvider]:
+    // connected -> Sync only; needs_reauth / disconnected / error -> Reconnect.
+    if (keyProvider != null) {
+      final status = account?.status ?? 'disconnected';
+      if (status == 'connected') {
+        return [
+          if (onSync != null)
+            _syncButton(
+              context,
+              key: ValueKey('integration-$keyProvider-sync'),
+            ),
+        ];
+      }
+      return [
+        FilledButton.icon(
+          key: ValueKey('integration-$keyProvider-reconnect'),
+          onPressed: onConnect,
+          icon: const Icon(Icons.sync, size: 16),
+          label: const Text('Reconnect Google'),
+        ),
+      ];
+    }
+
+    return [
+      FilledButton.icon(
+        onPressed: onConnect,
+        icon: Icon(connected ? Icons.sync : Icons.link, size: 16),
+        label: Text(connected ? 'Reconnect' : 'Connect'),
+      ),
+      if (connected && onSync != null) _syncButton(context),
+      if (!connected && onConnect == null)
+        Text(
+          'Coming next',
+          style: Theme.of(context)
+              .textTheme
+              .bodySmall
+              ?.copyWith(color: context.rhythm.textMuted),
+        ),
+    ];
   }
 }
 

--- a/apps/desktop_flutter/test/features/integrations/f1_calendar_reuse_test.dart
+++ b/apps/desktop_flutter/test/features/integrations/f1_calendar_reuse_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rhythm_desktop/features/integrations/models/integration_account.dart';
+
+void main() {
+  group('IntegrationAccount.fromJson', () {
+    test('parses needsReauth and status', () {
+      final a = IntegrationAccount.fromJson(const {
+        'id': 'google_calendar',
+        'provider': 'google_calendar',
+        'providerDisplayName': 'Google Calendar',
+        'status': 'needs_reauth',
+        'needsReauth': true,
+      });
+      expect(a.status, 'needs_reauth');
+      expect(a.needsReauth, true);
+    });
+
+    test('defaults needsReauth to false when absent', () {
+      final a = IntegrationAccount.fromJson(const {
+        'id': 'google_calendar',
+        'provider': 'google_calendar',
+        'providerDisplayName': 'Google Calendar',
+        'status': 'connected',
+      });
+      expect(a.needsReauth, false);
+    });
+  });
+}

--- a/apps/desktop_flutter/test/features/integrations/f1_calendar_reuse_test.dart
+++ b/apps/desktop_flutter/test/features/integrations/f1_calendar_reuse_test.dart
@@ -1,5 +1,11 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:rhythm_desktop/features/integrations/controllers/integrations_controller.dart';
+import 'package:rhythm_desktop/features/integrations/data/integrations_data_source.dart';
 import 'package:rhythm_desktop/features/integrations/models/integration_account.dart';
+import 'package:rhythm_desktop/features/integrations/repositories/integrations_repository.dart';
+import 'package:rhythm_desktop/features/integrations/views/integrations_view.dart';
 
 void main() {
   group('IntegrationAccount.fromJson', () {
@@ -25,4 +31,93 @@ void main() {
       expect(a.needsReauth, false);
     });
   });
+
+  group('Google Calendar card', () {
+    testWidgets(
+      'connected status shows Sync button and no Reconnect button',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(1400, 1200));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final repository = _FakeIntegrationsRepository(
+          accounts: [
+            IntegrationAccount(
+              id: 'google_calendar',
+              provider: 'google_calendar',
+              status: 'connected',
+              connected: true,
+            ),
+          ],
+        );
+
+        await _pumpIntegrationsView(tester, repository);
+
+        expect(
+          find.byKey(const ValueKey('integration-google_calendar-sync')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('integration-google_calendar-reconnect')),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets(
+      'needs_reauth status shows Reconnect button and no Sync button',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(1400, 1200));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        final repository = _FakeIntegrationsRepository(
+          accounts: [
+            IntegrationAccount(
+              id: 'google_calendar',
+              provider: 'google_calendar',
+              status: 'needs_reauth',
+              connected: false,
+              needsReauth: true,
+            ),
+          ],
+        );
+
+        await _pumpIntegrationsView(tester, repository);
+
+        expect(
+          find.byKey(const ValueKey('integration-google_calendar-reconnect')),
+          findsOneWidget,
+        );
+        expect(
+          find.byKey(const ValueKey('integration-google_calendar-sync')),
+          findsNothing,
+        );
+      },
+    );
+  });
+}
+
+Future<void> _pumpIntegrationsView(
+  WidgetTester tester,
+  _FakeIntegrationsRepository repository,
+) async {
+  await tester.pumpWidget(
+    ChangeNotifierProvider(
+      create: (_) => IntegrationsController(repository),
+      child: const MaterialApp(home: Scaffold(body: IntegrationsView())),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+class _FakeIntegrationsRepository extends IntegrationsRepository {
+  _FakeIntegrationsRepository({required this.accounts})
+      : super(IntegrationsDataSource(baseUrl: 'http://example.invalid'));
+
+  final List<IntegrationAccount> accounts;
+
+  @override
+  Future<List<IntegrationAccount>> getAccounts() async => accounts;
+
+  @override
+  Uri googleBeginUri() => Uri.parse('http://example.invalid/google/begin');
 }

--- a/apps/desktop_flutter/test/features/integrations/f1_calendar_reuse_test.dart
+++ b/apps/desktop_flutter/test/features/integrations/f1_calendar_reuse_test.dart
@@ -7,7 +7,114 @@ import 'package:rhythm_desktop/features/integrations/models/integration_account.
 import 'package:rhythm_desktop/features/integrations/repositories/integrations_repository.dart';
 import 'package:rhythm_desktop/features/integrations/views/integrations_view.dart';
 
+// ---------------------------------------------------------------------------
+// Counting stub for maybeAutoSyncCalendar tests
+// ---------------------------------------------------------------------------
+
+class _CountingRepository extends _FakeIntegrationsRepository {
+  _CountingRepository({required super.accounts});
+
+  int syncGoogleCalendarCallCount = 0;
+
+  @override
+  Future<void> syncGoogleCalendar() async {
+    syncGoogleCalendarCallCount++;
+  }
+}
+
 void main() {
+  // -------------------------------------------------------------------------
+  group('maybeAutoSyncCalendar', () {
+    test(
+      'triggers exactly one sync when account is connected + never synced, '
+      'and is idempotent on second call',
+      () async {
+        final repo = _CountingRepository(
+          accounts: [
+            IntegrationAccount(
+              id: 'google_calendar',
+              provider: 'google_calendar',
+              status: 'connected',
+              connected: true,
+              lastSyncedAt: null,
+            ),
+          ],
+        );
+        final controller = IntegrationsController(repo);
+
+        // Populate _accounts without triggering the auto-sync via load(),
+        // then call maybeAutoSyncCalendar directly.
+        await controller.load();
+        // Reset count — load() itself may have called maybeAutoSyncCalendar.
+        final afterLoad = repo.syncGoogleCalendarCallCount;
+
+        // First explicit call should sync once more (or, if load already did
+        // it, the flag is set and this is a no-op).
+        await controller.maybeAutoSyncCalendar();
+        final afterFirst = repo.syncGoogleCalendarCallCount;
+
+        // Second call must be idempotent.
+        await controller.maybeAutoSyncCalendar();
+        final afterSecond = repo.syncGoogleCalendarCallCount;
+
+        // Total syncs triggered (from load + first explicit call) == 1.
+        expect(afterLoad + (afterFirst - afterLoad), 1,
+            reason: 'Expected exactly one sync across load + first call');
+        // Second call adds zero.
+        expect(afterSecond, afterFirst, reason: 'Second call must be a no-op');
+      },
+    );
+
+    test(
+      'triggers zero syncs when account status is needs_reauth',
+      () async {
+        final repo = _CountingRepository(
+          accounts: [
+            IntegrationAccount(
+              id: 'google_calendar',
+              provider: 'google_calendar',
+              status: 'needs_reauth',
+              connected: false,
+              needsReauth: true,
+              lastSyncedAt: null,
+            ),
+          ],
+        );
+        final controller = IntegrationsController(repo);
+        await controller.load();
+        repo.syncGoogleCalendarCallCount = 0; // reset any load-time calls
+
+        await controller.maybeAutoSyncCalendar();
+        expect(repo.syncGoogleCalendarCallCount, 0,
+            reason: 'needs_reauth account must not trigger sync');
+      },
+    );
+
+    test(
+      'triggers zero syncs when account has already been synced',
+      () async {
+        final repo = _CountingRepository(
+          accounts: [
+            IntegrationAccount(
+              id: 'google_calendar',
+              provider: 'google_calendar',
+              status: 'connected',
+              connected: true,
+              lastSyncedAt: '2024-01-01T00:00:00Z',
+            ),
+          ],
+        );
+        final controller = IntegrationsController(repo);
+        await controller.load();
+        repo.syncGoogleCalendarCallCount = 0; // reset any load-time calls
+
+        await controller.maybeAutoSyncCalendar();
+        expect(repo.syncGoogleCalendarCallCount, 0,
+            reason: 'already-synced account must not trigger auto-sync');
+      },
+    );
+  });
+  // -------------------------------------------------------------------------
   group('IntegrationAccount.fromJson', () {
     test('parses needsReauth and status', () {
       final a = IntegrationAccount.fromJson(const {

--- a/docs/superpowers/specs/2026-06-15-single-google-oauth-and-mcp-autoinstall-design.md
+++ b/docs/superpowers/specs/2026-06-15-single-google-oauth-and-mcp-autoinstall-design.md
@@ -6,7 +6,7 @@ Branch base: `main` (current work branch: `opc-m1-foundation`)
 
 ## Summary
 
-Three related features that eliminate redundant logins and manual setup by
+Four related features that eliminate redundant logins and manual setup by
 reusing the credential and token a user already has:
 
 1. **Calendar reuse** — the Google credential captured at sign-in already
@@ -18,10 +18,15 @@ reusing the credential and token a user already has:
 3. **Google tools in the rhythm MCP** — Calendar and Gmail read/write tools,
    brokered through the Rhythm backend so they ride on the same single sign-in,
    gated behind an opt-in step-up consent for the broader scopes.
+4. **PCO tools in the rhythm MCP** — Planning Center Services read/write tools,
+   brokered through the Rhythm backend, reusing the PCO OAuth credential
+   already captured on the Integrations page. No re-consent (existing `services`
+   scope suffices; PCO governs write by user role).
 
 The features share infrastructure (the `integration_accounts` credential, the
-`/auth/google/begin` re-auth path, the rhythm MCP server, opencode's `addMcp`)
-and ship as three sequenced PRs: **F1 → F2 → F3**.
+`/auth/google/begin` and `/auth/planning-center/begin` re-auth paths, the
+rhythm MCP server, opencode's `addMcp`) and ship as four sequenced PRs:
+**F1 → F2 → F3, F4**.
 
 ## Background (verified in code)
 
@@ -207,9 +212,77 @@ broader scopes will not work for general users until verification clears.
 
 ---
 
+## Feature 4 — Planning Center (PCO) tools in the rhythm MCP (brokered)
+
+**Goal:** expose Planning Center Services read/write tools to opencode,
+authenticated by the PCO OAuth already captured on the Integrations page, via
+the Rhythm backend broker.
+
+### Background (verified in code)
+- PCO OAuth is implemented in `planning_center_oauth_service.ts`; begin/callback
+  at `/auth/planning-center/begin` and `/auth/planning-center/callback`
+  (`auth_controller.ts:208–225`, `auth_routes.ts:22–29`).
+- The credential is stored in `integration_accounts` under provider
+  `planning_center` with `refresh_token`, via
+  `upsertPlanningCenterAccountAsync()`
+  (`integration_accounts_repository.ts:312–378`).
+- Auto-refresh uses the **same** `ensureFreshAccount` path as Google
+  (`integrations_service.ts:507–522`); refresh via
+  `PlanningCenterOAuthService.refreshAccessToken()`.
+- Current scope is `openid services` (`env.ts:46`, `PCO_SCOPES`).
+- `PlanningCenterService` already calls Services v2 endpoints with
+  `Authorization: Bearer ${account.accessToken}` (`planning_center_service.ts`).
+
+### Consent model — none required
+PCO OAuth scopes are per-product (`services`), and read-vs-write is governed by
+the signed-in user's PCO role, not by separate scopes. The existing `services`
+scope already permits Services writes for users whose PCO permissions allow it.
+So F4 needs **no re-consent and no scope change**. (Adding other PCO products —
+People, Calendar, Giving, Check-Ins — would need a step-up consent reusing
+`/auth/planning-center/begin`; that is out of scope here.)
+
+There is no Google-style app-verification / CASA gate for PCO (private OAuth
+app).
+
+### Changes
+
+1. **Backend — new Rhythm API broker routes** (extend the PCO area of the
+   `integrations` controller / `PlanningCenterService`) wrapping PCO Services
+   v2 calls via `ensureFreshAccount('planning_center')` + the stored credential:
+   - Read: list service types, list plans (with `future` filter), list teams,
+     list needed positions, list team members, list plan items/songs.
+   - Write: create/update plan items, assign/remove a person to a position,
+     update a scheduled person's status. (Exact write set finalized in the
+     plan; mirror what the existing automation flows already read.)
+   - Each enforces the requesting user's session; a PCO 403 (user lacks role
+     permission) is surfaced as a clear, structured error (not a crash).
+
+2. **MCP tools** — add to the existing rhythm MCP server (`apps/mcp_server`):
+   e.g. `rhythm_pco_list_plans`, `rhythm_pco_get_plan_items`,
+   `rhythm_pco_list_needed_positions`, `rhythm_pco_assign_person`,
+   `rhythm_pco_update_plan_item`. They call the new broker routes with the same
+   `RHYTHM_API_TOKEN` — no new env vars, no new opencode config. F2's
+   auto-install ships them the moment they exist.
+
+3. **No frontend OAuth change.** The existing "Connect Planning Center" button
+   and begin/callback are untouched; F4 only consumes the already-stored
+   credential.
+
+### Error handling
+- `invalid_grant` / revocation → account flips to `disconnected` (shared path).
+- PCO permission denial (HTTP 403 from PCO) → structured "insufficient PCO
+  permissions" error returned to the tool, not a generic failure.
+
+### Testing
+- Unit: broker routes with mocked PCO API — success, expired→refresh, 403.
+- Contract: MCP tool input/output shapes.
+- Integration: a write tool round-trips against a mocked PCO Services endpoint.
+
+---
+
 ## Sequencing
 
-Three independent PRs, in order:
+Four PRs, in order:
 
 1. **F1 — Calendar reuse** (backend status semantics + Flutter Integrations UI).
    Establishes the shared `needsReauth` / scope-status signal.
@@ -217,6 +290,9 @@ Three independent PRs, in order:
    Settings status). Independent of F1.
 3. **F3 — Google tools in rhythm MCP** (step-up consent + broker routes + MCP
    tools). Depends on F1's status/`needsReauth` work and F2's auto-install.
+4. **F4 — PCO tools in rhythm MCP** (broker routes + MCP tools). Depends only on
+   F2's auto-install; independent of F1 and F3. No re-consent. Can land in
+   parallel with F3 after F2.
 
 ## Non-goals
 - No standalone third-party Google MCP server (rejected: leaks Rhythm's Google
@@ -225,3 +301,6 @@ Three independent PRs, in order:
 - No broadening of base sign-in scopes for all users.
 - No change to mobile sign-in beyond what F3's shared scope-upgrade path
   implies (mobile UI work tracked separately if needed).
+- No additional PCO products (People, Calendar, Giving, Check-Ins) in F4 — only
+  the already-authorized Services scope; new products would need a separate
+  step-up consent and are deferred.


### PR DESCRIPTION
## What & why

After Google sign-in, the calendar credential (refresh token + `calendar.readonly` scope) is **already** stored in the `google_calendar` row of `integration_accounts`. The Integrations screen, however, still offered a "Connect Google" button that ran a *second* OAuth round-trip. This PR makes the screen recognize the existing credential and connect silently — no second login.

Feature **F1** of the [single Google/PCO OAuth + MCP auto-install spec](docs/superpowers/specs/2026-06-15-single-google-oauth-and-mcp-autoinstall-design.md).

## How it works (end to end)

1. **`deriveAccountStatus(provider, account)`** (new pure helper, `integrations_status.ts`) → `connected` only when a refresh token **and** the calendar scope are present; `needs_reauth` for legacy accounts missing either; `error` / `disconnected` otherwise.
2. **`buildAccountDto`** folds the derived `status` + a new `needsReauth` flag into `GET /integrations/accounts` (DTO is a strict superset of the old shape).
3. **Flutter model** parses `needsReauth`.
4. **Integrations view** — Google Calendar card shows **Sync** when `connected` (no connect button), and **Reconnect Google** only on `needs_reauth` / `disconnected` / `error` (the only path that triggers a Google prompt; reuses the existing `googleBeginUri()` + `forceConsent`).
5. **Controller** fires a one-time silent calendar sync (`maybeAutoSyncCalendar()`) when connected and never-synced.

## Scope note for review

`buildAccountDto` derives status for **all three** providers, so Gmail/PCO status is now derived rather than raw `account.status`. Benign for normal flows (Gmail has `gmail.metadata`, PCO defaults to `services`, so connected stays connected); the helper pre-defines those scopes intentionally for reuse by F3/F4. Gmail/PCO cards are otherwise unchanged.

## Verification

- **api_server:** 794/794 vitest pass; `tsc --noEmit` clean.
- **Flutter:** `dart format` clean; `flutter analyze --no-fatal-infos` zero errors/warnings (pre-existing infos only); 507/507 tests pass.
- New tests: `deriveAccountStatus` (6 branches), `buildAccountDto`, model parsing, Sync-vs-Reconnect widget tests, auto-sync idempotency.

## Testing locally

Point Settings → API Server at `https://api.vcrcapps.com`, sign in with Google, open Integrations — Google Calendar should show **Connected + Sync** with no second login. (Legacy accounts predating the calendar scope will show **Reconnect** once.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)