### PR TITLE
F2: Auto-install the rhythm MCP server into opencode

### DIFF
--- a/apps/api_server/src/__tests__/opc_rhythm_mcp_ensure.test.ts
+++ b/apps/api_server/src/__tests__/opc_rhythm_mcp_ensure.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { OpencodeClientService } from '../services/opencode_client_service';
+
+const DESIRED = {
+  type: 'local',
+  command: ['npx', '-y', '@ajhochy/rhythm-mcp-server'],
+  environment: {
+    RHYTHM_API_URL: 'https://api.vcrcapps.com',
+    RHYTHM_API_TOKEN: 'tok-1',
+  },
+};
+
+describe('ensureRhythmMcp diff logic', () => {
+  let dir: string;
+  let configPath: string;
+  let svc: OpencodeClientService;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'opencode-cfg-'));
+    configPath = join(dir, 'opencode.json');
+    svc = new OpencodeClientService();
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it('adds rhythm when absent and persists environment', async () => {
+    const result = await svc.ensureRhythmMcp('tok-1', 'https://api.vcrcapps.com', {
+      configPath,
+      register: false,
+    });
+    expect(result.changed).toBe(true);
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(parsed.mcp.rhythm.environment.RHYTHM_API_TOKEN).toBe('tok-1');
+    expect(parsed.mcp.rhythm.command).toEqual(DESIRED.command);
+  });
+
+  it('no-ops when config already matches', async () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ mcp: { rhythm: DESIRED } }), 'utf8');
+    const result = await svc.ensureRhythmMcp('tok-1', 'https://api.vcrcapps.com', {
+      configPath,
+      register: false,
+    });
+    expect(result.changed).toBe(false);
+  });
+
+  it('rewrites when the token rotates', async () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ mcp: { rhythm: DESIRED } }), 'utf8');
+    const result = await svc.ensureRhythmMcp('tok-2', 'https://api.vcrcapps.com', {
+      configPath,
+      register: false,
+    });
+    expect(result.changed).toBe(true);
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(parsed.mcp.rhythm.environment.RHYTHM_API_TOKEN).toBe('tok-2');
+  });
+
+  it('preserves other mcp servers when updating rhythm', async () => {
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({ mcp: { other: { type: 'local', command: ['x'] } } }),
+      'utf8',
+    );
+    await svc.ensureRhythmMcp('tok-1', 'https://api.vcrcapps.com', {
+      configPath,
+      register: false,
+    });
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(parsed.mcp.other).toBeTruthy();
+    expect(parsed.mcp.rhythm).toBeTruthy();
+  });
+});

--- a/apps/api_server/src/__tests__/opc_rhythm_mcp_ensure_route.test.ts
+++ b/apps/api_server/src/__tests__/opc_rhythm_mcp_ensure_route.test.ts
@@ -1,0 +1,50 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { AddressInfo } from 'net';
+import http from 'http';
+import express from 'express';
+import { opencodeMcpRouter } from '../routes/opencode_mcp_routes';
+import { AppError } from '../errors/app_error';
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/opencode/mcp', opencodeMcpRouter);
+  // Minimal error handler mirroring the app's AppError -> status mapping.
+  app.use(
+    (
+      err: Error & { status?: number },
+      _req: express.Request,
+      res: express.Response,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      _next: express.NextFunction,
+    ) => {
+      const status = err instanceof AppError ? err.statusCode : (err.status ?? 500);
+      res.status(status).json({ error: err.message });
+    },
+  );
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      baseUrl = `http://127.0.0.1:${port}`;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe('POST /opencode/mcp/rhythm/ensure', () => {
+  it('400s when apiToken is missing', async () => {
+    const res = await fetch(`${baseUrl}/opencode/mcp/rhythm/ensure`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ apiUrl: 'https://api.vcrcapps.com' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api_server/src/routes/opencode_mcp_routes.ts
+++ b/apps/api_server/src/routes/opencode_mcp_routes.ts
@@ -85,6 +85,29 @@ opencodeMcpRouter.post(
   },
 );
 
+// ── POST /rhythm/ensure — auto-install/refresh the rhythm MCP server ─────────
+opencodeMcpRouter.post(
+  '/rhythm/ensure',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { apiToken, apiUrl } = req.body as {
+        apiToken?: string;
+        apiUrl?: string;
+      };
+      if (!apiToken || apiToken.trim() === '') {
+        return next(new AppError(400, 'BAD_REQUEST', 'apiToken is required'));
+      }
+      const result = await opencodeClient.ensureRhythmMcp(
+        apiToken.trim(),
+        (apiUrl && apiUrl.trim()) || 'https://api.vcrcapps.com',
+      );
+      res.json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
 // ── POST /:name/connect ──────────────────────────────────────────────────────
 
 opencodeMcpRouter.post(

--- a/apps/api_server/src/services/opencode_client_service.ts
+++ b/apps/api_server/src/services/opencode_client_service.ts
@@ -1113,6 +1113,73 @@ export class OpencodeClientService {
   }
 
   /**
+   * Idempotently register the rhythm MCP server into opencode.json with the
+   * live production token + URL. Adds when absent, rewrites + reconnects when
+   * the token/URL changed, no-ops when identical. `opts.configPath` overrides
+   * the default (~/.config/opencode/opencode.json) for tests; `opts.register`
+   * controls whether to also register live with a running engine.
+   */
+  async ensureRhythmMcp(
+    apiToken: string,
+    apiUrl: string,
+    opts?: { configPath?: string; register?: boolean },
+  ): Promise<{ changed: boolean; registered: boolean }> {
+    const { existsSync, readFileSync, writeFileSync, mkdirSync } =
+      require('fs') as typeof import('fs');
+    const { join, dirname } = require('path') as typeof import('path');
+    const { homedir } = require('os') as typeof import('os');
+
+    const configPath =
+      opts?.configPath ??
+      join(homedir(), '.config', 'opencode', 'opencode.json');
+
+    const desired = {
+      type: 'local' as const,
+      command: ['npx', '-y', '@ajhochy/rhythm-mcp-server'],
+      environment: { RHYTHM_API_URL: apiUrl, RHYTHM_API_TOKEN: apiToken },
+    };
+
+    let parsed: Record<string, unknown> = {};
+    if (existsSync(configPath)) {
+      try {
+        parsed = JSON.parse(readFileSync(configPath, 'utf8'));
+      } catch (err) {
+        throw new AppError(
+          502,
+          'SDK_ERROR',
+          `ensureRhythmMcp: could not parse opencode.json: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    const mcpSection = (parsed.mcp as Record<string, unknown> | undefined) ?? {};
+    const existing = mcpSection.rhythm;
+    if (JSON.stringify(existing) === JSON.stringify(desired)) {
+      return { changed: false, registered: false };
+    }
+
+    mcpSection.rhythm = desired;
+    parsed.mcp = mcpSection;
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(configPath, JSON.stringify(parsed, null, 2) + '\n', 'utf8');
+    logger.info('[OpencodeClientService] ensureRhythmMcp: persisted rhythm config');
+
+    let registered = false;
+    if (opts?.register !== false) {
+      try {
+        const client = this.requireClient();
+        await client.mcp.add({ body: { name: 'rhythm', config: desired } });
+        registered = true;
+      } catch (err) {
+        logger.warn(
+          `[OpencodeClientService] ensureRhythmMcp: live registration skipped: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    return { changed: true, registered };
+  }
+
+  /**
    * POST /mcp/{name}/connect — connect a named MCP server.
    *
    * OPC-M4-3: throws AppError on SDK error envelope (never swallows to false).

--- a/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
+++ b/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
@@ -5,16 +5,37 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
+import '../auth/auth_session_store.dart';
 import '../constants/app_constants.dart';
 import '../server/api_server_service.dart';
+import '../services/server_config_service.dart';
 import 'health_poller.dart';
+import 'rhythm_mcp_auto_installer.dart';
 
 enum AgentServerStatus { starting, ready, failed }
 
 class AgentServerController extends ChangeNotifier {
-  AgentServerController(this._service);
+  AgentServerController(
+    this._service, {
+    RhythmMcpAutoInstaller? autoInstaller,
+    ServerConfigService? serverConfigService,
+  })  : _autoInstaller = autoInstaller ?? RhythmMcpAutoInstaller(),
+        _serverConfigService = serverConfigService;
 
   final ApiServerService _service;
+
+  /// F2: installs/refreshes the rhythm MCP server inside the opencode engine
+  /// once the engine is ready, a user is authed, and the cloud server is in
+  /// use. Failures are non-fatal inside the installer.
+  final RhythmMcpAutoInstaller _autoInstaller;
+
+  /// Optional live source of the configured server URL. When absent we fall
+  /// back to [AppConstants.apiBaseUrl] (the cloud baseline).
+  final ServerConfigService? _serverConfigService;
+
+  /// De-dupes auto-install attempts: we only call the installer when the
+  /// session token differs from the last token we installed for.
+  String? _lastInstalledToken;
   AgentServerStatus _status = AgentServerStatus.starting;
   AgentServerFailureReason? _failureReason;
   String? _stderrTail;
@@ -94,8 +115,13 @@ class AgentServerController extends ChangeNotifier {
     notifyListeners();
 
     if (result.ok) {
-      // Fire-and-forget; failures are non-fatal.
-      unawaited(refreshCapabilities());
+      // Fire-and-forget; failures are non-fatal. After capabilities are
+      // detected, attempt the rhythm MCP auto-install (F2) — also fire-and-
+      // forget, gated and de-duped inside _maybeAutoInstallRhythmMcp.
+      unawaited(
+        refreshCapabilities()
+            .whenComplete(() => unawaited(_maybeAutoInstallRhythmMcp())),
+      );
 
       _poller = HealthPoller(
         checkFn: () => _service.checkHealth(AppConstants.agentLocalBaseUrl),
@@ -167,6 +193,39 @@ class AgentServerController extends ChangeNotifier {
         '[AgentServerController] failed to fetch capabilities: $e',
       );
       // _capabilities stays empty; status is unchanged.
+    }
+  }
+
+  /// F2: re-fire the rhythm MCP auto-install when the auth session changes
+  /// (sign-in / token rotation). Safe to call eagerly — the gate and the
+  /// per-token de-dupe make repeat calls cheap no-ops. Wire this wherever the
+  /// app reacts to auth changes.
+  void onAuthChanged() {
+    unawaited(_maybeAutoInstallRhythmMcp());
+  }
+
+  /// Attempts the rhythm MCP auto-install if and only if the engine is ready,
+  /// a user is authenticated, and the configured server is the cloud API.
+  /// De-dupes on the session token so the same token is never installed twice.
+  /// Belt-and-suspenders: the whole body is guarded — never throws.
+  Future<void> _maybeAutoInstallRhythmMcp() async {
+    try {
+      final token = AuthSessionStore.sessionToken;
+      final url = _serverConfigService?.url ?? AppConstants.apiBaseUrl;
+      final gateOpen = shouldAutoInstallRhythmMcp(
+        engineReady: isReady,
+        authenticated: token != null && token.isNotEmpty,
+        isCloudServer: url.contains('api.vcrcapps.com'),
+      );
+      if (!gateOpen) return;
+      // token is non-null here because the gate required authenticated == true.
+      if (token == _lastInstalledToken) return;
+      _lastInstalledToken = token;
+      await _autoInstaller.ensure(apiToken: token!, apiUrl: url);
+    } catch (err) {
+      stderr.writeln(
+        '[AgentServerController] rhythm MCP auto-install attempt failed: $err',
+      );
     }
   }
 

--- a/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
+++ b/apps/desktop_flutter/lib/app/core/agents/agent_server_controller.dart
@@ -220,8 +220,14 @@ class AgentServerController extends ChangeNotifier {
       if (!gateOpen) return;
       // token is non-null here because the gate required authenticated == true.
       if (token == _lastInstalledToken) return;
-      _lastInstalledToken = token;
-      await _autoInstaller.ensure(apiToken: token!, apiUrl: url);
+      // Only mark this token as installed when the installer actually
+      // succeeds. On a false/throw, leave _lastInstalledToken unchanged so a
+      // later trigger (ready hook or onAuthChanged) retries the same token.
+      final installed =
+          await _autoInstaller.ensure(apiToken: token!, apiUrl: url);
+      if (installed) {
+        _lastInstalledToken = token;
+      }
     } catch (err) {
       stderr.writeln(
         '[AgentServerController] rhythm MCP auto-install attempt failed: $err',

--- a/apps/desktop_flutter/lib/app/core/agents/agent_trigger_watcher.dart
+++ b/apps/desktop_flutter/lib/app/core/agents/agent_trigger_watcher.dart
@@ -118,7 +118,15 @@ class AgentTriggerWatcher extends ChangeNotifier {
         _agentServerController = agentServerController,
         _agentsController = agentsController,
         _interval = interval,
-        _httpClient = httpClient ?? http.Client();
+        _httpClient = httpClient ?? http.Client() {
+    // F2: re-fire the rhythm MCP auto-install whenever the auth session
+    // changes (sign-in / token rotation). AuthSessionService notifies its
+    // listeners on token change; the per-token de-dupe inside the controller
+    // makes repeat calls cheap no-ops.
+    _authSessionService.addListener(_onAuthSessionChanged);
+  }
+
+  void _onAuthSessionChanged() => _agentServerController.onAuthChanged();
 
   final ServerConfigService _serverConfigService;
   final AuthSessionService _authSessionService;
@@ -255,6 +263,7 @@ class AgentTriggerWatcher extends ChangeNotifier {
 
   @override
   void dispose() {
+    _authSessionService.removeListener(_onAuthSessionChanged);
     stop();
     _httpClient.close();
     super.dispose();

--- a/apps/desktop_flutter/lib/app/core/agents/rhythm_mcp_auto_installer.dart
+++ b/apps/desktop_flutter/lib/app/core/agents/rhythm_mcp_auto_installer.dart
@@ -5,6 +5,16 @@ import 'package:http/http.dart' as http;
 
 import '../constants/app_constants.dart';
 
+/// All three conditions must hold before auto-installing: the engine is ready,
+/// a user is authenticated, and the configured server is the cloud API (a
+/// localhost-only token cannot be reached by the MCP server process).
+bool shouldAutoInstallRhythmMcp({
+  required bool engineReady,
+  required bool authenticated,
+  required bool isCloudServer,
+}) =>
+    engineReady && authenticated && isCloudServer;
+
 /// Auto-installs (and refreshes) the rhythm MCP server inside the embedded
 /// opencode engine via the local agent server. Failures are non-fatal: a
 /// `false` return means "not installed this time", never an exception that

--- a/apps/desktop_flutter/lib/app/core/agents/rhythm_mcp_auto_installer.dart
+++ b/apps/desktop_flutter/lib/app/core/agents/rhythm_mcp_auto_installer.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import '../constants/app_constants.dart';
+
+/// Auto-installs (and refreshes) the rhythm MCP server inside the embedded
+/// opencode engine via the local agent server. Failures are non-fatal: a
+/// `false` return means "not installed this time", never an exception that
+/// blocks launch or agent sessions.
+class RhythmMcpAutoInstaller {
+  RhythmMcpAutoInstaller({http.Client? httpClient})
+      : _http = httpClient ?? http.Client();
+
+  final http.Client _http;
+
+  Future<bool> ensure({
+    required String apiToken,
+    required String apiUrl,
+  }) async {
+    try {
+      final res = await _http.post(
+        Uri.parse(
+          '${AppConstants.agentLocalBaseUrl}/opencode/mcp/rhythm/ensure',
+        ),
+        headers: const {'Content-Type': 'application/json'},
+        body: jsonEncode({'apiToken': apiToken, 'apiUrl': apiUrl}),
+      );
+      if (res.statusCode >= 200 && res.statusCode < 300) return true;
+      debugPrint(
+        'RhythmMcpAutoInstaller: ensure failed ${res.statusCode}: ${res.body}',
+      );
+      return false;
+    } catch (err) {
+      debugPrint('RhythmMcpAutoInstaller: ensure error $err');
+      return false;
+    }
+  }
+}

--- a/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
+++ b/apps/desktop_flutter/lib/features/settings/views/settings_view.dart
@@ -821,42 +821,62 @@ class _ClaudeIntegrationSectionState extends State<_ClaudeIntegrationSection> {
                     ],
                   ),
                 ),
-                const SizedBox(height: 16),
-                Text(
-                  'Claude Desktop config (~/.claude/claude_desktop_config.json):',
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                    color: context.rhythm.textSecondary,
+                const SizedBox(height: 8),
+                Theme(
+                  data: Theme.of(context).copyWith(
+                    dividerColor: Colors.transparent,
                   ),
-                ),
-                const SizedBox(height: 6),
-                Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: const Color(0xFF1E293B),
-                    borderRadius: BorderRadius.circular(RhythmRadius.md),
-                  ),
-                  child: SelectableText(
-                    '{\n'
-                    '  "mcpServers": {\n'
-                    '    "rhythm": {\n'
-                    '      "command": "npx",\n'
-                    '      "args": ["-y", "@ajhochy/rhythm-mcp-server"],\n'
-                    '      "env": {\n'
-                    '        "RHYTHM_API_URL": "${serverConfig.url}",\n'
-                    '        "RHYTHM_API_TOKEN": "${_tokenVisible ? token : "••••••••"}"\n'
-                    '      }\n'
-                    '    }\n'
-                    '  }\n'
-                    '}',
-                    style: const TextStyle(
-                      fontFamily: 'JetBrainsMono',
-                      fontSize: 12,
-                      color: Color(0xFF94A3B8),
-                      height: 1.6,
+                  child: ExpansionTile(
+                    tilePadding: EdgeInsets.zero,
+                    childrenPadding: EdgeInsets.zero,
+                    expandedCrossAxisAlignment: CrossAxisAlignment.start,
+                    title: Text(
+                      'Advanced: manual MCP setup',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                        color: context.rhythm.textSecondary,
+                      ),
                     ),
+                    children: [
+                      Text(
+                        'Claude Desktop config (~/.claude/claude_desktop_config.json):',
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: context.rhythm.textSecondary,
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF1E293B),
+                          borderRadius: BorderRadius.circular(RhythmRadius.md),
+                        ),
+                        child: SelectableText(
+                          '{\n'
+                          '  "mcpServers": {\n'
+                          '    "rhythm": {\n'
+                          '      "command": "npx",\n'
+                          '      "args": ["-y", "@ajhochy/rhythm-mcp-server"],\n'
+                          '      "env": {\n'
+                          '        "RHYTHM_API_URL": "${serverConfig.url}",\n'
+                          '        "RHYTHM_API_TOKEN": "${_tokenVisible ? token : "••••••••"}"\n'
+                          '      }\n'
+                          '    }\n'
+                          '  }\n'
+                          '}',
+                          style: const TextStyle(
+                            fontFamily: 'JetBrainsMono',
+                            fontSize: 12,
+                            color: Color(0xFF94A3B8),
+                            height: 1.6,
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
                 const SizedBox(height: 8),

--- a/apps/desktop_flutter/lib/features/settings/widgets/mcp_section.dart
+++ b/apps/desktop_flutter/lib/features/settings/widgets/mcp_section.dart
@@ -65,6 +65,32 @@ class _McpSectionState extends State<McpSection> {
         ),
         const SizedBox(height: 12),
 
+        // ── Rhythm install status ──────────────────────────────────────────
+        if (ctrl.servers.any((s) => s.name == 'rhythm')) ...[
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.check_circle,
+                  size: 16,
+                  color: context.rhythm.success,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'Rhythm tools: installed in opencode',
+                  key: const ValueKey('rhythm-mcp-installed'),
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: context.rhythm.success,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+
         // ── Server list card ───────────────────────────────────────────────
         Container(
           padding: const EdgeInsets.all(20),

--- a/apps/desktop_flutter/lib/main.dart
+++ b/apps/desktop_flutter/lib/main.dart
@@ -110,8 +110,10 @@ void main() async {
   )..initialize();
 
   final agentService = ApiServerService();
-  final agentServerController = AgentServerController(agentService)
-    ..initialize();
+  final agentServerController = AgentServerController(
+    agentService,
+    serverConfigService: serverConfigService,
+  )..initialize();
 
   // #614 — Wire SIGINT / SIGTERM listeners so that a terminal kill (Ctrl-C or
   // `kill <pid>`) still shuts down the spawned api_server cleanly.

--- a/apps/desktop_flutter/test/features/agents/agent_trigger_watcher_test.dart
+++ b/apps/desktop_flutter/test/features/agents/agent_trigger_watcher_test.dart
@@ -40,11 +40,19 @@ class _FakeAgentServerController extends AgentServerController {
 
   final bool _ready;
 
+  /// F2: counts how many times the auth-change re-fire hook was invoked.
+  int onAuthChangedCount = 0;
+
   @override
   bool get isReady => _ready;
 
   @override
   bool get hasAnyAgent => _ready;
+
+  @override
+  void onAuthChanged() {
+    onAuthChangedCount++;
+  }
 
   @override
   Future<void> initialize() async {}
@@ -296,6 +304,10 @@ class _StubAuthSessionService extends AuthSessionService {
 
   @override
   bool get isAuthenticated => _token != null;
+
+  /// Test-only: simulate a token change firing [notifyListeners] (as
+  /// signInWithGoogle / restoreSession do on a real token rotation).
+  void simulateAuthChange() => notifyListeners();
 }
 
 // ---------------------------------------------------------------------------
@@ -582,6 +594,52 @@ void main() {
 
       watcher.stop();
       expect(watcher.isPolling, isFalse);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // F2: auth-change re-fire wiring
+  // --------------------------------------------------------------------------
+
+  group('auth-change re-fire (F2)', () {
+    test('AuthSessionService notify drives AgentServerController.onAuthChanged',
+        () {
+      final auth = _StubAuthSessionService(token: 'tok');
+      final watcher = AgentTriggerWatcher(
+        serverConfigService: serverConfigService,
+        authSessionService: auth,
+        agentServerController: agentServerController,
+        agentsController: agentsController,
+      );
+      addTearDown(watcher.dispose);
+
+      expect(agentServerController.onAuthChangedCount, 0);
+
+      auth.simulateAuthChange();
+      expect(agentServerController.onAuthChangedCount, 1);
+
+      auth.simulateAuthChange();
+      expect(agentServerController.onAuthChangedCount, 2);
+    });
+
+    test('listener is removed on dispose (no leak / no further fires)', () {
+      final auth = _StubAuthSessionService(token: 'tok');
+      final watcher = AgentTriggerWatcher(
+        serverConfigService: serverConfigService,
+        authSessionService: auth,
+        agentServerController: agentServerController,
+        agentsController: agentsController,
+      );
+
+      auth.simulateAuthChange();
+      expect(agentServerController.onAuthChangedCount, 1);
+
+      watcher.dispose();
+
+      // After dispose the listener must be gone — further notifications are
+      // no-ops on the controller.
+      auth.simulateAuthChange();
+      expect(agentServerController.onAuthChangedCount, 1);
     });
   });
 }

--- a/apps/desktop_flutter/test/features/agents/f2_rhythm_mcp_autoinstall_test.dart
+++ b/apps/desktop_flutter/test/features/agents/f2_rhythm_mcp_autoinstall_test.dart
@@ -3,9 +3,55 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:rhythm_desktop/app/core/agents/agent_server_controller.dart';
 import 'package:rhythm_desktop/app/core/agents/rhythm_mcp_auto_installer.dart';
+import 'package:rhythm_desktop/app/core/auth/auth_session_store.dart';
+import 'package:rhythm_desktop/app/core/server/api_server_service.dart';
+import 'package:rhythm_desktop/app/core/services/server_config_service.dart';
+
+/// Fake server service that lets [AgentServerController.initialize] reach the
+/// ready state without spawning a real Node process. Mirrors the
+/// `_FakeApiServerService` pattern used in the other agent tests.
+class _FakeApiServerService extends ApiServerService {
+  @override
+  Future<AgentServerStartResult> start() async =>
+      (ok: true, reason: null, stderrTail: null, failureMessage: null);
+
+  @override
+  Future<bool> checkHealth(String baseUrl) async => true;
+
+  @override
+  void stop() {}
+
+  @override
+  Future<void> stopGracefully() async {}
+}
+
+/// Records [ensure] calls and returns a scripted result, so the controller's
+/// retry-on-failure de-dupe can be asserted directly.
+class _FakeAutoInstaller extends RhythmMcpAutoInstaller {
+  _FakeAutoInstaller({required this.result});
+
+  bool result;
+  int ensureCount = 0;
+  final List<String> tokensSeen = <String>[];
+
+  @override
+  Future<bool> ensure({
+    required String apiToken,
+    required String apiUrl,
+  }) async {
+    ensureCount++;
+    tokensSeen.add(apiToken);
+    return result;
+  }
+}
 
 void main() {
+  // HealthPoller (started inside AgentServerController.initialize) uses a
+  // WidgetsBinding-backed timer, so the binding must be initialized.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('RhythmMcpAutoInstaller.ensure', () {
     test('POSTs apiToken + apiUrl to the local agent ensure endpoint',
         () async {
@@ -104,6 +150,69 @@ void main() {
         ),
         isFalse,
       );
+    });
+  });
+
+  group('AgentServerController auto-install retry de-dupe', () {
+    setUp(() => AuthSessionStore.setSessionToken(null));
+    tearDown(() => AuthSessionStore.setSessionToken(null));
+
+    // Drives initialize() to ready while the gate is CLOSED (no token), so the
+    // initialize-time auto-install attempt is a no-op and the test fully
+    // controls subsequent onAuthChanged() fires.
+    Future<AgentServerController> readyController(
+      _FakeAutoInstaller installer,
+    ) async {
+      AuthSessionStore.setSessionToken(null);
+      final controller = AgentServerController(
+        _FakeApiServerService(),
+        autoInstaller: installer,
+        serverConfigService: ServerConfigService(), // defaults to cloud URL
+      );
+      await controller.initialize();
+      // initialize() fires refreshCapabilities().whenComplete(auto-install);
+      // let those microtasks/awaits settle before we assert.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(controller.isReady, isTrue);
+      // Gate was closed (no token), so nothing installed yet.
+      expect(installer.ensureCount, 0);
+      return controller;
+    }
+
+    test('failed ensure() does NOT record token → next call retries', () async {
+      final installer = _FakeAutoInstaller(result: false);
+      final controller = await readyController(installer);
+      addTearDown(controller.dispose);
+
+      AuthSessionStore.setSessionToken('tok-1');
+
+      controller.onAuthChanged();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(installer.ensureCount, 1);
+
+      // ensure returned false → token not recorded → second call retries.
+      controller.onAuthChanged();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(installer.ensureCount, 2);
+      expect(installer.tokensSeen, ['tok-1', 'tok-1']);
+    });
+
+    test('successful ensure() records token → second call is de-duped',
+        () async {
+      final installer = _FakeAutoInstaller(result: true);
+      final controller = await readyController(installer);
+      addTearDown(controller.dispose);
+
+      AuthSessionStore.setSessionToken('tok-1');
+
+      controller.onAuthChanged();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(installer.ensureCount, 1);
+
+      // ensure returned true → token recorded → second call de-duped.
+      controller.onAuthChanged();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(installer.ensureCount, 1);
     });
   });
 }

--- a/apps/desktop_flutter/test/features/agents/f2_rhythm_mcp_autoinstall_test.dart
+++ b/apps/desktop_flutter/test/features/agents/f2_rhythm_mcp_autoinstall_test.dart
@@ -7,7 +7,8 @@ import 'package:rhythm_desktop/app/core/agents/rhythm_mcp_auto_installer.dart';
 
 void main() {
   group('RhythmMcpAutoInstaller.ensure', () {
-    test('POSTs apiToken + apiUrl to the local agent ensure endpoint', () async {
+    test('POSTs apiToken + apiUrl to the local agent ensure endpoint',
+        () async {
       late Map<String, dynamic> body;
       late Uri calledUri;
       final client = MockClient((req) async {
@@ -45,6 +46,63 @@ void main() {
       expect(
         await installer.ensure(apiToken: 't', apiUrl: 'u'),
         false,
+      );
+    });
+  });
+
+  group('shouldAutoInstallRhythmMcp pure gate', () {
+    test('returns true only when all three conditions hold', () {
+      expect(
+        shouldAutoInstallRhythmMcp(
+          engineReady: true,
+          authenticated: true,
+          isCloudServer: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false when the engine is not ready', () {
+      expect(
+        shouldAutoInstallRhythmMcp(
+          engineReady: false,
+          authenticated: true,
+          isCloudServer: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when not authenticated', () {
+      expect(
+        shouldAutoInstallRhythmMcp(
+          engineReady: true,
+          authenticated: false,
+          isCloudServer: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when the server is not the cloud API', () {
+      expect(
+        shouldAutoInstallRhythmMcp(
+          engineReady: true,
+          authenticated: true,
+          isCloudServer: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when all three are false', () {
+      expect(
+        shouldAutoInstallRhythmMcp(
+          engineReady: false,
+          authenticated: false,
+          isCloudServer: false,
+        ),
+        isFalse,
       );
     });
   });

--- a/apps/desktop_flutter/test/features/agents/f2_rhythm_mcp_autoinstall_test.dart
+++ b/apps/desktop_flutter/test/features/agents/f2_rhythm_mcp_autoinstall_test.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:rhythm_desktop/app/core/agents/rhythm_mcp_auto_installer.dart';
+
+void main() {
+  group('RhythmMcpAutoInstaller.ensure', () {
+    test('POSTs apiToken + apiUrl to the local agent ensure endpoint', () async {
+      late Map<String, dynamic> body;
+      late Uri calledUri;
+      final client = MockClient((req) async {
+        calledUri = req.url;
+        body = jsonDecode(req.body) as Map<String, dynamic>;
+        return http.Response('{"changed":true,"registered":true}', 200);
+      });
+
+      final installer = RhythmMcpAutoInstaller(httpClient: client);
+      final ok = await installer.ensure(
+        apiToken: 'tok-1',
+        apiUrl: 'https://api.vcrcapps.com',
+      );
+
+      expect(ok, true);
+      expect(calledUri.path, '/opencode/mcp/rhythm/ensure');
+      expect(calledUri.host, 'localhost');
+      expect(calledUri.port, 4001);
+      expect(body['apiToken'], 'tok-1');
+      expect(body['apiUrl'], 'https://api.vcrcapps.com');
+    });
+
+    test('returns false (non-fatal) on a server error', () async {
+      final client = MockClient((_) async => http.Response('boom', 500));
+      final installer = RhythmMcpAutoInstaller(httpClient: client);
+      expect(
+        await installer.ensure(apiToken: 't', apiUrl: 'u'),
+        false,
+      );
+    });
+
+    test('returns false (non-fatal) when the client throws', () async {
+      final client = MockClient((_) async => throw Exception('network down'));
+      final installer = RhythmMcpAutoInstaller(httpClient: client);
+      expect(
+        await installer.ensure(apiToken: 't', apiUrl: 'u'),
+        false,
+      );
+    });
+  });
+}

--- a/apps/desktop_flutter/test/features/settings/f2_mcp_status_test.dart
+++ b/apps/desktop_flutter/test/features/settings/f2_mcp_status_test.dart
@@ -1,0 +1,115 @@
+/// F2 — Rhythm MCP install status indicator in the MCP section.
+///
+/// When opencode's listed MCP servers include one named 'rhythm', the section
+/// renders a status row keyed ValueKey('rhythm-mcp-installed') containing
+/// "installed". When the list does not include 'rhythm', that key is absent.
+///
+/// Mirrors the harness from opc_m4_3_mcp_section_test.dart: pumps the real
+/// McpSection inside a ChangeNotifierProvider<McpController> backed by a fake
+/// data source whose listServers() returns the injected server list.
+///
+/// Run with:
+///   flutter test test/features/settings/f2_mcp_status_test.dart
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:rhythm_desktop/app/theme/app_theme.dart';
+import 'package:rhythm_desktop/features/settings/controllers/mcp_controller.dart';
+import 'package:rhythm_desktop/features/settings/data/mcp_data_source.dart';
+import 'package:rhythm_desktop/features/settings/widgets/mcp_section.dart';
+
+// ---------------------------------------------------------------------------
+// Fake data source — returns the injected server list from listServers().
+// ---------------------------------------------------------------------------
+
+class _FakeMcpDataSource implements McpDataSource {
+  _FakeMcpDataSource({this.listResult = const []});
+
+  final List<McpServerEntry> listResult;
+
+  @override
+  Future<List<McpServerEntry>> listServers() async => listResult;
+
+  @override
+  Future<void> addServer({
+    required String name,
+    String? command,
+    String? url,
+  }) async {}
+
+  @override
+  Future<void> connectServer(String name) async {}
+
+  @override
+  Future<void> disconnectServer(String name) async {}
+
+  @override
+  Future<void> removeServer(String name) async {}
+}
+
+Widget _wrap(Widget child, McpController ctrl) {
+  return MaterialApp(
+    theme: AppTheme.light(),
+    home: Scaffold(
+      body: ChangeNotifierProvider<McpController>.value(
+        value: ctrl,
+        child: SingleChildScrollView(child: child),
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'f2: server list including "rhythm" renders installed status indicator',
+    (tester) async {
+      final ds = _FakeMcpDataSource(
+        listResult: const [
+          McpServerEntry(name: 'rhythm', status: 'connected'),
+          McpServerEntry(name: 'other-mcp', status: 'connected'),
+        ],
+      );
+      final ctrl = McpController(ds);
+      await ctrl.refresh();
+
+      await tester.pumpWidget(_wrap(const McpSection(), ctrl));
+      await tester.pump();
+
+      final indicator = find.byKey(const ValueKey('rhythm-mcp-installed'));
+      expect(indicator, findsOneWidget,
+          reason: 'installed status indicator must render when "rhythm" '
+              'is in the listed servers');
+      final indicatorText = tester.widget<Text>(indicator);
+      expect(indicatorText.data, contains('installed'),
+          reason: 'indicator text must contain "installed"');
+    },
+  );
+
+  testWidgets(
+    'f2: server list without "rhythm" omits the installed status indicator',
+    (tester) async {
+      final ds = _FakeMcpDataSource(
+        listResult: const [
+          McpServerEntry(name: 'other-mcp', status: 'connected'),
+        ],
+      );
+      final ctrl = McpController(ds);
+      await ctrl.refresh();
+
+      await tester.pumpWidget(_wrap(const McpSection(), ctrl));
+      await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey('rhythm-mcp-installed')),
+        findsNothing,
+        reason: 'installed indicator must be absent when "rhythm" is not '
+            'in the listed servers',
+      );
+    },
+  );
+}


### PR DESCRIPTION
## What & why

Users currently hand-copy a JSON snippet from Settings to wire the rhythm MCP server into opencode. This PR makes the app do it automatically — registering the `rhythm` MCP server with the live production session token + server URL, and keeping it fresh on token rotation.

Feature **F2** of the [single Google/PCO OAuth + MCP auto-install spec](docs/superpowers/specs/2026-06-15-single-google-oauth-and-mcp-autoinstall-design.md). Independent of F1.

## How it works (end to end)

1. **`OpencodeClientService.ensureRhythmMcp(apiToken, apiUrl)`** — idempotently writes `mcp.rhythm` into `~/.config/opencode/opencode.json` with `environment.{RHYTHM_API_URL, RHYTHM_API_TOKEN}` (the exact env keys `apps/mcp_server` reads). **Add** when absent, **rewrite + re-register** when the token/URL changed, **no-op** when identical. Live SDK registration is best-effort; if the engine isn't ready the config is still persisted for next launch.
2. **`POST /opencode/mcp/rhythm/ensure`** (local agent server, `AGENT_LOCAL` bypass) — 400s on missing `apiToken`, else calls `ensureRhythmMcp`. Declared before `/:name/connect` so the literal path isn't shadowed.
3. **`RhythmMcpAutoInstaller`** (Flutter) — POSTs `{apiToken, apiUrl}` to `localhost:4001`; **non-fatal** (returns false, never throws).
4. **Trigger** — pure gate `shouldAutoInstallRhythmMcp(engineReady && authenticated && isCloudServer)`. Fires after the opencode engine is ready + capabilities detected, and re-fires on session-token change via an `AuthSessionService` listener in `AgentTriggerWatcher`. De-duped by last *successfully* installed token (a failed install retries; a genuine token rotation re-installs).
5. **Settings** — shows "Rhythm tools: installed in opencode" when the `rhythm` server is present; the manual JSON snippet is demoted behind an "Advanced: manual MCP setup" expander (token + copy button stay visible).

## Verification

- **api_server:** 792/792 vitest; `tsc --noEmit` clean.
- **Flutter:** `dart format` clean; `flutter analyze --no-fatal-infos` zero errors/warnings; 514/514 tests.
- New tests: ensure diff logic (add/no-op/rewrite/preserve-others), route 400 validation, installer (2xx/500/throw), pure gate, retry-on-failure + de-dupe, auth-change re-fire + listener disposal, Settings status indicator.

## Notes for review

- The production session token is written to `opencode.json` in plaintext and POSTed to `localhost:4001` — consistent with existing handling (Settings already displays it; the manual setup this replaces already instructed putting the same token in a config file). No new exposure.
- `onAuthChanged` re-fire is wired through `AgentTriggerWatcher` (which already holds both `AuthSessionService` and `AgentServerController`); it's inert until the app shell mounts, but the engine-ready hook covers the common install path by then.

## Testing locally

Sign in (cloud server), open an opencode agent session — rhythm tools should be available without any manual config. Settings should show the install-status line. Re-sign-in should refresh the token in `~/.config/opencode/opencode.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)