### PR TITLE
F3: Google Calendar/Gmail tools in the rhythm MCP (brokered, step-up consent)

### DIFF
--- a/apps/api_server/src/__tests__/google_broker_helpers.test.ts
+++ b/apps/api_server/src/__tests__/google_broker_helpers.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  assertScope,
+  NeedsScopeUpgradeError,
+} from '../integrations/google_scope_guard';
+import { GmailApiService } from '../integrations/gmail/gmail_api_service';
+import { GoogleCalendarService } from '../integrations/google_calendar/google_calendar_service';
+import type { IntegrationAccount } from '../models/integration_account';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAccount(
+  scope: string | null,
+  accessToken = 'tok-123',
+): IntegrationAccount {
+  return {
+    id: 'acct-1',
+    ownerId: 1,
+    provider: 'google_calendar',
+    externalAccountId: 'sub-1',
+    email: 'user@example.com',
+    displayName: 'Test User',
+    status: 'connected',
+    accessToken,
+    refreshToken: null,
+    scope,
+    tokenType: 'Bearer',
+    expiresAt: null,
+    lastSyncedAt: null,
+    errorMessage: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// assertScope
+// ---------------------------------------------------------------------------
+
+describe('assertScope — exact-token matching', () => {
+  it('passes when the scope string contains the exact token', () => {
+    const account = makeAccount(
+      'https://www.googleapis.com/auth/gmail.readonly openid email',
+    );
+    expect(() =>
+      assertScope(account, 'https://www.googleapis.com/auth/gmail.readonly'),
+    ).not.toThrow();
+  });
+
+  it('passes for full calendar scope when present', () => {
+    const account = makeAccount(
+      'openid https://www.googleapis.com/auth/calendar',
+    );
+    expect(() =>
+      assertScope(account, 'https://www.googleapis.com/auth/calendar'),
+    ).not.toThrow();
+  });
+
+  it('FAILS with NeedsScopeUpgradeError for calendar.readonly when full calendar is required', () => {
+    // This is the key correctness test: calendar.readonly is a DIFFERENT token
+    // than calendar, so assertScope must not allow it to satisfy the full write scope.
+    const account = makeAccount(
+      'openid https://www.googleapis.com/auth/calendar.readonly',
+    );
+    expect(() =>
+      assertScope(account, 'https://www.googleapis.com/auth/calendar'),
+    ).toThrow(NeedsScopeUpgradeError);
+  });
+
+  it('throws NeedsScopeUpgradeError when scope is null', () => {
+    const account = makeAccount(null);
+    expect(() =>
+      assertScope(account, 'https://www.googleapis.com/auth/gmail.send'),
+    ).toThrow(NeedsScopeUpgradeError);
+  });
+
+  it('throws NeedsScopeUpgradeError when scope is empty string', () => {
+    const account = makeAccount('');
+    expect(() =>
+      assertScope(account, 'https://www.googleapis.com/auth/gmail.send'),
+    ).toThrow(NeedsScopeUpgradeError);
+  });
+
+  it('exposes the required scope on the error', () => {
+    const account = makeAccount('openid');
+    let err: NeedsScopeUpgradeError | undefined;
+    try {
+      assertScope(account, 'https://www.googleapis.com/auth/calendar');
+    } catch (e) {
+      err = e as NeedsScopeUpgradeError;
+    }
+    expect(err).toBeInstanceOf(NeedsScopeUpgradeError);
+    expect(err?.requiredScope).toBe(
+      'https://www.googleapis.com/auth/calendar',
+    );
+    expect(err?.name).toBe('NeedsScopeUpgradeError');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GmailApiService
+// ---------------------------------------------------------------------------
+
+describe('GmailApiService', () => {
+  describe('sendMessage', () => {
+    it('throws NeedsScopeUpgradeError when account lacks gmail.send scope', async () => {
+      const account = makeAccount(
+        'openid https://www.googleapis.com/auth/gmail.readonly',
+      );
+      const svc = new GmailApiService();
+      await expect(
+        svc.sendMessage(account, {
+          to: 'other@example.com',
+          subject: 'Hi',
+          body: 'Hello',
+        }),
+      ).rejects.toThrow(NeedsScopeUpgradeError);
+    });
+
+    it('sends email and returns {id} when gmail.send scope is present', async () => {
+      const account = makeAccount(
+        'openid https://www.googleapis.com/auth/gmail.send',
+      );
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(JSON.stringify({ id: 'm1' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      );
+      const svc = new GmailApiService();
+      const result = await svc.sendMessage(account, {
+        to: 'other@example.com',
+        subject: 'Test subject',
+        body: 'Test body',
+      });
+      expect(result).toEqual({ id: 'm1' });
+    });
+
+    it('throws AppError when fetch returns non-ok', async () => {
+      const account = makeAccount(
+        'openid https://www.googleapis.com/auth/gmail.send',
+      );
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response('Service Unavailable', { status: 503 }),
+        ),
+      );
+      const svc = new GmailApiService();
+      await expect(
+        svc.sendMessage(account, {
+          to: 'x@example.com',
+          subject: 'S',
+          body: 'B',
+        }),
+      ).rejects.toThrow(/Gmail send failed/);
+    });
+  });
+
+  describe('searchMessages', () => {
+    it('throws NeedsScopeUpgradeError when account lacks gmail.readonly', async () => {
+      const account = makeAccount('openid email');
+      const svc = new GmailApiService();
+      await expect(svc.searchMessages(account, 'from:boss')).rejects.toThrow(
+        NeedsScopeUpgradeError,
+      );
+    });
+
+    it('returns search results when gmail.readonly scope is present', async () => {
+      const account = makeAccount(
+        'openid https://www.googleapis.com/auth/gmail.readonly',
+      );
+      const mockPayload = { messages: [{ id: 'msg-1', threadId: 't-1' }] };
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(JSON.stringify(mockPayload), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      );
+      const svc = new GmailApiService();
+      const result = await svc.searchMessages(account, 'from:boss');
+      expect(result).toEqual(mockPayload);
+    });
+  });
+
+  describe('readMessage', () => {
+    it('throws NeedsScopeUpgradeError when account lacks gmail.readonly', async () => {
+      const account = makeAccount('openid email');
+      const svc = new GmailApiService();
+      await expect(svc.readMessage(account, 'msg-1')).rejects.toThrow(
+        NeedsScopeUpgradeError,
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GoogleCalendarService — write methods
+// ---------------------------------------------------------------------------
+
+describe('GoogleCalendarService — write methods', () => {
+  const readonlyAccount = makeAccount(
+    'openid https://www.googleapis.com/auth/calendar.readonly',
+  );
+  const writeAccount = makeAccount(
+    'openid https://www.googleapis.com/auth/calendar',
+  );
+
+  describe('createEvent', () => {
+    it('throws NeedsScopeUpgradeError for a calendar.readonly account', async () => {
+      const svc = new GoogleCalendarService();
+      await expect(
+        svc.createEvent(readonlyAccount, 'primary', {
+          summary: 'Team meeting',
+        }),
+      ).rejects.toThrow(NeedsScopeUpgradeError);
+    });
+
+    it('succeeds and returns the created event when full calendar scope is present', async () => {
+      const createdEvent = { id: 'evt-1', summary: 'Team meeting' };
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(JSON.stringify(createdEvent), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      );
+      const svc = new GoogleCalendarService();
+      const result = await svc.createEvent(writeAccount, 'primary', {
+        summary: 'Team meeting',
+      });
+      expect(result).toEqual(createdEvent);
+    });
+
+    it('throws AppError when fetch returns non-ok', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response('Forbidden', { status: 403 }),
+        ),
+      );
+      const svc = new GoogleCalendarService();
+      await expect(
+        svc.createEvent(writeAccount, 'primary', { summary: 'X' }),
+      ).rejects.toThrow(/Calendar create failed/);
+    });
+  });
+
+  describe('updateEvent', () => {
+    it('throws NeedsScopeUpgradeError for a calendar.readonly account', async () => {
+      const svc = new GoogleCalendarService();
+      await expect(
+        svc.updateEvent(readonlyAccount, 'primary', 'evt-1', {
+          summary: 'Updated',
+        }),
+      ).rejects.toThrow(NeedsScopeUpgradeError);
+    });
+
+    it('succeeds when full calendar scope is present', async () => {
+      const updatedEvent = { id: 'evt-1', summary: 'Updated' };
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(JSON.stringify(updatedEvent), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+      );
+      const svc = new GoogleCalendarService();
+      const result = await svc.updateEvent(writeAccount, 'primary', 'evt-1', {
+        summary: 'Updated',
+      });
+      expect(result).toEqual(updatedEvent);
+    });
+  });
+
+  describe('deleteEvent', () => {
+    it('throws NeedsScopeUpgradeError for a calendar.readonly account', async () => {
+      const svc = new GoogleCalendarService();
+      await expect(
+        svc.deleteEvent(readonlyAccount, 'primary', 'evt-1'),
+      ).rejects.toThrow(NeedsScopeUpgradeError);
+    });
+
+    it('succeeds (no throw) when full calendar scope is present and delete returns 204', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(new Response(null, { status: 204 })),
+      );
+      const svc = new GoogleCalendarService();
+      await expect(
+        svc.deleteEvent(writeAccount, 'primary', 'evt-1'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('treats 410 Gone as a success (already deleted)', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(new Response(null, { status: 410 })),
+      );
+      const svc = new GoogleCalendarService();
+      await expect(
+        svc.deleteEvent(writeAccount, 'primary', 'evt-1'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws AppError for unexpected non-ok status', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response('Internal Server Error', { status: 500 }),
+        ),
+      );
+      const svc = new GoogleCalendarService();
+      await expect(
+        svc.deleteEvent(writeAccount, 'primary', 'evt-1'),
+      ).rejects.toThrow(/Calendar delete failed/);
+    });
+  });
+});

--- a/apps/api_server/src/__tests__/google_broker_routes.test.ts
+++ b/apps/api_server/src/__tests__/google_broker_routes.test.ts
@@ -1,0 +1,191 @@
+/**
+ * ROUTE-LEVEL tests for the Google broker (F3) — driven through the REAL Express
+ * router, controller, and error handler. The service layer
+ * (IntegrationsService / GoogleCalendarService / GmailApiService) is mocked, but
+ * the REAL NeedsScopeUpgradeError is preserved via importActual so the
+ * controller's `instanceof` check matches and produces a structured 409.
+ *
+ *   fetch -> express(googleBrokerRouter) -> GoogleBrokerController (REAL)
+ *         -> mocked services
+ *
+ * Transport: a real `http` server on an ephemeral port + global fetch (Node 22).
+ *
+ * Run with:
+ *   cd apps/api_server && npx vitest run src/__tests__/google_broker_routes.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import type { AddressInfo } from 'net';
+import http from 'http';
+
+// requireAuth is NOT bypassed on /integrations — mock the auth service so any
+// Bearer token resolves to a user.
+vi.mock('../services/auth_service', () => ({
+  AuthService: class {
+    async getUserForSessionToken() {
+      return { id: 42, email: 'test@example.com', name: 'Test User' };
+    }
+  },
+}));
+
+// Mock the service layer. ensureFreshGoogleAccount returns a fake account; the
+// calendar/gmail helpers are spies the individual tests configure. vi.hoisted
+// lets the spies exist before the hoisted vi.mock factories reference them.
+const {
+  ensureFreshGoogleAccount,
+  listUpcomingEvents,
+  createEvent,
+  updateEvent,
+  deleteEvent,
+  searchMessages,
+  readMessage,
+  sendMessage,
+} = vi.hoisted(() => ({
+  ensureFreshGoogleAccount: vi.fn(),
+  listUpcomingEvents: vi.fn(),
+  createEvent: vi.fn(),
+  updateEvent: vi.fn(),
+  deleteEvent: vi.fn(),
+  searchMessages: vi.fn(),
+  readMessage: vi.fn(),
+  sendMessage: vi.fn(),
+}));
+
+vi.mock('../services/integrations_service', () => ({
+  IntegrationsService: class {
+    ensureFreshGoogleAccount = ensureFreshGoogleAccount;
+  },
+}));
+
+vi.mock('../integrations/google_calendar/google_calendar_service', () => ({
+  GoogleCalendarService: class {
+    listUpcomingEvents = listUpcomingEvents;
+    createEvent = createEvent;
+    updateEvent = updateEvent;
+    deleteEvent = deleteEvent;
+  },
+}));
+
+vi.mock('../integrations/gmail/gmail_api_service', () => ({
+  GmailApiService: class {
+    searchMessages = searchMessages;
+    readMessage = readMessage;
+    sendMessage = sendMessage;
+  },
+}));
+
+// Preserve the REAL NeedsScopeUpgradeError so `instanceof` in the controller matches.
+vi.mock('../integrations/google_scope_guard', async () => {
+  const actual = await vi.importActual<
+    typeof import('../integrations/google_scope_guard')
+  >('../integrations/google_scope_guard');
+  return actual;
+});
+
+import express from 'express';
+import { googleBrokerRouter } from '../routes/google_broker_routes';
+import { errorHandler } from '../middleware/error_handler';
+import { NeedsScopeUpgradeError } from '../integrations/google_scope_guard';
+
+const FAKE_ACCOUNT = { id: 1, accessToken: 'tok', scope: '' };
+
+let server: http.Server;
+let base: string;
+
+async function req(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  const res = await fetch(`${base}${path}`, {
+    method,
+    headers: {
+      Authorization: 'Bearer test-token',
+      ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+    },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let parsed: unknown = null;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+  }
+  return { status: res.status, body: parsed };
+}
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/integrations/google', googleBrokerRouter);
+  app.use(errorHandler);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', resolve);
+  });
+  const addr = server.address() as AddressInfo;
+  base = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ensureFreshGoogleAccount.mockResolvedValue(FAKE_ACCOUNT);
+});
+
+describe('GET /integrations/google/calendar/events', () => {
+  it('returns 200 with the stubbed upcoming events', async () => {
+    const events = [{ externalId: 'primary:abc', title: 'Standup' }];
+    listUpcomingEvents.mockResolvedValue(events);
+
+    const { status, body } = await req('GET', '/integrations/google/calendar/events');
+
+    expect(status).toBe(200);
+    expect(body).toEqual(events);
+    expect(ensureFreshGoogleAccount).toHaveBeenCalledWith(42);
+    expect(listUpcomingEvents).toHaveBeenCalledWith(FAKE_ACCOUNT, ['primary']);
+  });
+});
+
+describe('POST /integrations/google/gmail/send', () => {
+  it('maps NeedsScopeUpgradeError to a 409 with structured body (NOT 500)', async () => {
+    sendMessage.mockRejectedValue(
+      new NeedsScopeUpgradeError('https://www.googleapis.com/auth/gmail.send'),
+    );
+
+    const { status, body } = await req('POST', '/integrations/google/gmail/send', {
+      to: 'a@b.com',
+      subject: 'Hi',
+      body: 'Hello',
+    });
+
+    expect(status).toBe(409);
+    expect(body).toEqual({
+      code: 'needs_scope_upgrade',
+      requiredScope: 'https://www.googleapis.com/auth/gmail.send',
+    });
+  });
+
+  it('returns the send result on success', async () => {
+    sendMessage.mockResolvedValue({ id: 'sent-1' });
+
+    const { status, body } = await req('POST', '/integrations/google/gmail/send', {
+      to: 'a@b.com',
+      subject: 'Hi',
+      body: 'Hello',
+    });
+
+    expect(status).toBe(200);
+    expect(body).toEqual({ id: 'sent-1' });
+    expect(sendMessage).toHaveBeenCalledWith(FAKE_ACCOUNT, {
+      to: 'a@b.com',
+      subject: 'Hi',
+      body: 'Hello',
+    });
+  });
+});

--- a/apps/api_server/src/__tests__/google_broker_routes.test.ts
+++ b/apps/api_server/src/__tests__/google_broker_routes.test.ts
@@ -152,6 +152,29 @@ describe('GET /integrations/google/calendar/events', () => {
   });
 });
 
+describe('PATCH /integrations/google/calendar/events/:id', () => {
+  it('wraps start/end into {dateTime} objects (symmetric with create)', async () => {
+    updateEvent.mockResolvedValue({ id: 'evt1' });
+
+    const { status } = await req(
+      'PATCH',
+      '/integrations/google/calendar/events/evt1',
+      {
+        start: '2026-06-20T09:00:00-07:00',
+        end: '2026-06-20T10:00:00-07:00',
+        summary: 'Moved',
+      },
+    );
+
+    expect(status).toBe(200);
+    expect(updateEvent).toHaveBeenCalledTimes(1);
+    const patch = updateEvent.mock.calls[0][3];
+    expect(patch.start).toEqual({ dateTime: '2026-06-20T09:00:00-07:00' });
+    expect(patch.end).toEqual({ dateTime: '2026-06-20T10:00:00-07:00' });
+    expect(patch.summary).toBe('Moved');
+  });
+});
+
 describe('POST /integrations/google/gmail/send', () => {
   it('maps NeedsScopeUpgradeError to a 409 with structured body (NOT 500)', async () => {
     sendMessage.mockRejectedValue(

--- a/apps/api_server/src/__tests__/google_step_up_scopes.test.ts
+++ b/apps/api_server/src/__tests__/google_step_up_scopes.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { env } from '../config/env';
+import { GoogleOAuthService, GOOGLE_AGENT_SCOPES } from '../services/google_oauth_service';
+
+describe('Google step-up scopes', () => {
+  let origClientId: string;
+  let origClientSecret: string;
+  let origRedirectUri: string;
+
+  beforeEach(() => {
+    origClientId = env.googleClientId;
+    origClientSecret = env.googleClientSecret;
+    origRedirectUri = env.googleRedirectUri;
+    (env as { googleClientId: string }).googleClientId = 'web-client-id.apps.googleusercontent.com';
+    (env as { googleClientSecret: string }).googleClientSecret = 'web-client-secret';
+    (env as { googleRedirectUri: string }).googleRedirectUri = 'http://localhost:4000/auth/google/callback';
+  });
+
+  afterEach(() => {
+    (env as { googleClientId: string }).googleClientId = origClientId;
+    (env as { googleClientSecret: string }).googleClientSecret = origClientSecret;
+    (env as { googleRedirectUri: string }).googleRedirectUri = origRedirectUri;
+  });
+
+  it('agent scope set includes full calendar + gmail read/send', () => {
+    expect(GOOGLE_AGENT_SCOPES).toContain('https://www.googleapis.com/auth/calendar');
+    expect(GOOGLE_AGENT_SCOPES).toContain('https://www.googleapis.com/auth/gmail.readonly');
+    expect(GOOGLE_AGENT_SCOPES).toContain('https://www.googleapis.com/auth/gmail.send');
+  });
+
+  it('getAuthorizationUrl(scopes) embeds the requested scope set and forces consent', () => {
+    const svc = new GoogleOAuthService();
+    const url = svc.getAuthorizationUrl({
+      sessionToken: 'state-tok',
+      forceConsent: true,
+      scopes: GOOGLE_AGENT_SCOPES,
+    });
+    expect(url).toContain(encodeURIComponent('https://www.googleapis.com/auth/calendar'));
+    expect(url).toContain('prompt=consent');
+    // must NOT include the readonly variant (we passed the full calendar scope)
+    expect(url).not.toContain(encodeURIComponent('https://www.googleapis.com/auth/calendar.readonly'));
+  });
+
+  it('getAuthorizationUrl without scopes uses the base scopes (unchanged default)', () => {
+    const svc = new GoogleOAuthService();
+    const url = svc.getAuthorizationUrl({ sessionToken: 'state-tok', forceConsent: false });
+    // base set includes calendar.readonly
+    expect(url).toContain(encodeURIComponent('https://www.googleapis.com/auth/calendar.readonly'));
+    // base set must NOT include the full calendar scope (only readonly)
+    expect(url).not.toContain(encodeURIComponent('https://www.googleapis.com/auth/calendar%20'));
+    // base set includes gmail.metadata
+    expect(url).toContain(encodeURIComponent('https://www.googleapis.com/auth/gmail.metadata'));
+  });
+});

--- a/apps/api_server/src/app.ts
+++ b/apps/api_server/src/app.ts
@@ -10,6 +10,7 @@ import { facilitiesRouter } from './routes/facilities_routes';
 import { dashboardRouter } from './routes/dashboard_routes';
 import { healthRouter } from './routes/health_routes';
 import { integrationsRouter } from './routes/integrations_routes';
+import { googleBrokerRouter } from './routes/google_broker_routes';
 import { messagesRouter } from './routes/messages_routes';
 import { projectInstancesRouter } from './routes/project_instances_routes';
 import { projectTemplatesRouter } from './routes/project_templates_routes';
@@ -67,6 +68,7 @@ export function createApp() {
   app.use('/auth', authRouter);
   app.use('/automation-catalog', automationCatalogRouter);
   app.use('/automation-rules', automationRulesRouter);
+  app.use('/integrations/google', googleBrokerRouter);
   app.use('/integrations', integrationsRouter);
   app.use('/tasks', tasksRouter);
   app.use('/project-templates', projectTemplatesRouter);

--- a/apps/api_server/src/controllers/auth_controller.ts
+++ b/apps/api_server/src/controllers/auth_controller.ts
@@ -3,7 +3,7 @@ import { AppError } from '../errors/app_error';
 import { IntegrationAccountsRepository } from '../repositories/integration_accounts_repository';
 import { WorkspaceRepository } from '../repositories/workspace_repository';
 import { AuthService } from '../services/auth_service';
-import { GoogleOAuthService } from '../services/google_oauth_service';
+import { GoogleOAuthService, GOOGLE_AGENT_SCOPES } from '../services/google_oauth_service';
 import { PlanningCenterOAuthService } from '../services/planning_center_oauth_service';
 
 const googleOAuth = new GoogleOAuthService();
@@ -65,13 +65,26 @@ export class AuthController {
     next: NextFunction,
   ) {
     try {
-      const { sessionToken } = _req.query as Record<string, string>;
+      const { sessionToken, intent } = _req.query as Record<string, string>;
       const user = sessionToken
         ? await authService.getUserForSessionToken(sessionToken)
         : null;
       if (!sessionToken || !user) {
         throw AppError.unauthorized('Valid sessionToken is required');
       }
+
+      if (intent === 'agent') {
+        res.redirect(
+          googleOAuth.getAuthorizationUrl({
+            sessionToken,
+            loginHint: user.email,
+            forceConsent: true,
+            scopes: GOOGLE_AGENT_SCOPES,
+          }),
+        );
+        return;
+      }
+
       const existingCalendar = await integrationAccountsRepo.findByProviderAsync(
         'google_calendar',
         user.id,

--- a/apps/api_server/src/controllers/google_broker_controller.ts
+++ b/apps/api_server/src/controllers/google_broker_controller.ts
@@ -64,7 +64,11 @@ export class GoogleBrokerController {
       const account = await integrationsService.ensureFreshGoogleAccount(
         req.auth!.user.id,
       );
-      const { calendarId, ...patch } = req.body as Record<string, unknown>;
+      const { calendarId, start, end, ...rest } =
+        req.body as Record<string, unknown>;
+      const patch: Record<string, unknown> = { ...rest };
+      if (start !== undefined) patch.start = { dateTime: start };
+      if (end !== undefined) patch.end = { dateTime: end };
       const result = await calendar.updateEvent(
         account,
         (calendarId as string) ?? 'primary',

--- a/apps/api_server/src/controllers/google_broker_controller.ts
+++ b/apps/api_server/src/controllers/google_broker_controller.ts
@@ -1,0 +1,132 @@
+import type { NextFunction, Request, Response } from 'express';
+import { GmailApiService } from '../integrations/gmail/gmail_api_service';
+import { GoogleCalendarService } from '../integrations/google_calendar/google_calendar_service';
+import { NeedsScopeUpgradeError } from '../integrations/google_scope_guard';
+import { IntegrationsService } from '../services/integrations_service';
+
+const integrationsService = new IntegrationsService();
+const calendar = new GoogleCalendarService();
+const gmail = new GmailApiService();
+
+/**
+ * Brokered Google tools (F3) — mirrors the PlanningCenter broker. Each handler
+ * refreshes the stored Google credential and delegates to the integration
+ * helper. A `NeedsScopeUpgradeError` (the credential lacks a write scope) is
+ * mapped to a structured HTTP 409 so callers can prompt a re-consent; anything
+ * else flows to the Express error handler.
+ */
+export class GoogleBrokerController {
+  private handleError(err: unknown, res: Response, next: NextFunction) {
+    if (err instanceof NeedsScopeUpgradeError) {
+      res
+        .status(409)
+        .json({ code: 'needs_scope_upgrade', requiredScope: err.requiredScope });
+      return;
+    }
+    next(err);
+  }
+
+  async listEvents(req: Request, res: Response, next: NextFunction) {
+    try {
+      const account = await integrationsService.ensureFreshGoogleAccount(
+        req.auth!.user.id,
+      );
+      const calendarId = (req.query.calendarId as string) || 'primary';
+      const result = await calendar.listUpcomingEvents(account, [calendarId]);
+      res.json(result);
+    } catch (err) {
+      this.handleError(err, res, next);
+    }
+  }
+
+  async createEvent(req: Request, res: Response, next: NextFunction) {
+    try {
+      const account = await integrationsService.ensureFreshGoogleAccount(
+        req.auth!.user.id,
+      );
+      const { calendarId, summary, start, end, location, description } =
+        req.body as Record<string, string | undefined>;
+      const result = await calendar.createEvent(account, calendarId ?? 'primary', {
+        summary,
+        start: { dateTime: start },
+        end: { dateTime: end },
+        location,
+        description,
+      });
+      res.json(result);
+    } catch (err) {
+      this.handleError(err, res, next);
+    }
+  }
+
+  async updateEvent(req: Request, res: Response, next: NextFunction) {
+    try {
+      const account = await integrationsService.ensureFreshGoogleAccount(
+        req.auth!.user.id,
+      );
+      const { calendarId, ...patch } = req.body as Record<string, unknown>;
+      const result = await calendar.updateEvent(
+        account,
+        (calendarId as string) ?? 'primary',
+        req.params.id,
+        patch,
+      );
+      res.json(result);
+    } catch (err) {
+      this.handleError(err, res, next);
+    }
+  }
+
+  async deleteEvent(req: Request, res: Response, next: NextFunction) {
+    try {
+      const account = await integrationsService.ensureFreshGoogleAccount(
+        req.auth!.user.id,
+      );
+      const calendarId = (req.query.calendarId as string) || 'primary';
+      await calendar.deleteEvent(account, calendarId, req.params.id);
+      res.status(204).end();
+    } catch (err) {
+      this.handleError(err, res, next);
+    }
+  }
+
+  async searchGmail(req: Request, res: Response, next: NextFunction) {
+    try {
+      const account = await integrationsService.ensureFreshGoogleAccount(
+        req.auth!.user.id,
+      );
+      const result = await gmail.searchMessages(
+        account,
+        (req.query.q as string) ?? '',
+      );
+      res.json(result);
+    } catch (err) {
+      this.handleError(err, res, next);
+    }
+  }
+
+  async readEmail(req: Request, res: Response, next: NextFunction) {
+    try {
+      const account = await integrationsService.ensureFreshGoogleAccount(
+        req.auth!.user.id,
+      );
+      const result = await gmail.readMessage(account, req.params.id);
+      res.json(result);
+    } catch (err) {
+      this.handleError(err, res, next);
+    }
+  }
+
+  async sendEmail(req: Request, res: Response, next: NextFunction) {
+    try {
+      const account = await integrationsService.ensureFreshGoogleAccount(
+        req.auth!.user.id,
+      );
+      const { to, subject, body } = req.body as Record<string, string>;
+      const result = await gmail.sendMessage(account, { to, subject, body });
+      res.json(result);
+    } catch (err) {
+      this.handleError(err, res, next);
+    }
+  }
+}

--- a/apps/api_server/src/integrations/gmail/gmail_api_service.ts
+++ b/apps/api_server/src/integrations/gmail/gmail_api_service.ts
@@ -1,0 +1,64 @@
+import { AppError } from '../../errors/app_error';
+import type { IntegrationAccount } from '../../models/integration_account';
+import { assertScope } from '../google_scope_guard';
+
+const GMAIL = 'https://gmail.googleapis.com/gmail/v1/users/me';
+
+export class GmailApiService {
+  async searchMessages(
+    account: IntegrationAccount,
+    query: string,
+  ): Promise<unknown> {
+    assertScope(account, 'https://www.googleapis.com/auth/gmail.readonly');
+    return this.getJson(account, `/messages?q=${encodeURIComponent(query)}`);
+  }
+
+  async readMessage(
+    account: IntegrationAccount,
+    id: string,
+  ): Promise<unknown> {
+    assertScope(account, 'https://www.googleapis.com/auth/gmail.readonly');
+    return this.getJson(
+      account,
+      `/messages/${encodeURIComponent(id)}?format=full`,
+    );
+  }
+
+  async sendMessage(
+    account: IntegrationAccount,
+    msg: { to: string; subject: string; body: string },
+  ): Promise<{ id: string }> {
+    assertScope(account, 'https://www.googleapis.com/auth/gmail.send');
+    const raw = Buffer.from(
+      `To: ${msg.to}\r\nSubject: ${msg.subject}\r\n\r\n${msg.body}`,
+    )
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+    const res = await fetch(`${GMAIL}/messages/send`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${account.accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ raw }),
+    });
+    if (!res.ok) {
+      throw AppError.badRequest(`Gmail send failed: ${await res.text()}`);
+    }
+    return (await res.json()) as { id: string };
+  }
+
+  private async getJson(
+    account: IntegrationAccount,
+    path: string,
+  ): Promise<unknown> {
+    const res = await fetch(`${GMAIL}${path}`, {
+      headers: { Authorization: `Bearer ${account.accessToken}` },
+    });
+    if (!res.ok) {
+      throw AppError.badRequest(`Gmail request failed: ${await res.text()}`);
+    }
+    return res.json();
+  }
+}

--- a/apps/api_server/src/integrations/google_calendar/google_calendar_service.ts
+++ b/apps/api_server/src/integrations/google_calendar/google_calendar_service.ts
@@ -1,6 +1,7 @@
 import { AppError } from '../../errors/app_error';
 import type { IntegrationAccount } from '../../models/integration_account';
 import type { GoogleCalendarOption } from '../../models/google_calendar_preferences';
+import { assertScope } from '../google_scope_guard';
 
 interface GoogleCalendarEventDateTime {
   date?: string;
@@ -131,5 +132,70 @@ export class GoogleCalendarService {
     }
 
     return normalized;
+  }
+
+  async createEvent(
+    account: IntegrationAccount,
+    calendarId: string,
+    event: Record<string, unknown>,
+  ): Promise<unknown> {
+    assertScope(account, 'https://www.googleapis.com/auth/calendar');
+    const res = await fetch(
+      `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${account.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(event),
+      },
+    );
+    if (!res.ok) {
+      throw AppError.badRequest(`Calendar create failed: ${await res.text()}`);
+    }
+    return res.json();
+  }
+
+  async updateEvent(
+    account: IntegrationAccount,
+    calendarId: string,
+    eventId: string,
+    patch: Record<string, unknown>,
+  ): Promise<unknown> {
+    assertScope(account, 'https://www.googleapis.com/auth/calendar');
+    const res = await fetch(
+      `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+      {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${account.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(patch),
+      },
+    );
+    if (!res.ok) {
+      throw AppError.badRequest(`Calendar update failed: ${await res.text()}`);
+    }
+    return res.json();
+  }
+
+  async deleteEvent(
+    account: IntegrationAccount,
+    calendarId: string,
+    eventId: string,
+  ): Promise<void> {
+    assertScope(account, 'https://www.googleapis.com/auth/calendar');
+    const res = await fetch(
+      `https://www.googleapis.com/calendar/v3/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+      {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${account.accessToken}` },
+      },
+    );
+    if (!res.ok && res.status !== 410) {
+      throw AppError.badRequest(`Calendar delete failed: ${await res.text()}`);
+    }
   }
 }

--- a/apps/api_server/src/integrations/google_scope_guard.ts
+++ b/apps/api_server/src/integrations/google_scope_guard.ts
@@ -1,0 +1,26 @@
+import type { IntegrationAccount } from '../models/integration_account';
+
+/** Thrown when the stored Google credential lacks the scope a tool needs. The
+ *  broker controller maps this to a structured 409 { code: 'needs_scope_upgrade' }. */
+export class NeedsScopeUpgradeError extends Error {
+  constructor(public readonly requiredScope: string) {
+    super(`needs_scope_upgrade: ${requiredScope}`);
+    this.name = 'NeedsScopeUpgradeError';
+  }
+}
+
+/**
+ * Asserts the account's stored scope string contains `scope` as an exact
+ * whitespace-delimited token.
+ *
+ * Google scopes are space-separated. Using exact-token matching means that
+ * `https://www.googleapis.com/auth/calendar.readonly` does NOT satisfy a
+ * requirement for `https://www.googleapis.com/auth/calendar` (they are
+ * different tokens), which is the correct behaviour for the write-scope guard.
+ */
+export function assertScope(account: IntegrationAccount, scope: string): void {
+  const granted = (account.scope ?? '').split(/\s+/);
+  if (!granted.includes(scope)) {
+    throw new NeedsScopeUpgradeError(scope);
+  }
+}

--- a/apps/api_server/src/routes/google_broker_routes.ts
+++ b/apps/api_server/src/routes/google_broker_routes.ts
@@ -1,0 +1,30 @@
+import { Router } from 'express';
+import { GoogleBrokerController } from '../controllers/google_broker_controller';
+import { requireAuth } from '../middleware/auth_middleware';
+
+const controller = new GoogleBrokerController();
+export const googleBrokerRouter = Router();
+
+googleBrokerRouter.use(requireAuth);
+googleBrokerRouter.get(
+  '/calendar/events',
+  controller.listEvents.bind(controller),
+);
+googleBrokerRouter.post(
+  '/calendar/events',
+  controller.createEvent.bind(controller),
+);
+googleBrokerRouter.patch(
+  '/calendar/events/:id',
+  controller.updateEvent.bind(controller),
+);
+googleBrokerRouter.delete(
+  '/calendar/events/:id',
+  controller.deleteEvent.bind(controller),
+);
+googleBrokerRouter.get('/gmail/search', controller.searchGmail.bind(controller));
+googleBrokerRouter.get(
+  '/gmail/messages/:id',
+  controller.readEmail.bind(controller),
+);
+googleBrokerRouter.post('/gmail/send', controller.sendEmail.bind(controller));

--- a/apps/api_server/src/services/google_oauth_service.ts
+++ b/apps/api_server/src/services/google_oauth_service.ts
@@ -17,6 +17,15 @@ const GOOGLE_SCOPES = [
 
 export const GOOGLE_DESKTOP_SCOPES = GOOGLE_SCOPES;
 
+export const GOOGLE_AGENT_SCOPES = [
+  'openid',
+  'email',
+  'profile',
+  'https://www.googleapis.com/auth/calendar',
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/gmail.send',
+];
+
 interface GoogleTokenResponse {
   access_token: string;
   expires_in?: number;
@@ -39,8 +48,11 @@ export class GoogleOAuthService {
     sessionToken: string;
     loginHint?: string | null;
     forceConsent?: boolean;
+    scopes?: string[];
   }): string {
     this.assertConfigured();
+
+    const scopeList = options.scopes ?? GOOGLE_SCOPES;
 
     const params = new URLSearchParams({
       client_id: env.googleClientId,
@@ -48,7 +60,7 @@ export class GoogleOAuthService {
       response_type: 'code',
       access_type: 'offline',
       include_granted_scopes: 'true',
-      scope: GOOGLE_SCOPES.join(' '),
+      scope: scopeList.join(' '),
       state: options.sessionToken,
       ...(options.loginHint ? { login_hint: options.loginHint } : {}),
       ...(options.forceConsent ? { prompt: 'consent' } : {}),

--- a/apps/api_server/src/services/integrations_service.ts
+++ b/apps/api_server/src/services/integrations_service.ts
@@ -504,6 +504,21 @@ export class IntegrationsService {
     }
   }
 
+  /**
+   * Public broker entry point. Returns a fresh Google credential (refreshing
+   * tokens if near expiry). Gmail and Calendar share one Google credential in
+   * this codebase — sign-in stores identical tokens to both rows — so the
+   * canonical `google_calendar` account is used for both calendar and gmail
+   * brokered calls. Throws if Google is not connected.
+   */
+  async ensureFreshGoogleAccount(userId: number): Promise<IntegrationAccount> {
+    const account = await this.ensureFreshAccount('google_calendar', userId);
+    if (!account) {
+      throw AppError.badRequest('Google is not connected');
+    }
+    return account;
+  }
+
   private async ensureFreshAccount(
     provider: "google_calendar" | "gmail" | "planning_center",
     userId: number,

--- a/apps/desktop_flutter/lib/features/integrations/controllers/integrations_controller.dart
+++ b/apps/desktop_flutter/lib/features/integrations/controllers/integrations_controller.dart
@@ -93,6 +93,7 @@ class IntegrationsController extends ChangeNotifier {
   }
 
   Uri googleBeginUri() => _repository.googleBeginUri();
+  Uri googleAgentBeginUri() => _repository.googleAgentBeginUri();
   Uri planningCenterBeginUri() => _repository.planningCenterBeginUri();
 
   Future<void> syncAll() async {

--- a/apps/desktop_flutter/lib/features/integrations/data/integrations_data_source.dart
+++ b/apps/desktop_flutter/lib/features/integrations/data/integrations_data_source.dart
@@ -36,6 +36,14 @@ class IntegrationsDataSource {
         },
       );
 
+  Uri googleAgentBeginUri() => Uri.parse('$_baseUrl/auth/google/begin').replace(
+        queryParameters: {
+          'intent': 'agent',
+          if (AuthSessionStore.sessionToken != null)
+            'sessionToken': AuthSessionStore.sessionToken!,
+        },
+      );
+
   Uri planningCenterBeginUri() =>
       Uri.parse('$_baseUrl/auth/planning-center/begin').replace(
         queryParameters: {

--- a/apps/desktop_flutter/lib/features/integrations/repositories/integrations_repository.dart
+++ b/apps/desktop_flutter/lib/features/integrations/repositories/integrations_repository.dart
@@ -21,6 +21,7 @@ class IntegrationsRepository {
       _dataSource.fetchPlanningCenterTaskOptions();
 
   Uri googleBeginUri() => _dataSource.googleBeginUri();
+  Uri googleAgentBeginUri() => _dataSource.googleAgentBeginUri();
   Uri planningCenterBeginUri() => _dataSource.planningCenterBeginUri();
 
   Future<void> syncGoogleCalendar() => _dataSource.syncGoogleCalendar();

--- a/apps/desktop_flutter/lib/features/integrations/views/integrations_view.dart
+++ b/apps/desktop_flutter/lib/features/integrations/views/integrations_view.dart
@@ -140,6 +140,12 @@ class _IntegrationsViewState extends State<IntegrationsView> {
                                 ),
                               ),
                               const SizedBox(height: 20),
+                              _GoogleAgentConsentCard(
+                                onEnable: () => _openExternal(
+                                  controller.googleAgentBeginUri(),
+                                ),
+                              ),
+                              const SizedBox(height: 16),
                               const _ImportSection(),
                               const SizedBox(height: 4),
                             ],
@@ -1352,6 +1358,68 @@ class _ImportSection extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Google agent consent card
+// ---------------------------------------------------------------------------
+
+class _GoogleAgentConsentCard extends StatelessWidget {
+  const _GoogleAgentConsentCard({required this.onEnable});
+
+  final VoidCallback onEnable;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: context.rhythm.surfaceRaised,
+        borderRadius: BorderRadius.circular(RhythmRadius.xl),
+        border: Border.all(color: context.rhythm.borderSubtle),
+        boxShadow: RhythmElevation.panel,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'ASSISTANT TOOLS',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: context.rhythm.textSecondary,
+              letterSpacing: 0.8,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Google tools for the assistant',
+            style: TextStyle(
+              fontWeight: FontWeight.w600,
+              color: context.rhythm.textPrimary,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Grant the assistant access to full Google Calendar and Gmail '
+            '(read + send) so it can create events, draft emails, and act '
+            'on your behalf.',
+            style: TextStyle(
+              fontSize: 13,
+              color: context.rhythm.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 16),
+          OutlinedButton.icon(
+            key: const ValueKey('enable-google-tools'),
+            onPressed: onEnable,
+            icon: const Icon(Icons.open_in_new, size: 16),
+            label: const Text('Enable Google tools for the assistant'),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/apps/desktop_flutter/test/features/integrations/f3_google_agent_uri_test.dart
+++ b/apps/desktop_flutter/test/features/integrations/f3_google_agent_uri_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rhythm_desktop/features/integrations/data/integrations_data_source.dart';
+
+void main() {
+  test('googleAgentBeginUri targets /auth/google/begin with intent=agent', () {
+    final ds = IntegrationsDataSource(baseUrl: 'https://api.example.com');
+    final uri = ds.googleAgentBeginUri();
+    expect(uri.path, '/auth/google/begin');
+    expect(uri.queryParameters['intent'], 'agent');
+  });
+}

--- a/apps/mcp_server/src/index.ts
+++ b/apps/mcp_server/src/index.ts
@@ -12,6 +12,7 @@ import { registerDashboardTools } from './tools/dashboard.js';
 import { registerClaudeTriggerTools } from './tools/claude_triggers.js';
 import { registerAutomationTools } from './tools/automations.js';
 import { registerNotificationTools } from './tools/notifications.js';
+import { registerGoogleTools } from './tools/google.js';
 
 const RHYTHM_API_URL = process.env.RHYTHM_API_URL ?? 'https://api.vcrcapps.com';
 const RHYTHM_API_TOKEN = process.env.RHYTHM_API_TOKEN ?? '';
@@ -41,6 +42,7 @@ registerDashboardTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerClaudeTriggerTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerAutomationTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 registerNotificationTools(server, RHYTHM_AGENT_URL);
+registerGoogleTools(server, RHYTHM_API_URL, RHYTHM_API_TOKEN);
 
 // Connect over stdio (Claude Desktop / Claude Code MCP transport)
 const transport = new StdioServerTransport();

--- a/apps/mcp_server/src/tools/__tests__/google.test.ts
+++ b/apps/mcp_server/src/tools/__tests__/google.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { registerGoogleTools } from '../google.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: true;
+}>;
+
+interface RegisteredTool {
+  name: string;
+  description: string;
+  shape: Record<string, unknown>;
+  handler: ToolHandler;
+}
+
+function makeStubServer(): { server: unknown; tools: Map<string, RegisteredTool> } {
+  const tools = new Map<string, RegisteredTool>();
+  const server = {
+    tool(name: string, description: string, shape: Record<string, unknown>, handler: ToolHandler) {
+      tools.set(name, { name, description, shape, handler });
+    },
+  };
+  return { server, tools };
+}
+
+const API_URL = 'http://x';
+const API_TOKEN = 'tok';
+
+function makeFetchOk(body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  });
+}
+
+function makeFetch409() {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status: 409,
+    json: async () => ({ error: 'scope upgrade needed' }),
+  });
+}
+
+describe('registerGoogleTools — rhythm_list_calendar_events', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('(a) GETs /integrations/google/calendar/events with calendarId=primary by default', async () => {
+    const mockFetch = makeFetchOk([]);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerGoogleTools(server as any, API_URL, API_TOKEN);
+
+    await tools.get('rhythm_list_calendar_events')!.handler({});
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${API_URL}/integrations/google/calendar/events?calendarId=primary`);
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${API_TOKEN}`);
+  });
+
+  it('(b) passes a custom calendar_id when provided', async () => {
+    const mockFetch = makeFetchOk([]);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerGoogleTools(server as any, API_URL, API_TOKEN);
+
+    await tools.get('rhythm_list_calendar_events')!.handler({ calendar_id: 'work@example.com' });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('calendarId=work%40example.com');
+  });
+
+  it('(c) returns JSON text on success', async () => {
+    const events = [{ id: '1', summary: 'Staff Meeting' }];
+    const mockFetch = makeFetchOk(events);
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerGoogleTools(server as any, API_URL, API_TOKEN);
+
+    const res = await tools.get('rhythm_list_calendar_events')!.handler({});
+
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0].text).toContain('Staff Meeting');
+  });
+
+  it('(d) returns isError with "Enable Google tools" message on HTTP 409', async () => {
+    const mockFetch = makeFetch409();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerGoogleTools(server as any, API_URL, API_TOKEN);
+
+    const res = await tools.get('rhythm_list_calendar_events')!.handler({});
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text.toLowerCase()).toContain('google tools');
+    expect(res.content[0].text.toLowerCase()).toContain('enable');
+  });
+
+  it('(e) returns isError (not 409 message) on other non-ok responses', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'server error' }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerGoogleTools(server as any, API_URL, API_TOKEN);
+
+    const res = await tools.get('rhythm_list_calendar_events')!.handler({});
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('Rhythm API error 500');
+  });
+});
+
+describe('registerGoogleTools — rhythm_search_gmail', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('(a) GETs /integrations/google/gmail/search with encoded query', async () => {
+    const mockFetch = makeFetchOk({ messages: [] });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerGoogleTools(server as any, API_URL, API_TOKEN);
+
+    await tools.get('rhythm_search_gmail')!.handler({ query: 'from:boss is:unread' });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/integrations/google/gmail/search');
+    expect(url).toContain('from%3Aboss');
+  });
+
+  it('(b) returns isError with "Enable Google tools" message on HTTP 409', async () => {
+    const mockFetch = makeFetch409();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { server, tools } = makeStubServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerGoogleTools(server as any, API_URL, API_TOKEN);
+
+    const res = await tools.get('rhythm_search_gmail')!.handler({ query: 'test' });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text.toLowerCase()).toContain('google tools');
+    expect(res.content[0].text.toLowerCase()).toContain('enable');
+  });
+});

--- a/apps/mcp_server/src/tools/google.ts
+++ b/apps/mcp_server/src/tools/google.ts
@@ -1,0 +1,122 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { apiGet, apiPost, apiPatch, toolResult, toolError, RhythmApiError } from '../api_client.js';
+import { registerTool } from './_tool.js';
+
+function handleErr(err: unknown) {
+  if (err instanceof RhythmApiError && err.status === 409) {
+    return toolError(
+      new Error(
+        'Google tools are not authorized yet. Ask the user to open Rhythm → ' +
+        'Settings and click "Enable Google tools for the assistant" to grant access.',
+      ),
+    );
+  }
+  return toolError(err);
+}
+
+export function registerGoogleTools(server: McpServer, apiUrl: string, apiToken: string) {
+  registerTool(server, 'rhythm_list_calendar_events',
+    'List upcoming Google Calendar events for the signed-in user. Returns event id, title, start, end, location.',
+    {
+      calendar_id: z.string().optional().describe("Calendar id; defaults to 'primary'."),
+      max: z.number().optional().describe('Max events to return.'),
+    },
+    async ({ calendar_id = 'primary', max }: { calendar_id?: string; max?: number }) => {
+      try {
+        const qs = new URLSearchParams({ calendarId: calendar_id });
+        if (max) qs.set('max', String(max));
+        const events = await apiGet<unknown>(apiUrl, apiToken, `/integrations/google/calendar/events?${qs.toString()}`);
+        return toolResult(JSON.stringify(events, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_create_calendar_event',
+    'Create a Google Calendar event. Requires the user to have enabled Google tools (full calendar scope).',
+    {
+      summary: z.string().describe('Event title.'),
+      start: z.string().describe('Start datetime, ISO 8601 (e.g. 2026-06-20T09:00:00-07:00).'),
+      end: z.string().describe('End datetime, ISO 8601.'),
+      calendar_id: z.string().optional().describe("Calendar id; defaults to 'primary'."),
+      location: z.string().optional(),
+      description: z.string().optional(),
+    },
+    async (args: { summary: string; start: string; end: string; calendar_id?: string; location?: string; description?: string }) => {
+      try {
+        const event = await apiPost<unknown>(apiUrl, apiToken, '/integrations/google/calendar/events', {
+          calendarId: args.calendar_id ?? 'primary',
+          summary: args.summary,
+          start: args.start,
+          end: args.end,
+          location: args.location,
+          description: args.description,
+        });
+        return toolResult(JSON.stringify(event, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_update_calendar_event',
+    'Update an existing Google Calendar event (e.g. time, title, location). Requires Google tools enabled.',
+    {
+      id: z.string().describe('Event id.'),
+      calendar_id: z.string().optional().describe("Calendar id; defaults to 'primary'."),
+      summary: z.string().optional(),
+      start: z.string().optional().describe('New start ISO 8601.'),
+      end: z.string().optional().describe('New end ISO 8601.'),
+      location: z.string().optional(),
+      description: z.string().optional(),
+    },
+    async (args: { id: string; calendar_id?: string; summary?: string; start?: string; end?: string; location?: string; description?: string }) => {
+      try {
+        const patch: Record<string, unknown> = {};
+        if (args.calendar_id) patch.calendarId = args.calendar_id;
+        if (args.summary !== undefined) patch.summary = args.summary;
+        if (args.start !== undefined) patch.start = args.start;
+        if (args.end !== undefined) patch.end = args.end;
+        if (args.location !== undefined) patch.location = args.location;
+        if (args.description !== undefined) patch.description = args.description;
+        const event = await apiPatch<unknown>(apiUrl, apiToken, `/integrations/google/calendar/events/${args.id}`, patch);
+        return toolResult(JSON.stringify(event, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_search_gmail',
+    "Search the signed-in user's Gmail. Returns matching message ids/threads. Requires Google tools enabled.",
+    { query: z.string().describe('Gmail search query, e.g. "from:boss is:unread".') },
+    async ({ query }: { query: string }) => {
+      try {
+        const res = await apiGet<unknown>(apiUrl, apiToken, `/integrations/google/gmail/search?q=${encodeURIComponent(query)}`);
+        return toolResult(JSON.stringify(res, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_read_email',
+    'Read a Gmail message by id (full body). Requires Google tools enabled.',
+    { id: z.string().describe('Gmail message id.') },
+    async ({ id }: { id: string }) => {
+      try {
+        const res = await apiGet<unknown>(apiUrl, apiToken, `/integrations/google/gmail/messages/${encodeURIComponent(id)}`);
+        return toolResult(JSON.stringify(res, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+
+  registerTool(server, 'rhythm_send_email',
+    'Send an email as the signed-in user via Gmail. Requires Google tools enabled.',
+    {
+      to: z.string().describe('Recipient email address.'),
+      subject: z.string().describe('Subject line.'),
+      body: z.string().describe('Plain-text body.'),
+    },
+    async ({ to, subject, body }: { to: string; subject: string; body: string }) => {
+      try {
+        const res = await apiPost<unknown>(apiUrl, apiToken, '/integrations/google/gmail/send', { to, subject, body });
+        return toolResult(JSON.stringify(res, null, 2));
+      } catch (err) { return handleErr(err); }
+    },
+  );
+}


### PR DESCRIPTION
## What & why

Exposes Google **Calendar** + **Gmail** read/write tools to opencode through the rhythm MCP server, brokered by the Rhythm backend on the same single sign-in. Broader scopes are requested **only** via an opt-in step-up consent — base sign-in scopes are unchanged.

Feature **F3** of the [single Google/PCO OAuth + MCP auto-install spec](docs/superpowers/specs/2026-06-15-single-google-oauth-and-mcp-autoinstall-design.md). Depends logically on F1 (shared status/needsReauth) and F2 (auto-install); code is self-contained off `main`.

## ⚠️ External gate — Google app verification

`calendar` (full) + Gmail read/send are Google **sensitive/restricted** scopes. This code can merge and be tested with your own account (test users), but **broad scopes will not work for general users until Google OAuth app verification clears** (Gmail restricted scopes also require an annual CASA assessment). This is a process/cost dependency outside the code.

## How it works (end to end)

1. **Step-up consent (no base broadening):** `GOOGLE_SCOPES` (base sign-in) stays `calendar.readonly` + `gmail.metadata`. A new `GOOGLE_AGENT_SCOPES` (full `calendar`, `gmail.readonly`, `gmail.send`) is requested **only** when `GET /auth/google/begin?intent=agent` is hit (`forceConsent`). `getAuthorizationUrl` gained an optional `scopes` override; the normal connect path is byte-for-byte unchanged.
2. **Scope guard:** `assertScope` matches Google scopes as **exact whitespace-delimited tokens**, so `calendar.readonly` does **not** satisfy a full-`calendar` write requirement. Missing scope → `NeedsScopeUpgradeError`.
3. **Broker routes** (`/integrations/google`, `requireAuth`): list/create/update/delete calendar events, gmail search/read/send. `ensureFreshGoogleAccount` refreshes the stored credential first. `NeedsScopeUpgradeError` → **HTTP 409 `{ code: 'needs_scope_upgrade', requiredScope }`** (never a 500). Calendar create **and** update wrap `start`/`end` into Google's `{ dateTime }` shape.
4. **MCP tools** (`apps/mcp_server/src/tools/google.ts`): `rhythm_list_calendar_events`, `_create_calendar_event`, `_update_calendar_event`, `rhythm_search_gmail`, `rhythm_read_email`, `rhythm_send_email`. A 409 → friendly "ask the user to enable Google tools" error. No new env/credential — rides `RHYTHM_API_TOKEN`.
5. **Flutter:** `googleAgentBeginUri()` + an "Enable Google tools for the assistant" button (Integrations view) that launches the `intent=agent` step-up. The upgraded scope persists to both `google_calendar` and `gmail` rows, so subsequent broker calls pass `assertScope`.

## No base-sign-in / regression changes

Base `GOOGLE_SCOPES` unchanged; the `intent=agent` branch early-returns before the normal scope logic. `/integrations/google` is a distinct segment from the existing `/integrations/google-calendar/*` (no shadowing). Mounted before `/integrations`.

## Verification

- **api_server:** 815/815 vitest; `tsc --noEmit` clean.
- **mcp_server:** 40/40 vitest; `tsc --noEmit` clean.
- **Flutter:** `dart format` clean; `flutter analyze --no-fatal-infos` zero errors/warnings; 501/501 tests.
- Notable: step-up scope test (base vs agent), exact-token guard test (readonly ≠ full calendar), gmail.send gate, broker route 409→needs_scope_upgrade (real `NeedsScopeUpgradeError`), **regression test** that calendar update wraps `start`/`end` into `{dateTime}`, MCP tool 409→friendly error.

## Known limitations

- `rhythm_read_email`/`_search_gmail` return raw Google JSON — bodies are base64url MIME parts the agent decodes client-side.
- `rhythm_create_calendar_event` supports timed events only (`{dateTime}`), not all-day (`{date}`).
- A `DELETE /calendar/events/:id` route exists but no MCP delete tool is exposed (the 6-tool set matches the spec).

## Testing locally

Same server-colocation caveat as F4: the broker routes + the Google credential must be on the same server. To smoke with your own Google account before verification: connect Google, click "Enable Google tools", then from an agent session call `rhythm_list_calendar_events`, `rhythm_create_calendar_event`, `rhythm_search_gmail`. (Requires the local mcp_server build / a published package — see F2/F4 notes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)