### PR TITLE
F4: Planning Center Services tools in the rhythm MCP (brokered)

### DIFF
--- a/apps/api_server/src/__tests__/pco_broker.test.ts
+++ b/apps/api_server/src/__tests__/pco_broker.test.ts
@@ -28,6 +28,7 @@ describe('PlanningCenterService.listServiceTypes', () => {
     expect(result).toEqual([{ id: 'st1', name: 'Sunday' }]);
     const [url, init] = fetchMock.mock.calls[0];
     expect(String(url)).toContain('/services/v2/service_types');
+    expect(String(url)).toContain('per_page=100');
     expect((init.headers as Record<string, string>).Authorization).toBe('Bearer at');
   });
 });
@@ -47,5 +48,6 @@ describe('PlanningCenterService.listPlans', () => {
     expect(String(fetchMock.mock.calls[0][0])).toContain(
       '/services/v2/service_types/st1/plans?filter=future',
     );
+    expect(String(fetchMock.mock.calls[0][0])).toContain('per_page=100');
   });
 });

--- a/apps/api_server/src/__tests__/pco_broker.test.ts
+++ b/apps/api_server/src/__tests__/pco_broker.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlanningCenterService } from '../integrations/planning_center/planning_center_service';
+import type { IntegrationAccount } from '../models/integration_account';
+
+function acct(): IntegrationAccount {
+  return {
+    id: 'p', ownerId: 1, provider: 'planning_center', externalAccountId: 's',
+    email: null, displayName: null, status: 'connected',
+    accessToken: 'at', refreshToken: 'rt', scope: 'openid services',
+    tokenType: 'Bearer', expiresAt: null, lastSyncedAt: null,
+    errorMessage: null, createdAt: '', updatedAt: '',
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('PlanningCenterService.listServiceTypes', () => {
+  it('GETs service_types with the account bearer token', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: [{ id: 'st1', attributes: { name: 'Sunday' } }] }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const svc = new PlanningCenterService();
+    const result = await svc.listServiceTypes(acct());
+    expect(result).toEqual([{ id: 'st1', name: 'Sunday' }]);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain('/services/v2/service_types');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer at');
+  });
+});
+
+describe('PlanningCenterService.listPlans', () => {
+  it('GETs future plans for a service type', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: [{ id: 'p1', attributes: { title: 'Plan A', dates: 'Jan 5' } }] }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const svc = new PlanningCenterService();
+    const result = await svc.listPlans(acct(), 'st1');
+    expect(result).toEqual([{ id: 'p1', title: 'Plan A', dates: 'Jan 5' }]);
+    expect(String(fetchMock.mock.calls[0][0])).toContain(
+      '/services/v2/service_types/st1/plans?filter=future',
+    );
+  });
+});

--- a/apps/api_server/src/__tests__/pco_broker.test.ts
+++ b/apps/api_server/src/__tests__/pco_broker.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { PlanningCenterService } from '../integrations/planning_center/planning_center_service';
+import { PlanningCenterService, PcoPermissionError } from '../integrations/planning_center/planning_center_service';
 import type { IntegrationAccount } from '../models/integration_account';
 
 function acct(): IntegrationAccount {
@@ -49,5 +49,41 @@ describe('PlanningCenterService.listPlans', () => {
       '/services/v2/service_types/st1/plans?filter=future',
     );
     expect(String(fetchMock.mock.calls[0][0])).toContain('per_page=100');
+  });
+});
+
+describe('PlanningCenterService.updatePlanItem', () => {
+  it('PATCHes the item and returns its id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: { id: 'i1', attributes: { title: 'New' } } }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const svc = new PlanningCenterService();
+    const res = await svc.updatePlanItem(acct(), 'st1', 'p1', 'i1', { title: 'New' });
+    expect(res.id).toBe('i1');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain(
+      '/services/v2/service_types/st1/plans/p1/items/i1',
+    );
+    expect(init.method).toBe('PATCH');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+      'application/json',
+    );
+    const body = JSON.parse(init.body as string);
+    expect(body.data.attributes.title).toBe('New');
+  });
+
+  it('maps a PCO 403 to PcoPermissionError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('forbidden', { status: 403 })),
+    );
+    const svc = new PlanningCenterService();
+    await expect(
+      svc.updatePlanItem(acct(), 'st1', 'p1', 'i1', { title: 'X' }),
+    ).rejects.toBeInstanceOf(PcoPermissionError);
   });
 });

--- a/apps/api_server/src/__tests__/pco_broker_routes.test.ts
+++ b/apps/api_server/src/__tests__/pco_broker_routes.test.ts
@@ -1,0 +1,212 @@
+/**
+ * ROUTE-LEVEL tests for the PCO broker routes — driven through the REAL Express
+ * router, controller, and error handler. The service layer (IntegrationsService
+ * + PlanningCenterService) is mocked so no real PCO/network/DB is hit.
+ *
+ *   fetch -> express(pcoBrokerRouter) -> PcoBrokerController (REAL)
+ *         -> IntegrationsService (MOCKED) + PlanningCenterService (MOCKED)
+ *
+ * requireAuth strictly requires a real Bearer token (AGENT_LOCAL does not bypass
+ * /integrations). Rather than skip it, the REAL pcoBrokerRouter (which mounts
+ * requireAuth itself) is mounted on a tiny express app; AuthService is stubbed
+ * so any Bearer token resolves to user id 1. This exercises the full
+ * router+requireAuth+controller+error-handler stack with a known identity.
+ *
+ * Run with:
+ *   cd apps/api_server && npx vitest run src/__tests__/pco_broker_routes.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { AddressInfo } from 'net';
+import http from 'http';
+
+// --- Mock the service layer the controller depends on. ----------------------
+// Stubs declared via vi.hoisted so they exist before the hoisted vi.mock
+// factories run.
+const stubs = vi.hoisted(() => ({
+  freshAccount: { id: 7, provider: 'planning_center', accessToken: 'tok' },
+  ensureFreshPlanningCenterAccount: vi.fn(),
+  listServiceTypes: vi.fn(),
+  listPlans: vi.fn(),
+  listPlanItems: vi.fn(),
+  listNeededPositions: vi.fn(),
+  updatePlanItem: vi.fn(),
+  assignPersonToPlan: vi.fn(),
+  updateScheduledPerson: vi.fn(),
+}));
+const {
+  freshAccount,
+  ensureFreshPlanningCenterAccount,
+  listServiceTypes,
+  listPlans,
+  listPlanItems,
+  listNeededPositions,
+  updatePlanItem,
+  assignPersonToPlan,
+  updateScheduledPerson,
+} = stubs;
+
+// requireAuth (mounted inside pcoBrokerRouter) strictly demands a Bearer token
+// and resolves it via AuthService — AGENT_LOCAL does NOT bypass /integrations.
+// Stub AuthService so any token maps to user id 1; the test sends a token.
+vi.mock('../services/auth_service', () => ({
+  AuthService: class {
+    getUserForSessionToken = vi.fn().mockResolvedValue({ id: 1 });
+  },
+}));
+
+vi.mock('../services/integrations_service', () => ({
+  IntegrationsService: class {
+    ensureFreshPlanningCenterAccount = stubs.ensureFreshPlanningCenterAccount;
+  },
+}));
+
+vi.mock('../integrations/planning_center/planning_center_service', async () => {
+  // Keep the REAL PcoPermissionError so `instanceof` checks in the controller
+  // match what the (mocked) service methods throw.
+  const actual = await vi.importActual<
+    typeof import('../integrations/planning_center/planning_center_service')
+  >('../integrations/planning_center/planning_center_service');
+  return {
+    PcoPermissionError: actual.PcoPermissionError,
+    PlanningCenterService: class {
+      listServiceTypes = stubs.listServiceTypes;
+      listPlans = stubs.listPlans;
+      listPlanItems = stubs.listPlanItems;
+      listNeededPositions = stubs.listNeededPositions;
+      updatePlanItem = stubs.updatePlanItem;
+      assignPersonToPlan = stubs.assignPersonToPlan;
+      updateScheduledPerson = stubs.updateScheduledPerson;
+    },
+  };
+});
+
+import express from 'express';
+import { pcoBrokerRouter } from '../routes/pco_broker_routes';
+import { errorHandler } from '../middleware/error_handler';
+import { PcoPermissionError } from '../integrations/planning_center/planning_center_service';
+
+let server: http.Server;
+let base: string;
+
+async function req(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  const res = await fetch(`${base}${path}`, {
+    method,
+    headers: {
+      authorization: 'Bearer test-token',
+      ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let parsed: unknown = null;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+  }
+  return { status: res.status, body: parsed };
+}
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/integrations/planning-center/api', pcoBrokerRouter);
+  app.use(errorHandler);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', resolve);
+  });
+  const addr = server.address() as AddressInfo;
+  base = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ensureFreshPlanningCenterAccount.mockResolvedValue(freshAccount);
+});
+
+describe('GET /integrations/planning-center/api/service-types', () => {
+  it('returns 200 with the service data and passes the fresh account', async () => {
+    const known = [{ id: 'st1', name: 'Sunday' }];
+    listServiceTypes.mockResolvedValue(known);
+
+    const { status, body } = await req('GET', '/integrations/planning-center/api/service-types');
+
+    expect(status).toBe(200);
+    expect(body).toEqual(known);
+    expect(ensureFreshPlanningCenterAccount).toHaveBeenCalledWith(1);
+    expect(listServiceTypes).toHaveBeenCalledWith(freshAccount);
+  });
+});
+
+describe('PCO permission denial signaling', () => {
+  it('maps PcoPermissionError to HTTP 403 with code pco_permission_denied (not 500)', async () => {
+    listServiceTypes.mockRejectedValue(new PcoPermissionError('nope'));
+
+    const { status, body } = await req('GET', '/integrations/planning-center/api/service-types');
+
+    expect(status).toBe(403);
+    expect(body.code).toBe('pco_permission_denied');
+    expect(body.message).toBe('nope');
+  });
+});
+
+describe('write routes', () => {
+  it('PATCH item with attributes forwards the attributes object', async () => {
+    updatePlanItem.mockResolvedValue({ id: 'i1' });
+    const { status, body } = await req(
+      'PATCH',
+      '/integrations/planning-center/api/service-types/st1/plans/p1/items/i1',
+      { attributes: { length: 300 } },
+    );
+    expect(status).toBe(200);
+    expect(body).toEqual({ id: 'i1' });
+    expect(updatePlanItem).toHaveBeenCalledWith(freshAccount, 'st1', 'p1', 'i1', {
+      length: 300,
+    });
+  });
+
+  it('PATCH item without attributes builds { title } from req.body.title', async () => {
+    updatePlanItem.mockResolvedValue({ id: 'i1' });
+    await req(
+      'PATCH',
+      '/integrations/planning-center/api/service-types/st1/plans/p1/items/i1',
+      { title: 'New title' },
+    );
+    expect(updatePlanItem).toHaveBeenCalledWith(freshAccount, 'st1', 'p1', 'i1', {
+      title: 'New title',
+    });
+  });
+
+  it('POST team-members forwards personId, teamId, positionName', async () => {
+    assignPersonToPlan.mockResolvedValue({ id: 'm1' });
+    const { status } = await req(
+      'POST',
+      '/integrations/planning-center/api/plans/p1/team-members',
+      { personId: 'pe1', teamId: 't1', positionName: 'Guitar' },
+    );
+    expect(status).toBe(200);
+    expect(assignPersonToPlan).toHaveBeenCalledWith(freshAccount, 'p1', 'pe1', 't1', 'Guitar');
+  });
+
+  it('PATCH team-members forwards status', async () => {
+    updateScheduledPerson.mockResolvedValue({ id: 'm1' });
+    const { status } = await req(
+      'PATCH',
+      '/integrations/planning-center/api/plans/p1/team-members/m1',
+      { status: 'C' },
+    );
+    expect(status).toBe(200);
+    expect(updateScheduledPerson).toHaveBeenCalledWith(freshAccount, 'p1', 'm1', 'C');
+  });
+});

--- a/apps/api_server/src/app.ts
+++ b/apps/api_server/src/app.ts
@@ -10,6 +10,7 @@ import { facilitiesRouter } from './routes/facilities_routes';
 import { dashboardRouter } from './routes/dashboard_routes';
 import { healthRouter } from './routes/health_routes';
 import { integrationsRouter } from './routes/integrations_routes';
+import { pcoBrokerRouter } from './routes/pco_broker_routes';
 import { messagesRouter } from './routes/messages_routes';
 import { projectInstancesRouter } from './routes/project_instances_routes';
 import { projectTemplatesRouter } from './routes/project_templates_routes';
@@ -67,6 +68,7 @@ export function createApp() {
   app.use('/auth', authRouter);
   app.use('/automation-catalog', automationCatalogRouter);
   app.use('/automation-rules', automationRulesRouter);
+  app.use('/integrations/planning-center/api', pcoBrokerRouter);
   app.use('/integrations', integrationsRouter);
   app.use('/tasks', tasksRouter);
   app.use('/project-templates', projectTemplatesRouter);

--- a/apps/api_server/src/controllers/pco_broker_controller.ts
+++ b/apps/api_server/src/controllers/pco_broker_controller.ts
@@ -1,0 +1,137 @@
+import type { NextFunction, Request, Response } from 'express';
+import {
+  PcoPermissionError,
+  PlanningCenterService,
+} from '../integrations/planning_center/planning_center_service';
+import { IntegrationsService } from '../services/integrations_service';
+
+const integrationsService = new IntegrationsService();
+const planningCenter = new PlanningCenterService();
+
+/**
+ * Broker routes that expose PlanningCenterService read/write helpers to the
+ * rhythm MCP server. Each handler resolves the stored planning_center account
+ * (refreshing the token first), then calls the corresponding service method.
+ * A PCO 403 surfaces as PcoPermissionError and is translated to HTTP 403 with a
+ * machine-readable code so callers can distinguish a permission denial from a
+ * generic failure.
+ */
+export class PcoBrokerController {
+  private handle<T>(
+    res: Response,
+    next: NextFunction,
+    work: () => Promise<T>,
+  ): void {
+    work()
+      .then((result) => {
+        res.json(result);
+      })
+      .catch((err) => {
+        if (err instanceof PcoPermissionError) {
+          res
+            .status(403)
+            .json({ code: 'pco_permission_denied', message: err.message });
+          return;
+        }
+        next(err);
+      });
+  }
+
+  listServiceTypes(req: Request, res: Response, next: NextFunction) {
+    this.handle(res, next, async () => {
+      const account = await integrationsService.ensureFreshPlanningCenterAccount(
+        req.auth!.user.id,
+      );
+      return planningCenter.listServiceTypes(account);
+    });
+  }
+
+  listPlans(req: Request, res: Response, next: NextFunction) {
+    this.handle(res, next, async () => {
+      const account = await integrationsService.ensureFreshPlanningCenterAccount(
+        req.auth!.user.id,
+      );
+      return planningCenter.listPlans(account, req.params.serviceTypeId);
+    });
+  }
+
+  listPlanItems(req: Request, res: Response, next: NextFunction) {
+    this.handle(res, next, async () => {
+      const account = await integrationsService.ensureFreshPlanningCenterAccount(
+        req.auth!.user.id,
+      );
+      return planningCenter.listPlanItems(
+        account,
+        req.params.serviceTypeId,
+        req.params.planId,
+      );
+    });
+  }
+
+  listNeededPositions(req: Request, res: Response, next: NextFunction) {
+    this.handle(res, next, async () => {
+      const account = await integrationsService.ensureFreshPlanningCenterAccount(
+        req.auth!.user.id,
+      );
+      return planningCenter.listNeededPositions(
+        account,
+        req.params.serviceTypeId,
+        req.params.planId,
+      );
+    });
+  }
+
+  updatePlanItem(req: Request, res: Response, next: NextFunction) {
+    this.handle(res, next, async () => {
+      const account = await integrationsService.ensureFreshPlanningCenterAccount(
+        req.auth!.user.id,
+      );
+      const body = req.body as Record<string, unknown>;
+      const attributes =
+        body.attributes && typeof body.attributes === 'object'
+          ? (body.attributes as Record<string, unknown>)
+          : { title: body.title };
+      return planningCenter.updatePlanItem(
+        account,
+        req.params.serviceTypeId,
+        req.params.planId,
+        req.params.itemId,
+        attributes,
+      );
+    });
+  }
+
+  assignPersonToPlan(req: Request, res: Response, next: NextFunction) {
+    this.handle(res, next, async () => {
+      const account = await integrationsService.ensureFreshPlanningCenterAccount(
+        req.auth!.user.id,
+      );
+      const { personId, teamId, positionName } = req.body as Record<
+        string,
+        string
+      >;
+      return planningCenter.assignPersonToPlan(
+        account,
+        req.params.planId,
+        personId,
+        teamId,
+        positionName,
+      );
+    });
+  }
+
+  updateScheduledPerson(req: Request, res: Response, next: NextFunction) {
+    this.handle(res, next, async () => {
+      const account = await integrationsService.ensureFreshPlanningCenterAccount(
+        req.auth!.user.id,
+      );
+      const { status } = req.body as Record<string, string>;
+      return planningCenter.updateScheduledPerson(
+        account,
+        req.params.planId,
+        req.params.memberId,
+        status,
+      );
+    });
+  }
+}

--- a/apps/api_server/src/integrations/planning_center/planning_center_service.ts
+++ b/apps/api_server/src/integrations/planning_center/planning_center_service.ts
@@ -629,6 +629,58 @@ export class PlanningCenterService {
     return signals;
   }
 
+  async listServiceTypes(account: IntegrationAccount) {
+    const res = await this.getJson(account, '/services/v2/service_types');
+    return (res.data ?? []).map((r) => ({
+      id: r.id,
+      name: (r.attributes?.name as string) ?? '',
+    }));
+  }
+
+  async listPlans(account: IntegrationAccount, serviceTypeId: string) {
+    const res = await this.getJson(
+      account,
+      `/services/v2/service_types/${serviceTypeId}/plans?filter=future`,
+    );
+    return (res.data ?? []).map((r) => ({
+      id: r.id,
+      title: (r.attributes?.title as string) ?? null,
+      dates: (r.attributes?.dates as string) ?? null,
+    }));
+  }
+
+  async listPlanItems(
+    account: IntegrationAccount,
+    serviceTypeId: string,
+    planId: string,
+  ) {
+    const res = await this.getJson(
+      account,
+      `/services/v2/service_types/${serviceTypeId}/plans/${planId}/items`,
+    );
+    return (res.data ?? []).map((r) => ({
+      id: r.id,
+      title: (r.attributes?.title as string) ?? null,
+      type: (r.attributes?.item_type as string) ?? null,
+    }));
+  }
+
+  async listNeededPositions(
+    account: IntegrationAccount,
+    serviceTypeId: string,
+    planId: string,
+  ) {
+    const res = await this.getJson(
+      account,
+      `/services/v2/service_types/${serviceTypeId}/plans/${planId}/needed_positions`,
+    );
+    return (res.data ?? []).map((r) => ({
+      id: r.id,
+      teamPositionName: (r.attributes?.team_position_name as string) ?? null,
+      quantity: (r.attributes?.quantity as number) ?? null,
+    }));
+  }
+
   async fetchServiceItems(
     account: IntegrationAccount,
     serviceTypeId: string,

--- a/apps/api_server/src/integrations/planning_center/planning_center_service.ts
+++ b/apps/api_server/src/integrations/planning_center/planning_center_service.ts
@@ -176,6 +176,15 @@ function isoDate(value: string | null): string | null {
 
 const SPECIAL_SERVICE_TEMPLATE_NAME = 'special service project';
 
+export class PcoPermissionError extends Error {
+  constructor(
+    message = 'Insufficient Planning Center permissions for this action.',
+  ) {
+    super(message);
+    this.name = 'PcoPermissionError';
+  }
+}
+
 export class PlanningCenterService {
   async collectAutomationSignals(
     account: IntegrationAccount,
@@ -699,6 +708,94 @@ export class PlanningCenterService {
         sequence: (attrs.sequence as number) ?? 0,
       };
     });
+  }
+
+  private async sendJson(
+    account: IntegrationAccount,
+    method: 'POST' | 'PATCH' | 'DELETE',
+    path: string,
+    body?: unknown,
+  ): Promise<JsonApiResponse> {
+    const response = await fetch(
+      `https://api.planningcenteronline.com${path}`,
+      {
+        method,
+        headers: {
+          Authorization: `Bearer ${account.accessToken}`,
+          'User-Agent': 'Rhythm (https://github.com/ajhochy/Rhythm)',
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      },
+    );
+    if (response.status === 403) {
+      throw new PcoPermissionError();
+    }
+    if (!response.ok) {
+      const text = await response.text();
+      throw AppError.badRequest(`Planning Center request failed: ${text}`);
+    }
+    return (await response.json()) as JsonApiResponse;
+  }
+
+  async updatePlanItem(
+    account: IntegrationAccount,
+    serviceTypeId: string,
+    planId: string,
+    itemId: string,
+    attributes: Record<string, unknown>,
+  ): Promise<{ id: string }> {
+    const res = await this.sendJson(
+      account,
+      'PATCH',
+      `/services/v2/service_types/${serviceTypeId}/plans/${planId}/items/${itemId}`,
+      { data: { type: 'Item', id: itemId, attributes } },
+    );
+    const data = res.data as unknown as { id?: string } | undefined;
+    return { id: data?.id ?? itemId };
+  }
+
+  async assignPersonToPlan(
+    account: IntegrationAccount,
+    planId: string,
+    personId: string,
+    teamId: string,
+    positionName: string,
+  ): Promise<{ id: string }> {
+    const res = await this.sendJson(
+      account,
+      'POST',
+      `/services/v2/plans/${planId}/team_members`,
+      {
+        data: {
+          type: 'PlanPerson',
+          attributes: { team_position_name: positionName },
+          relationships: {
+            person: { data: { type: 'Person', id: personId } },
+            team: { data: { type: 'Team', id: teamId } },
+          },
+        },
+      },
+    );
+    const data = res.data as unknown as { id?: string } | undefined;
+    return { id: data?.id ?? '' };
+  }
+
+  async updateScheduledPerson(
+    account: IntegrationAccount,
+    planId: string,
+    memberId: string,
+    status: string,
+  ): Promise<{ id: string }> {
+    const res = await this.sendJson(
+      account,
+      'PATCH',
+      `/services/v2/plans/${planId}/team_members/${memberId}`,
+      { data: { type: 'PlanPerson', id: memberId, attributes: { status } } },
+    );
+    const data = res.data as unknown as { id?: string } | undefined;
+    return { id: data?.id ?? memberId };
   }
 
   private async getJson(

--- a/apps/api_server/src/integrations/planning_center/planning_center_service.ts
+++ b/apps/api_server/src/integrations/planning_center/planning_center_service.ts
@@ -630,22 +630,22 @@ export class PlanningCenterService {
   }
 
   async listServiceTypes(account: IntegrationAccount) {
-    const res = await this.getJson(account, '/services/v2/service_types');
+    const res = await this.getJson(account, '/services/v2/service_types?per_page=100');
     return (res.data ?? []).map((r) => ({
       id: r.id,
-      name: (r.attributes?.name as string) ?? '',
+      name: (r.attributes?.name as string | undefined) ?? '',
     }));
   }
 
   async listPlans(account: IntegrationAccount, serviceTypeId: string) {
     const res = await this.getJson(
       account,
-      `/services/v2/service_types/${serviceTypeId}/plans?filter=future`,
+      `/services/v2/service_types/${serviceTypeId}/plans?filter=future&per_page=100`,
     );
     return (res.data ?? []).map((r) => ({
       id: r.id,
-      title: (r.attributes?.title as string) ?? null,
-      dates: (r.attributes?.dates as string) ?? null,
+      title: (r.attributes?.title as string | undefined) ?? null,
+      dates: (r.attributes?.dates as string | undefined) ?? null,
     }));
   }
 
@@ -656,12 +656,12 @@ export class PlanningCenterService {
   ) {
     const res = await this.getJson(
       account,
-      `/services/v2/service_types/${serviceTypeId}/plans/${planId}/items`,
+      `/services/v2/service_types/${serviceTypeId}/plans/${planId}/items?per_page=100`,
     );
     return (res.data ?? []).map((r) => ({
       id: r.id,
-      title: (r.attributes?.title as string) ?? null,
-      type: (r.attributes?.item_type as string) ?? null,
+      title: (r.attributes?.title as string | undefined) ?? null,
+      type: (r.attributes?.item_type as string | undefined) ?? null,
     }));
   }
 
@@ -672,12 +672,12 @@ export class PlanningCenterService {
   ) {
     const res = await this.getJson(
       account,
-      `/services/v2/service_types/${serviceTypeId}/plans/${planId}/needed_positions`,
+      `/services/v2/service_types/${serviceTypeId}/plans/${planId}/needed_positions?per_page=100`,
     );
     return (res.data ?? []).map((r) => ({
       id: r.id,
-      teamPositionName: (r.attributes?.team_position_name as string) ?? null,
-      quantity: (r.attributes?.quantity as number) ?? null,
+      teamPositionName: (r.attributes?.team_position_name as string | undefined) ?? null,
+      quantity: (r.attributes?.quantity as number | undefined) ?? null,
     }));
   }
 

--- a/apps/api_server/src/routes/pco_broker_routes.ts
+++ b/apps/api_server/src/routes/pco_broker_routes.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import { PcoBrokerController } from '../controllers/pco_broker_controller';
+import { requireAuth } from '../middleware/auth_middleware';
+
+const controller = new PcoBrokerController();
+export const pcoBrokerRouter = Router();
+
+pcoBrokerRouter.use(requireAuth);
+
+pcoBrokerRouter.get(
+  '/service-types',
+  controller.listServiceTypes.bind(controller),
+);
+pcoBrokerRouter.get(
+  '/service-types/:serviceTypeId/plans',
+  controller.listPlans.bind(controller),
+);
+pcoBrokerRouter.get(
+  '/service-types/:serviceTypeId/plans/:planId/items',
+  controller.listPlanItems.bind(controller),
+);
+pcoBrokerRouter.get(
+  '/service-types/:serviceTypeId/plans/:planId/needed-positions',
+  controller.listNeededPositions.bind(controller),
+);
+pcoBrokerRouter.patch(
+  '/service-types/:serviceTypeId/plans/:planId/items/:itemId',
+  controller.updatePlanItem.bind(controller),
+);
+pcoBrokerRouter.post(
+  '/plans/:planId/team-members',
+  controller.assignPersonToPlan.bind(controller),
+);
+pcoBrokerRouter.patch(
+  '/plans/:planId/team-members/:memberId',
+  controller.updateScheduledPerson.bind(controller),
+);

--- a/apps/api_server/src/services/integrations_service.ts
+++ b/apps/api_server/src/services/integrations_service.ts
@@ -504,6 +504,16 @@ export class IntegrationsService {
     }
   }
 
+  async ensureFreshPlanningCenterAccount(
+    userId: number,
+  ): Promise<IntegrationAccount> {
+    const account = await this.ensureFreshAccount("planning_center", userId);
+    if (!account || !account.accessToken) {
+      throw AppError.badRequest("Planning Center is not connected");
+    }
+    return account;
+  }
+
   private async ensureFreshAccount(
     provider: "google_calendar" | "gmail" | "planning_center",
     userId: number,

--- a/apps/mcp_server/src/index.ts
+++ b/apps/mcp_server/src/index.ts
@@ -12,6 +12,7 @@ import { registerDashboardTools } from './tools/dashboard.js';
 import { registerClaudeTriggerTools } from './tools/claude_triggers.js';
 import { registerAutomationTools } from './tools/automations.js';
 import { registerNotificationTools } from './tools/notifications.js';
+import { registerPcoTools } from './tools/pco.js';
 
 const RHYTHM_API_URL = process.env.RHYTHM_API_URL ?? 'https://api.vcrcapps.com';
 const RHYTHM_API_TOKEN = process.env.RHYTHM_API_TOKEN ?? '';
@@ -41,6 +42,7 @@ registerDashboardTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerClaudeTriggerTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerAutomationTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerNotificationTools(server, RHYTHM_AGENT_URL);
+registerPcoTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 
 // Connect over stdio (Claude Desktop / Claude Code MCP transport)
 const transport = new StdioServerTransport();

--- a/apps/mcp_server/src/tools/__tests__/pco.test.ts
+++ b/apps/mcp_server/src/tools/__tests__/pco.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { registerPcoTools } from '../pco.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: true;
+}>;
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  shape: Record<string, unknown>;
+  handler: ToolHandler;
+}
+
+function makeStubServer(): { server: unknown; tools: Map<string, RegisteredTool> } {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    tool(name: string, description: string, shape: Record<string, unknown>, handler: ToolHandler) {
+      tools.set(name, { name, description, shape, handler });
+    },
+  };
+  return { server, tools };
+}
+
+const API_URL = 'http://x';
+const API_TOKEN = 'tok';
+
+function makeFetchOk(body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  });
+}
+
+function makeFetch403() {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status: 403,
+    json: async () => ({ error: 'Forbidden' }),
+  });
+}
+
+describe('registerPcoTools — rhythm_pco_list_plans', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('calls the correct broker URL with Bearer token and returns JSON as tool text', async () => {
+    const plans = [{ id: '1', title: 'June 22 Service' }];
+    const mockFetch = makeFetchOk(plans);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerPcoTools(server as any, API_URL, API_TOKEN);
+
+    const res = await tools.get('rhythm_pco_list_plans')!.handler({ service_type_id: '123' });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://x/integrations/planning-center/api/service-types/123/plans');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer tok');
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0].text).toContain('June 22 Service');
+  });
+
+  it('returns a friendly isError result when the API responds with HTTP 403', async () => {
+    const mockFetch = makeFetch403();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerPcoTools(server as any, API_URL, API_TOKEN);
+
+    const res = await tools.get('rhythm_pco_list_plans')!.handler({ service_type_id: '123' });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text.toLowerCase()).toContain('planning center');
+    // Should NOT surface a raw stack or "Rhythm API error 403" verbatim
+    expect(res.content[0].text).not.toContain('Rhythm API error 403');
+  });
+});
+
+describe('registerPcoTools — rhythm_pco_list_service_types', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('calls the service-types broker endpoint and returns results', async () => {
+    const serviceTypes = [{ id: '5', name: 'Sunday Morning' }];
+    const mockFetch = makeFetchOk(serviceTypes);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerPcoTools(server as any, API_URL, API_TOKEN);
+
+    const res = await tools.get('rhythm_pco_list_service_types')!.handler({});
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('http://x/integrations/planning-center/api/service-types');
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0].text).toContain('Sunday Morning');
+  });
+});

--- a/apps/mcp_server/src/tools/pco.ts
+++ b/apps/mcp_server/src/tools/pco.ts
@@ -1,0 +1,115 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { apiGet, apiPost, apiPatch, toolResult, toolError, RhythmApiError } from '../api_client.js';
+import { registerTool } from './_tool.js';
+
+function handleErr(err: unknown) {
+  if (err instanceof RhythmApiError && err.status === 403) {
+    return toolError(
+      new Error(
+        'Your Planning Center account lacks permission for this action. ' +
+        'A PCO admin must grant the needed role/permission.',
+      ),
+    );
+  }
+  return toolError(err);
+}
+
+export function registerPcoTools(server: McpServer, apiUrl: string, apiToken: string) {
+  registerTool(server, 'rhythm_pco_list_service_types',
+    'List Planning Center Services service types (e.g. "Sunday Morning"). Returns id and name for each.',
+    {},
+    async () => {
+      try {
+        const data = await apiGet<unknown>(apiUrl, apiToken, '/integrations/planning-center/api/service-types');
+        return toolResult(JSON.stringify(data, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_pco_list_plans',
+    'List upcoming (future) Planning Center plans for a service type. Returns id, title, dates.',
+    { service_type_id: z.string().describe('Service type id from rhythm_pco_list_service_types.') },
+    async ({ service_type_id }: { service_type_id: string }) => {
+      try {
+        const data = await apiGet<unknown>(apiUrl, apiToken, `/integrations/planning-center/api/service-types/${service_type_id}/plans`);
+        return toolResult(JSON.stringify(data, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_pco_get_plan_items',
+    'List the items (songs, sermons, etc.) in a Planning Center plan. Returns id, title, type.',
+    {
+      service_type_id: z.string().describe('Service type id.'),
+      plan_id: z.string().describe('Plan id from rhythm_pco_list_plans.'),
+    },
+    async ({ service_type_id, plan_id }: { service_type_id: string; plan_id: string }) => {
+      try {
+        const data = await apiGet<unknown>(apiUrl, apiToken, `/integrations/planning-center/api/service-types/${service_type_id}/plans/${plan_id}/items`);
+        return toolResult(JSON.stringify(data, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_pco_list_needed_positions',
+    'List unfilled/needed positions for a Planning Center plan. Returns id, teamPositionName, quantity.',
+    {
+      service_type_id: z.string().describe('Service type id.'),
+      plan_id: z.string().describe('Plan id.'),
+    },
+    async ({ service_type_id, plan_id }: { service_type_id: string; plan_id: string }) => {
+      try {
+        const data = await apiGet<unknown>(apiUrl, apiToken, `/integrations/planning-center/api/service-types/${service_type_id}/plans/${plan_id}/needed-positions`);
+        return toolResult(JSON.stringify(data, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_pco_update_plan_item',
+    'Update a Planning Center plan item (e.g. its title). Requires PCO edit permission.',
+    {
+      service_type_id: z.string(),
+      plan_id: z.string(),
+      item_id: z.string(),
+      title: z.string().describe('New item title.'),
+    },
+    async ({ service_type_id, plan_id, item_id, title }: { service_type_id: string; plan_id: string; item_id: string; title: string }) => {
+      try {
+        const data = await apiPatch<unknown>(apiUrl, apiToken, `/integrations/planning-center/api/service-types/${service_type_id}/plans/${plan_id}/items/${item_id}`, { title });
+        return toolResult(JSON.stringify(data, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_pco_assign_person',
+    'Assign a person to a position on a Planning Center plan. Requires PCO scheduling permission.',
+    {
+      plan_id: z.string(),
+      person_id: z.string(),
+      team_id: z.string(),
+      position_name: z.string(),
+    },
+    async ({ plan_id, person_id, team_id, position_name }: { plan_id: string; person_id: string; team_id: string; position_name: string }) => {
+      try {
+        const data = await apiPost<unknown>(apiUrl, apiToken, `/integrations/planning-center/api/plans/${plan_id}/team-members`, { personId: person_id, teamId: team_id, positionName: position_name });
+        return toolResult(JSON.stringify(data, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_pco_update_scheduled_person',
+    "Update a scheduled person's status on a plan (e.g. confirm/decline). Requires PCO scheduling permission.",
+    {
+      plan_id: z.string(),
+      member_id: z.string(),
+      status: z.string().describe('New status, e.g. "C" (confirmed) or "D" (declined).'),
+    },
+    async ({ plan_id, member_id, status }: { plan_id: string; member_id: string; status: string }) => {
+      try {
+        const data = await apiPatch<unknown>(apiUrl, apiToken, `/integrations/planning-center/api/plans/${plan_id}/team-members/${member_id}`, { status });
+        return toolResult(JSON.stringify(data, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+}


### PR DESCRIPTION
## What & why

Exposes Planning Center (PCO) **Services** read/write tools to opencode through the rhythm MCP server, brokered by the Rhythm backend using the PCO OAuth credential **already captured** on the Integrations page. **No re-consent** — the existing `services` scope suffices, and PCO governs writes by the signed-in user's role.

Feature **F4** of the [single Google/PCO OAuth + MCP auto-install spec](docs/superpowers/specs/2026-06-15-single-google-oauth-and-mcp-autoinstall-design.md). Depends only on F2's auto-install (the tools ship once the rhythm MCP is installed); independent of F1/F3.

## How it works (end to end)

`rhythm_pco_*` MCP tool → `RHYTHM_API_TOKEN` Bearer → Rhythm broker route under `/integrations/planning-center/api` → `ensureFreshPlanningCenterAccount` (reuses the existing token-refresh path) → `PlanningCenterService` → PCO Services v2 REST.

- **Read helpers** (`PlanningCenterService`): `listServiceTypes`, `listPlans` (`?filter=future`), `listPlanItems`, `listNeededPositions` — all with `per_page=100`.
- **Write helpers**: `updatePlanItem`, `assignPersonToPlan`, `updateScheduledPerson`. A PCO **403** → `PcoPermissionError`.
- **Broker controller/routes** (`/integrations/planning-center/api`, `requireAuth`): 7 endpoints; `PcoPermissionError` → **HTTP 403 `{ code: 'pco_permission_denied' }`** (never a generic 500).
- **MCP tools** (`apps/mcp_server/src/tools/pco.ts`): `rhythm_pco_list_service_types`, `_list_plans`, `_get_plan_items`, `_list_needed_positions`, `_update_plan_item`, `_assign_person`, `_update_scheduled_person`. A 403 becomes a friendly "your PCO account lacks permission" tool error. No new env/credential — rides the same `RHYTHM_API_TOKEN`.

## No OAuth changes

F4 adds **zero** sign-in/scope/OAuth code. `ensureFreshPlanningCenterAccount` is a thin public wrapper over the existing private `ensureFreshAccount('planning_center', …)`. Existing PCO sync, integrations routes, and mount order are untouched (broker mounted at the more-specific `/integrations/planning-center/api` before `/integrations`).

## Verification

- **api_server:** 797/797 vitest; `tsc --noEmit` clean.
- **mcp_server:** 36/36 vitest; `tsc --noEmit` clean.
- Tests: read helpers (URL + `per_page=100` + bearer), write `updatePlanItem` (method/URL/Content-Type/body) + 403→`PcoPermissionError`, broker route 200 + 403→`pco_permission_denied` (real `PcoPermissionError` via `importActual`, requireAuth exercised), MCP tool path + 403 friendly error.

## Known limitations (flag for review / live validation)

1. **Unverified write payload shapes.** `assignPersonToPlan` (`POST .../plans/:id/team_members`) and `updateScheduledPerson` (`PATCH .../team_members/:id`, `status`) use best-effort PCO Services v2 payloads — **validate against a live PCO sandbox** before relying on them. `updatePlanItem` is the only write with an asserted payload.
2. **Read 403s → HTTP 400.** Reads use `getJson` (shared with existing sync paths), which maps non-OK to `AppError.badRequest` (400), not the structured `pco_permission_denied` 403. Reads rarely 403 on the `services` scope; unifying this was avoided to not change existing sync error handling.
3. `assignPersonToPlan` returns `{ id: '' }` if PCO omits an id in the response.

## Testing locally

Requires F2 (or manual rhythm MCP install). Connect Planning Center in Integrations, then from an opencode agent session call e.g. `rhythm_pco_list_service_types` → `rhythm_pco_list_plans` → `rhythm_pco_get_plan_items`. Writes require your PCO role to permit the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)